### PR TITLE
Merge standard and automatic containers

### DIFF
--- a/sources/SolidMiddleware/packages/LDP/index.js
+++ b/sources/SolidMiddleware/packages/LDP/index.js
@@ -15,7 +15,7 @@ module.exports = {
     aliases: {
       'GET view/activities': 'ldp.activities',
       'GET type/:container': 'ldp.type',
-      'GET container/:container': 'ldp.container',
+      'GET container/:container': 'ldp.automaticContainer',
       'GET subject/:identifier': 'ldp.subject'
     }
   },
@@ -83,7 +83,10 @@ module.exports = {
         accept: 'turtle'
       });
     },
-    async container(ctx) {
+    /*
+     * Returns a container constructed by the middleware, making a SparQL query on the fly
+     */
+    async automaticContainer(ctx) {
       ctx.meta.$responseType = 'application/ld+json';
 
       const result = await ctx.call('triplestore.query', {
@@ -110,6 +113,52 @@ module.exports = {
         '@type': ['ldp:Container', 'ldp:BasicContainer'],
         'ldp:contains': result
       };
+    },
+    /*
+     * Returns a LDP container persisted in the triple store
+     * @param containerUri The full URI of the container
+     */
+    async standardContainer(ctx) {
+      ctx.meta.$responseType = 'application/n-triples';
+
+      return await ctx.call('triplestore.query', {
+        query: `
+          PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+          PREFIX as: <https://www.w3.org/ns/activitystreams#>
+          PREFIX ldp: <http://www.w3.org/ns/ldp#>
+          CONSTRUCT {
+            ?container ldp:contains ?subject .
+          	?subject ?predicate ?object .
+          }
+          WHERE {
+            <${ctx.params.containerUri}> 
+                a ldp:BasicContainer ;
+          	    ldp:contains ?subject .
+          	?container ldp:contains ?subject .
+            ?subject ?predicate ?object .
+          }
+              `,
+        accept: 'turtle'
+      });
+    },
+    /*
+     * Attach an object to a standard container
+     * @param objectUri The full URI of the object to store
+     * @param containerUri The full URI of the container where to store the object
+     */
+    async attachToContainer(ctx) {
+      // Use a JSON-LD because this is currently the only type supported for INSERT operations
+      const container = {
+        '@context': 'http://www.w3.org/ns/ldp',
+        id: ctx.params.containerUri,
+        type: ['Container', 'BasicContainer'],
+        contains: ctx.params.objectUri
+      };
+
+      return await ctx.call('triplestore.insert', {
+        resource: container,
+        accept: 'json'
+      });
     }
   }
 };

--- a/sources/frontend/src/App.js
+++ b/sources/frontend/src/App.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { List, Value } from '@solid/react';
 import './App.css';
-import NoteService from './NoteService.js';
 
 const App = () => {
   let ldpServer = `http://${window.location.hostname}:3000`;
@@ -31,6 +30,8 @@ const App = () => {
     const activity = await response.json();
 
     alert('Activity created with ID : ' + activity.id);
+
+    window.location.reload();
   };
 
   return (
@@ -58,11 +59,12 @@ const App = () => {
         </List>
       </div>
       <hr />
-      <Value src="[https://ruben.verborgh.org/profile/].label" />
-      <p className="App-section">Ruben's friends</p>
+      <p className="App-section">
+        <Value src="[https://ruben.verborgh.org/profile/].label" />
+      </p>
       <div className="App-form">
         <List src="[https://ruben.verborgh.org/profile/#me].friends.firstName" container={items => <p>{items}</p>}>
-          {item => <span>{`${item}`} </span>}
+          {(item, index) => <span key={index}>{`${item}`} </span>}
         </List>
       </div>
     </div>


### PR DESCRIPTION
Remplace https://github.com/assemblee-virtuelle/semapps/pull/62

Garde les containers "standards" (tels que décrit [ici](https://hackmd.io/@srosset/ldp-containers)) afin qu'ils soient disponibles pour un usage futur. Les différencie clairement des containers "automatiques" afin qu'on se rappelle de quoi il s'agit (cela pourra évoluer encore dans le futur).