### PR TITLE
Use triple store to define LDP containers

### DIFF
--- a/sources/SolidMiddleware/packages/LDP/index.js
+++ b/sources/SolidMiddleware/packages/LDP/index.js
@@ -14,7 +14,8 @@ module.exports = {
     aliases: {
       'GET view/activities': 'ldp.activities',
       'GET type/:container': 'ldp.type',
-      'GET subject/:identifier': 'ldp.subject'
+      'GET subject/:identifier': 'ldp.subject',
+      'GET container/:container': 'ldp.container'
     }
   },
   dependencies: ['triplestore'],
@@ -85,6 +86,43 @@ module.exports = {
       });
 
       return result;
+    },
+    async container(ctx) {
+      ctx.meta.$responseType = 'text/turtle';
+
+      return await ctx.call('triplestore.query', {
+        query: `
+          PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+          PREFIX as: <https://www.w3.org/ns/activitystreams#>
+          PREFIX ldp: <http://www.w3.org/ns/ldp#>
+          CONSTRUCT {
+            ?container ldp:contains ?subject .
+          	?subject ?predicate ?object .
+          }
+          WHERE {
+            <${this.settings.homeUrl}container/${ctx.params.container}> 
+                a ldp:BasicContainer ;
+          	    ldp:contains ?subject .
+          	?container ldp:contains ?subject .
+            ?subject ?predicate ?object .
+          }
+              `,
+        accept: 'turtle'
+      });
+    },
+    async attachToContainer(ctx) {
+      // Use a JSON-LD because this is currently the only type supported for INSERT operations
+      const container = {
+        '@context': 'http://www.w3.org/ns/ldp',
+        id: this.settings.homeUrl + 'container/' + ctx.params.container,
+        type: 'BasicContainer',
+        contains: ctx.params.objectUri
+      };
+
+      return await ctx.call('triplestore.insert', {
+        resource: container,
+        accept: 'json'
+      });
     }
   }
 };

--- a/sources/frontend/src/App.js
+++ b/sources/frontend/src/App.js
@@ -27,6 +27,8 @@ const App = () => {
     const activity = await response.json();
 
     alert('Activity created with ID : ' + activity.id);
+
+    window.location.reload();
   };
 
   return (
@@ -39,10 +41,10 @@ const App = () => {
         <textarea rows="7" value={content} onChange={e => setContent(e.target.value)} />
         <button onClick={sendNote}>Envoyer le message</button>
       </div>
-      <p className="App-section">Ruben's friends</p>
+      <p className="App-section">Messages already posted</p>
       <div className="App-form">
-        <List src="[https://ruben.verborgh.org/profile/#me].friends.firstName" container={items => <p>{items}</p>}>
-          {item => <span>{`${item}`} </span>}
+        <List src="[http://localhost:3000/container/as:Note].ldp_contains.as_name" container={items => <div>{items}</div>}>
+          {(item, index) => <p key={index}>{`${item}`} </p>}
         </List>
       </div>
     </div>


### PR DESCRIPTION
**A discuter ensemble à la réunion de demain.**

- Pour que LDFlex fonctionne correctement, il est nécessaire d'avoir des containers LDP. C'est cela qui permet d'indexer les différents objets.
- Je propose donc un nouvel endpoint `/container/as:Note` (qui pourra éventuellement remplacer `/type/as:Note`) qui retourne un vrai container LDP, avec les objets qu'il contient.
- Ce container LDP est enregistré dans le triple store via l'action `ldp.attachToContainer`
- Cette action est appelée par le service `activitypub` lorsqu'une nouvelle Note est créée.

Ca marche côté front : le titre des messages postés s'affiche en dessous du formulaire.