### PR TITLE
LDP get : slug and containerUri parameters

### DIFF
--- a/src/middleware/packages/ldp/actions/post.js
+++ b/src/middleware/packages/ldp/actions/post.js
@@ -2,21 +2,19 @@ const { MIME_TYPES } = require('@semapps/mime-types');
 
 module.exports = {
   api: async function api(ctx) {
-    let { typeURL, containerUri } = ctx.params;
-    const body = ctx.meta.body;
-    const slug = ctx.meta.headers.slug;
-    if (!body['@id']) {
-      body['@id'] = this.generateId(typeURL, containerUri, slug);
-    }
+    let { typeURL } = ctx.params;
     try {
-      let out = await ctx.call('ldp.post', {
-        resource: body,
+      const resource = await ctx.call('ldp.post', {
+        containerUri: `${this.settings.baseUrl}${typeURL}/`,
+        slug: ctx.meta.headers.slug,
+        resource: ctx.meta.body,
         contentType: ctx.meta.headers['content-type'],
         accept: MIME_TYPES.JSON
       });
+
       ctx.meta.$statusCode = 201;
       ctx.meta.$responseHeaders = {
-        Location: out['@id'],
+        Location: resource['@id'],
         Link: '<http://www.w3.org/ns/ldp#Resource>; rel="type"',
         'Content-Length': 0
       };
@@ -38,25 +36,32 @@ module.exports = {
       },
       contentType: {
         type: 'string'
+      },
+      containerUri: {
+        type: 'string'
+      },
+      slug: {
+        type: 'string',
+        optional: true
       }
     },
     async handler(ctx) {
-      let resource = ctx.params.resource;
-      const accept = ctx.params.accept;
-      const contentType = ctx.params.contentType;
-      if (ctx.params.webId) {
-        ctx.meta.webId = ctx.params.webId;
-      }
+      const { resource, containerUri, slug, accept, contentType, webId } = ctx.params;
+
+      if (webId) ctx.meta.webId = webId;
+
+      // Generate ID and make sure it doesn't exist already
+      resource['@id'] = `${containerUri}${slug || this.generateId()}`;
       resource['@id'] = await this.findUnusedUri(ctx, resource['@id']);
 
       await ctx.call('triplestore.insert', {
-        resource: resource,
-        contentType: contentType
+        resource,
+        contentType
       });
 
       return await ctx.call('ldp.get', {
         resourceUri: resource['@id'],
-        accept: accept
+        accept
       });
     }
   }

--- a/src/middleware/packages/ldp/service.js
+++ b/src/middleware/packages/ldp/service.js
@@ -77,9 +77,8 @@ const LdpService = {
     }
   },
   methods: {
-    generateId(type, containerUri, slug) {
-      const id = slug || uuid().substring(0, 8);
-      return containerUri ? `${containerUri}${id}` : `${this.settings.baseUrl}${type}/${id}`;
+    generateId() {
+      return uuid().substring(0, 8);
     },
     async findUnusedUri(ctx, generatedId) {
       let existingBegining = await ctx.call('triplestore.query', {


### PR DESCRIPTION
Le code actuel empêche de passer un slug ou un URI de container à l'action `ldp.get`. Pour cela, on est obligé d'appeler `ldp.api_get`, ou alors de fournir directement l'URI complète, ce qui rend le service difficilement utilisable.

J'ai donc déplacé la génération de l'URI au niveau de `ldp.get`.