### PR TITLE
Improve automatic containers results

### DIFF
--- a/sources/SolidMiddleware/packages/LDP/index.js
+++ b/sources/SolidMiddleware/packages/LDP/index.js
@@ -86,7 +86,7 @@ module.exports = {
     async container(ctx) {
       ctx.meta.$responseType = 'application/ld+json';
 
-      const result = await ctx.call('triplestore.query', {
+      const resources = await ctx.call('triplestore.query', {
         query: `
           PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           PREFIX as: <https://www.w3.org/ns/activitystreams#>
@@ -101,15 +101,17 @@ module.exports = {
         accept: 'json'
       });
 
-      return {
-        '@context': {
-          as: 'https://www.w3.org/ns/activitystreams#',
-          ldp: 'http://www.w3.org/ns/ldp#'
-        },
+      const container = {
+        '@context': 'http://www.w3.org/ns/ldp#',
         '@id': `${this.settings.homeUrl}container/${ctx.params.container}`,
-        '@type': ['ldp:Container', 'ldp:BasicContainer'],
-        'ldp:contains': result
+        '@type': ['Container', 'BasicContainer'],
+        'contains': resources
       };
+
+      return jsonld.compact(container, {
+        as: 'https://www.w3.org/ns/activitystreams#',
+        ldp: 'http://www.w3.org/ns/ldp#'
+      });
     }
   }
 };


### PR DESCRIPTION
Actuellement le JSON-LD retourné par l'endpoint http://localhost:3000/container/as:Note est comme ça :
```json
{
  "@context": {
    "as": "https://www.w3.org/ns/activitystreams#",
    "ldp": "http://www.w3.org/ns/ldp#"
  },
  "@id": "http://localhost:3000/container/as:Note",
  "@type": [
    "ldp:Container",
    "ldp:BasicContainer"
  ],
  "ldp:contains": [
    {
      "@id": "http://localhost:3000/subject/032d83a1",
      "https://www.w3.org/ns/activitystreams#published": [
        {
          "@value": "2019-05-28T12:12:12Z",
          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
        }
      ],
      "https://www.w3.org/ns/activitystreams#name": [
        {
          "@value": "Hello World 3"
        }
      ],
      "https://www.w3.org/ns/activitystreams#content": [
        {
          "@value": "Voilà mon premier message, très content de faire partie du fedivers !"
        }
      ],
      "@type": [
        "https://www.w3.org/ns/activitystreams#Note"
      ]
    }
  ]
}
```
Ce n'est pas faux mais peu lisible.
Avec cette modification, il apparait comme ça:
```json
{
  "@context": {
    "as": "https://www.w3.org/ns/activitystreams#",
    "ldp": "http://www.w3.org/ns/ldp#"
  },
  "@id": "http://localhost:3000/container/as:Note",
  "@type": [
    "ldp:Container",
    "ldp:BasicContainer"
  ],
  "ldp:contains": [
    {
      "@id": "http://localhost:3000/subject/032d83a1",
      "@type": "as:Note",
      "as:content": "Voilà mon premier message, très content de faire partie du fedivers !",
      "as:name": "Hello World 3",
      "as:published": {
        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
        "@value": "2019-05-28T12:12:12Z"
      }
    }
  ]
}
```
Le mapping avec l'ontologie ActivityStreams est fait correctement.