### PR TITLE
Allow to run different boilerplates and frontend

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Default env variables for docker-compose files
+MIDDLEWARE=runner
+FRONTEND=playground

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -48,11 +48,11 @@ services:
       - "3000:3000"
     expose:
       - "3000"
-    command: npm run start --prefix ./boilerplates/runner
+    command: npm run start --prefix ./boilerplates/${MIDDLEWARE}
 
   frontend:
     build:
-      context: ./src/frontend/playground
+      context: ./src/frontend/${FRONTEND}
       dockerfile: Dockerfile
     container_name: frontend
     restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,13 +49,13 @@ services:
       - "3000:3000"
     expose:
       - "3000"
-    command: npm run start --prefix ./boilerplates/runner
+    command: ./boilerplates/${MIDDLEWARE}/entrypoint.sh
     stdin_open: true
     tty: true
 
   frontend:
     build:
-      context: ./src/frontend/playground
+      context: ./src/frontend/${FRONTEND}
       dockerfile: Dockerfile
     container_name: frontend
     restart: always
@@ -64,7 +64,7 @@ services:
     environment:
       - PORT=5000
     volumes:
-      - ./src/frontend/playground:/app
+      - ./src/frontend/${FRONTEND}:/app
     networks:
       - semapps
     ports:

--- a/src/middleware/Dockerfile
+++ b/src/middleware/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install pm2 -g
 RUN npm install nodemon -g
 
 # install tool for npm lib compile in C
-RUN apk add --update --no-cache autoconf libtool automake python alpine-sdk openssh-keygen
+RUN apk add --update --no-cache autoconf bash libtool automake python alpine-sdk openssh-keygen
 
 # Install app dependencies
 # COPY ./main/package.json /data/
@@ -23,19 +23,8 @@ RUN cd /main/ && npm cache clean --force && npm install --loglevel verbose
 # add src & build configuraiton
 COPY . /main/
 RUN cd /main/ && npm run bootstrap
-#RUN cd /main/boilerplates/runner && npm install 
-
-# Generate public/private keys for JWT unless they already exist
-RUN cd /main/boilerplates/runner/jwt && \
-    if [ ! -f "jwtRS256.key" ]; then \
-      ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key -P "" && \
-      openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub ; \
-    else \
-      echo "Public/private keys already exist, skipping..." ; \
-    fi
 
 # Expose ports (for orchestrators and dynamic reverse proxies)
 EXPOSE 3000
 
-# CMD [ "ls", "./boilerplates/runner/"]
-CMD [ "pm2-runtime", "./boilerplates/runner/index.js", "--name" ,"SemappSolid"]
+CMD [ "pm2-runtime", "./boilerplates/runner/index.js", "--name" ,"middleware"]

--- a/src/middleware/boilerplates/runner/entrypoint.sh
+++ b/src/middleware/boilerplates/runner/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd ${CURRENT_DIR}/jwt || exit
+
+if [ ! -f "jwtRS256.key" ]; then
+  ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key -P ""
+  openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub ;
+else
+  echo "Public/private keys already exist, skipping..." ;
+fi
+
+npm run start


### PR DESCRIPTION
Permet de lancer un autre boilerplate ou un autre frontend avec Docker de cette manière:

```bash
FRONTEND=dms make start
MIDDLEWARE=mailer make start
```

Nécessaire pour plus de flexibilité avec les autres projets (Mailer Colibris, etc).

La génération des clés pour le JWT se fait maintenant au runtime.