### PR TITLE
Config .env vars for frontend

### DIFF
--- a/src/frontend/.env
+++ b/src/frontend/.env
@@ -1,0 +1,2 @@
+# https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env
+REACT_APP_MIDDLEWARE_URL=http://localhost:3000

--- a/src/frontend/.env
+++ b/src/frontend/.env
@@ -1,2 +1,2 @@
 # https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env
-REACT_APP_MIDDLEWARE_URL=http://localhost:3000
+REACT_APP_MIDDLEWARE_URL=http://localhost:3000/

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -1,0 +1,2 @@
+.env.local
+.env.*.local

--- a/src/frontend/src/UserProfile.js
+++ b/src/frontend/src/UserProfile.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Link } from '@reach/router';
-import { CONTAINER_URI } from './constants';
+import { CONTAINER_URI } from './config';
 import useQuery from './api/useQuery';
 import { deleteResource, removeFromContainer } from './api/actions';
 

--- a/src/frontend/src/Users.js
+++ b/src/frontend/src/Users.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import useQuery from './api/useQuery';
 import UserPreview from './UserPreview';
-import { MIDDLEWARE_URL } from './constants';
+import { CONTAINER_URI } from './config';
 
 const Users = () => {
-  const { data: usersUris } = useQuery(`${MIDDLEWARE_URL}/ldp/schema:Person`);
+  const { data: usersUris } = useQuery(CONTAINER_URI);
   return (
     <div className="container">
       <h2>Liste des utilisateurs</h2>

--- a/src/frontend/src/config.js
+++ b/src/frontend/src/config.js
@@ -1,4 +1,4 @@
 module.exports = {
   MIDDLEWARE_URL: process.env.REACT_APP_MIDDLEWARE_URL,
-  CONTAINER_URI: `${process.env.REACT_APP_MIDDLEWARE_URL}/ldp/schema:Person`
+  CONTAINER_URI: `${process.env.REACT_APP_MIDDLEWARE_URL}ldp/schema:Person`
 };

--- a/src/frontend/src/config.js
+++ b/src/frontend/src/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  MIDDLEWARE_URL: process.env.REACT_APP_MIDDLEWARE_URL,
+  CONTAINER_URI: `${process.env.REACT_APP_MIDDLEWARE_URL}/ldp/schema:Person`
+};

--- a/src/frontend/src/constants.js
+++ b/src/frontend/src/constants.js
@@ -1,3 +1,0 @@
-export const MIDDLEWARE_URL = 'http://localhost:3000';
-
-export const CONTAINER_URI = `${MIDDLEWARE_URL}/ldp/schema:Person`;

--- a/src/frontend/src/forms/CreateUserForm.js
+++ b/src/frontend/src/forms/CreateUserForm.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Form, Field } from 'react-final-form';
-import { CONTAINER_URI } from '../constants';
+import { CONTAINER_URI } from '../config';
 import { getUserId } from '../utils';
 import { addResource, addToContainer } from '../api/actions';
 
 const CreateUserForm = ({ navigate }) => {
   const dispatch = useDispatch();
+
+  console.log('CONTAINER_URI', CONTAINER_URI);
 
   const createUser = async values => {
     const user = {

--- a/src/frontend/src/forms/CreateUserForm.js
+++ b/src/frontend/src/forms/CreateUserForm.js
@@ -8,8 +8,6 @@ import { addResource, addToContainer } from '../api/actions';
 const CreateUserForm = ({ navigate }) => {
   const dispatch = useDispatch();
 
-  console.log('CONTAINER_URI', CONTAINER_URI);
-
   const createUser = async values => {
     const user = {
       '@context': 'http://schema.org/',

--- a/src/frontend/src/forms/EditUserForm.js
+++ b/src/frontend/src/forms/EditUserForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Form, Field } from 'react-final-form';
 import { useDispatch } from 'react-redux';
-import { CONTAINER_URI } from '../constants';
+import { CONTAINER_URI } from '../config';
 import useQuery from '../api/useQuery';
 import { editResource } from '../api/actions';
 

--- a/src/frontend/src/forms/SendMessageForm.js
+++ b/src/frontend/src/forms/SendMessageForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Form, Field } from 'react-final-form';
-import { MIDDLEWARE_URL } from '../constants';
+import { CONTAINER_URI } from '../config';
 import useQuery from '../api/useQuery';
 
 const SendMessageForm = ({ userId }) => {
@@ -14,7 +14,7 @@ const SendMessageForm = ({ userId }) => {
       content: values.content
     };
 
-    const response = await fetch(`${MIDDLEWARE_URL}/ldp/schema:Person`, {
+    const response = await fetch(CONTAINER_URI, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'


### PR DESCRIPTION
Première partie de https://github.com/assemblee-virtuelle/semapps/issues/104

Pour l'instant il suffit d'ajouter un fichier `.env.local` en prod (dans le dossier /src/frontend) pour que ça marche.
En dev ça marche tout de suite sans config.

> Dans le futur on pourra envisager de mettre les variables non-sensibles dans un fichier `.env.production`, mais il faudrait pour cela que le code React soit lancé en production (voir https://github.com/assemblee-virtuelle/semapps/issues/106)