### PR TITLE
Clean, consistent LDP get results

### DIFF
--- a/src/middleware/packages/triplestore/index.js
+++ b/src/middleware/packages/triplestore/index.js
@@ -35,7 +35,7 @@ const TripleStoreService = {
         const contentType = ctx.params.contentType;
         const type = negotiateTypeMime(contentType);
         let rdf;
-        if (type != MIME_TYPES.JSON) {
+        if (type !== MIME_TYPES.JSON) {
           rdf = params.resource;
         } else {
           rdf = await jsonld.toRDF(params.resource, {
@@ -164,12 +164,12 @@ const TripleStoreService = {
         const webId = ctx.params.webId || ctx.meta.webId;
         const acceptNegociatedType = negotiateType(accept);
         const acceptType = acceptNegociatedType.mime;
-        const fueskiAccept = acceptNegociatedType.fusekiMapping;
+        const fusekiAccept = acceptNegociatedType.fusekiMapping;
         const headers = {
           'Content-Type': 'application/sparql-query',
           'X-SemappsUser': webId,
           Authorization: this.Authorization,
-          Accept: fueskiAccept
+          Accept: fusekiAccept
         };
 
         const response = await fetch(this.settings.sparqlEndpoint + this.settings.mainDataset + '/query', {


### PR DESCRIPTION
Je ne sais pas si je m'y suis pris de la bonne manière, mais au niveau front (et notamment react-admin), cela me pose un problème que les résultats retournés par le serveur LDP ne soient pas toujours les mêmes.

En l'occurence quand on fait un GET en JSON-LD sur une ressource, on obtient des résultats comme ceux-ci:

```
{
  "@id": "http://localhost:3000/ldp/pair:Project/005ef2d0",
  "@type": "pair:Project",
  "description": "Test",
  "label": "Les chemins de la Transition",
  "webPage": "sdcscd",
  "@context": {
    "description": {
      "@id": "http://virtual-assembly.org/ontologies/pair#description"
    },
    "webPage": {
      "@id": "http://virtual-assembly.org/ontologies/pair#webPage"
    },
    "label": {
      "@id": "http://virtual-assembly.org/ontologies/pair#label"
    },
    "schema": "http://schema.org/",
    "as": "https://www.w3.org/ns/activitystreams#",
    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
    "ldp": "http://www.w3.org/ns/ldp#",
    "foaf": "http://xmlns.com/foaf/0.1/",
    "pair": "http://virtual-assembly.org/ontologies/pair#"
  }
}
```
Le formattage du JSON est fait directement par Fuseki.

En l'occurence ce serait plus simple si les résultats étaient compactés comme pour les autres appels à LDP. On obtiendrait alors quelque chose de plus clean comme ça:

```
{
  "@context": {
    "as": "https://www.w3.org/ns/activitystreams#",
    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
    "ldp": "http://www.w3.org/ns/ldp#",
    "schema": "http://schema.org/",
    "foaf": "http://xmlns.com/foaf/0.1/",
    "pair": "http://virtual-assembly.org/ontologies/pair#"
  },
  "@id": "http://localhost:3000/ldp/pair:Project/005ef2d0",
  "@type": "pair:Project",
  "pair:description": "Test",
  "pair:label": "Les chemins de la Transition",
  "pair:webPage": "sdcscd"
}
```

C'est ce que cette PR fait.

J'ai mis le code de "compactage" du côté du service LDP car c'est à ce niveau qu'on a les ontologies. Mais ce n'est peut-être pas juste ?