### PR TITLE
Launch all ActivityPub sub-services with a single service

### DIFF
--- a/src/middleware/boilerplates/runner/createServices.js
+++ b/src/middleware/boilerplates/runner/createServices.js
@@ -1,15 +1,7 @@
 const { LdpService, TripleStoreAdapter } = require('@semapps/ldp');
 const { SparqlEndpointService } = require('@semapps/sparql-endpoint');
 const FusekiAdminService = require('@semapps/fuseki-admin');
-const {
-  ActivityService,
-  OutboxService,
-  InboxService,
-  FollowService,
-  MongoDbCollectionService,
-  ActorService,
-  ObjectService
-} = require('@semapps/activitypub');
+const { ActivityPubService } = require('@semapps/activitypub');
 const { TripleStoreService } = require('@semapps/triplestore');
 const { WebIdService } = require('@semapps/webid');
 const MongoDbAdapter = require('moleculer-db-adapter-mongo');
@@ -51,32 +43,15 @@ function createServices(broker) {
   });
 
   // ActivityPub
-  broker.createService(MongoDbCollectionService, {
-    adapter: new MongoDbAdapter(CONFIG.MONGODB_URL)
-  });
-  broker.createService(ActorService, {
-    adapter: new TripleStoreAdapter('ldp'),
-    settings: {
-      containerUri: CONFIG.HOME_URL + 'users/'
-    },
-    dependencies: ['ldp'] // TODO set this in TripleStoreAdapter
-  });
-  broker.createService(ActivityService, {
-    adapter: new MongoDbAdapter(CONFIG.MONGODB_URL),
-    settings: {
-      containerUri: CONFIG.HOME_URL + 'activities/'
+  broker.createService(ActivityPubService, {
+    baseUri: CONFIG.HOME_URL,
+    storage: {
+      collections: new MongoDbAdapter(CONFIG.MONGODB_URL),
+      activities: new MongoDbAdapter(CONFIG.MONGODB_URL),
+      actors: new TripleStoreAdapter('ldp'),
+      objects: new TripleStoreAdapter('ldp')
     }
   });
-  broker.createService(ObjectService, {
-    adapter: new TripleStoreAdapter('ldp'),
-    settings: {
-      containerUri: CONFIG.HOME_URL + 'objects/'
-    },
-    dependencies: ['ldp'] // TODO set this in TripleStoreAdapter
-  });
-  broker.createService(FollowService);
-  broker.createService(InboxService);
-  broker.createService(OutboxService);
 }
 
 module.exports = createServices;

--- a/src/middleware/packages/activitypub/index.js
+++ b/src/middleware/packages/activitypub/index.js
@@ -1,6 +1,7 @@
 const constants = require('./constants');
 
 module.exports = {
+  ActivityPubService: require('./service'),
   ActorService: require('./services/actor'),
   ActivityService: require('./services/activity'),
   MongoDbCollectionService: require('./services/collection/mongodb-collection'),

--- a/src/middleware/packages/activitypub/service.js
+++ b/src/middleware/packages/activitypub/service.js
@@ -1,0 +1,72 @@
+const ActorService = require('./services/actor');
+const ActivityService = require('./services/activity');
+const MongoDbCollectionService = require('./services/collection/mongodb-collection');
+const TripleStoreCollectionService = require('./services/collection/triplestore-collection');
+const FollowService = require('./services/follow');
+const InboxService = require('./services/inbox');
+const ObjectService = require('./services/object');
+const OutboxService = require('./services/outbox');
+
+const ActivityPubService = {
+  name: 'activitypub',
+  settings: {
+    baseUri: null,
+    context: {
+      '@vocab': 'https://www.w3.org/ns/activitystreams#',
+      foaf: 'http://xmlns.com/foaf/0.1/'
+    },
+    storage: {
+      collections: null,
+      activities: null,
+      actors: null,
+      objects: null
+    }
+  },
+  created() {
+    this.broker.createService(
+      this.originalSchema.storage.collections.constructor.name === 'TripleStoreAdapter'
+        ? TripleStoreCollectionService
+        : MongoDbCollectionService,
+      {
+        adapter: this.originalSchema.storage.collections,
+        settings: {
+          context: this.originalSchema.context
+        },
+        dependencies: this.originalSchema.storage.objects.constructor.name === 'TripleStoreAdapter' ? ['ldp'] : [] // TODO set this in TripleStoreAdapter
+      }
+    );
+
+    this.broker.createService(ActorService, {
+      adapter: this.originalSchema.storage.actors,
+      settings: {
+        containerUri: this.originalSchema.baseUri + 'users/',
+        context: this.originalSchema.context
+      },
+      dependencies: this.originalSchema.storage.actors.constructor.name === 'TripleStoreAdapter' ? ['ldp'] : [] // TODO set this in TripleStoreAdapter
+    });
+
+    this.broker.createService(ActivityService, {
+      adapter: this.originalSchema.storage.activities,
+      settings: {
+        containerUri: this.originalSchema.baseUri + 'activities/',
+        context: this.originalSchema.context
+      },
+      dependencies: this.originalSchema.storage.objects.constructor.name === 'TripleStoreAdapter' ? ['ldp'] : [] // TODO set this in TripleStoreAdapter
+    });
+
+    this.broker.createService(ObjectService, {
+      adapter: this.originalSchema.storage.objects,
+      settings: {
+        containerUri: this.originalSchema.baseUri + 'objects/',
+        context: this.originalSchema.context
+      },
+      dependencies: this.originalSchema.storage.objects.constructor.name === 'TripleStoreAdapter' ? ['ldp'] : [] // TODO set this in TripleStoreAdapter
+    });
+
+    this.broker.createService(FollowService);
+    this.broker.createService(InboxService);
+    this.broker.createService(OutboxService);
+  }
+};
+
+module.exports = ActivityPubService;


### PR DESCRIPTION
Pour éviter d'avoir à créer 7 services différents, crée un service ActivityPub unique qui s'occupe de lancer tous les sous-services.

A noter que cela reste possible pour l'utilisateur d'importer directement les sous-services, s'il veut faire sa propre configuration.