### PR TITLE
middle level SPARQL computing migration to ldp service + claen up logic + spimplify patch

### DIFF
--- a/src/middleware/packages/activitypub/services/object.js
+++ b/src/middleware/packages/activitypub/services/object.js
@@ -16,11 +16,10 @@ const ObjectService = {
 
       const tombstone = {
         '@context': this.settings.context,
-        '@id': ctx.params.id,
         type: 'Tombstone',
+        slug: ctx.params.id.match(new RegExp(`.*/(.*)`))[1],
         deleted: new Date().toISOString()
       };
-
       return await this._create(ctx, tombstone);
     }
   }

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -26,20 +26,17 @@ module.exports = {
       webId: { type: 'string', optional: true }
     },
     async handler(ctx) {
-      const {
-        resourceUri,
-        webId
-      } = ctx.params;
+      const { resourceUri, webId } = ctx.params;
 
       const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
         uri: resourceUri
       });
 
       if (triplesNb > 0) {
-        const query =`DELETE
+        const query = `DELETE
             WHERE
             { <${resourceUri}> ?p ?v }
-            `
+            `;
         await ctx.call('triplestore.update', {
           query,
           webId

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -26,17 +26,23 @@ module.exports = {
       webId: { type: 'string', optional: true }
     },
     async handler(ctx) {
-      const resourceUri = ctx.params.resourceUri;
-      if (ctx.params.webId) {
-        ctx.meta.webId = ctx.params.webId;
-      }
+      const {
+        resourceUri,
+        webId
+      } = ctx.params;
+
       const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
         uri: resourceUri
       });
 
       if (triplesNb > 0) {
-        await ctx.call('triplestore.delete', {
-          uri: resourceUri
+        const query =`DELETE
+            WHERE
+            { <${resourceUri}> ?p ?v }
+            `
+        await ctx.call('triplestore.update', {
+          query,
+          webId
         });
       } else {
         throw new MoleculerError('Not found', 404, 'NOT_FOUND');

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -86,7 +86,7 @@ module.exports = {
 
         return result;
       } else {
-        console.log('HIHI',resourceUri);
+        console.log('HIHI', resourceUri);
         throw new MoleculerError('Not found', 404, 'NOT_FOUND');
       }
     }

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -86,6 +86,7 @@ module.exports = {
 
         return result;
       } else {
+        console.log('HIHI',resourceUri);
         throw new MoleculerError('Not found', 404, 'NOT_FOUND');
       }
     }

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -86,7 +86,6 @@ module.exports = {
 
         return result;
       } else {
-        console.log('HIHI',resourceUri);
         throw new MoleculerError('Not found', 404, 'NOT_FOUND');
       }
     }

--- a/src/middleware/packages/ldp/services/resource/actions/patch.js
+++ b/src/middleware/packages/ldp/services/resource/actions/patch.js
@@ -4,14 +4,13 @@ module.exports = {
   api: async function api(ctx) {
     const { containerUri, id, ...resource } = ctx.params;
 
-    //PATCH have to still in same container and @id can't be different
+    //PATCH have to stay in same container and @id can't be different
     resource['@id'] = `${containerUri}/${id}`;
 
     try {
       await ctx.call('ldp.resource.patch', {
         resource,
-        contentType: ctx.meta.headers['content-type'],
-        containerUri
+        contentType: ctx.meta.headers['content-type']
       });
       ctx.meta.$statusCode = 204;
       ctx.meta.$responseHeaders = {
@@ -46,10 +45,7 @@ module.exports = {
       });
 
       if (triplesNb > 0) {
-        const query = await this.buildPatchDeleteQuery({
-          resource
-        });
-        // console.log(query);
+        const query = await this.buildDeleteQueryFromResource(resource);
 
         await ctx.call('triplestore.update', {
           query,

--- a/src/middleware/packages/ldp/services/resource/actions/patch.js
+++ b/src/middleware/packages/ldp/services/resource/actions/patch.js
@@ -1,16 +1,10 @@
-const {
-  MoleculerError
-} = require('moleculer').Errors;
+const { MoleculerError } = require('moleculer').Errors;
 
 module.exports = {
   api: async function api(ctx) {
-    const {
-      containerUri,
-      id,
-      ...resource
-    } = ctx.params;
+    const { containerUri, id, ...resource } = ctx.params;
 
-    //PATCH have to still in same container and @id can't be different 
+    //PATCH have to still in same container and @id can't be different
     resource['@id'] = `${containerUri}/${id}`;
 
     try {
@@ -45,22 +39,16 @@ module.exports = {
       }
     },
     async handler(ctx) {
-      const {
-        resource,
-        contentType,
-        webId
-      } = ctx.params;
+      const { resource, contentType, webId } = ctx.params;
 
       const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
         uri: resource['@id']
       });
 
       if (triplesNb > 0) {
-
-
         const query = await this.buildPatchDeleteQuery({
           resource
-        })
+        });
         // console.log(query);
 
         await ctx.call('triplestore.update', {

--- a/src/middleware/packages/ldp/services/resource/actions/post.js
+++ b/src/middleware/packages/ldp/services/resource/actions/post.js
@@ -49,7 +49,7 @@ module.exports = {
       const { resource, containerUri, slug, contentType, webId } = ctx.params;
 
       // Generate ID and make sure it doesn't exist already
-      resource['@id'] = resource['@id'] || `${containerUri.replace(/\/$/, '')}/${slug || generateId()}`;
+      resource['@id'] = `${containerUri.replace(/\/$/, '')}/${slug || generateId()}`;
       resource['@id'] = await this.findUnusedUri(ctx, resource['@id']);
 
       if (!resource['@context']) {

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -30,14 +30,14 @@ module.exports = {
     params: {
       resource: { type: 'object' },
       webId: { type: 'string', optional: true },
-      contentType: { type: 'string' },
+      contentType: { type: 'string' }
     },
     async handler(ctx) {
       const { resource, accept, contentType, webId } = ctx.params;
       const matches = resource['@id'].match(new RegExp(`(.*)/(.*)`));
       const effetivContainerUri = matches[1];
       const slug = matches[2];
-      console.log(resource['@id'],effetivContainerUri,slug);
+      console.log(resource['@id'], effetivContainerUri, slug);
 
       const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
         uri: resource['@id']
@@ -50,7 +50,7 @@ module.exports = {
           resource,
           contentType,
           webId,
-          containerUri : effetivContainerUri,
+          containerUri: effetivContainerUri,
           slug
         });
 

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -13,7 +13,7 @@ module.exports = {
         accept: ctx.meta.headers.accept,
         contentType: ctx.meta.headers['content-type'],
         containerUri,
-        slug:id
+        slug: id
       });
       ctx.meta.$statusCode = 204;
       ctx.meta.$responseHeaders = {
@@ -32,11 +32,11 @@ module.exports = {
       resource: { type: 'object' },
       webId: { type: 'string', optional: true },
       contentType: { type: 'string' },
-      containerUri : { type: 'string' },
-      slug :  { type: 'string' }
+      containerUri: { type: 'string' },
+      slug: { type: 'string' }
     },
     async handler(ctx) {
-      const { resource, accept, contentType,containerUri,slug, webId } = ctx.params;
+      const { resource, accept, contentType, containerUri, slug, webId } = ctx.params;
 
       const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
         uri: resource['@id']

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -37,7 +37,6 @@ module.exports = {
       const matches = resource['@id'].match(new RegExp(`(.*)/(.*)`));
       const effetivContainerUri = matches[1];
       const slug = matches[2];
-      console.log(resource['@id'], effetivContainerUri, slug);
 
       const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
         uri: resource['@id']

--- a/src/middleware/packages/ldp/services/resource/methods.js
+++ b/src/middleware/packages/ldp/services/resource/methods.js
@@ -50,15 +50,15 @@ module.exports = {
         });
     });
   },
-  buildPatchDeleteQuery(params) {
+  buildDeleteQueryFromResource(resource) {
     return new Promise((resolve, reject) => {
       let deleteSPARQL = '';
       let counter = 0;
       let query;
       const text =
-        typeof params.resource === 'string' || params.resource instanceof String
-          ? params.resource
-          : JSON.stringify(params.resource);
+        typeof resource === 'string' || resource instanceof String
+          ? resource
+          : JSON.stringify(resource);
       const textStream = streamifyString(text);
       rdfParser
         .parse(textStream, {

--- a/src/middleware/packages/ldp/services/resource/methods.js
+++ b/src/middleware/packages/ldp/services/resource/methods.js
@@ -55,10 +55,7 @@ module.exports = {
       let deleteSPARQL = '';
       let counter = 0;
       let query;
-      const text =
-        typeof resource === 'string' || resource instanceof String
-          ? resource
-          : JSON.stringify(resource);
+      const text = typeof resource === 'string' || resource instanceof String ? resource : JSON.stringify(resource);
       const textStream = streamifyString(text);
       rdfParser
         .parse(textStream, {

--- a/src/middleware/packages/ldp/services/resource/methods.js
+++ b/src/middleware/packages/ldp/services/resource/methods.js
@@ -49,5 +49,32 @@ module.exports = {
           });
         });
     });
+  },
+  buildPatchDeleteQuery(params) {
+    return new Promise((resolve, reject) => {
+      let deleteSPARQL = '';
+      let counter = 0;
+      let query;
+      const text =
+        typeof params.resource === 'string' || params.resource instanceof String
+          ? params.resource
+          : JSON.stringify(params.resource);
+      const textStream = streamifyString(text);
+      rdfParser
+        .parse(textStream, {
+          contentType: 'application/ld+json'
+        })
+        .on('data', quad => {
+          deleteSPARQL = deleteSPARQL.concat(
+            `DELETE WHERE  {<${quad.subject.value}> <${quad.predicate.value}> ?o};
+            `
+          );
+          counter++;
+        })
+        .on('error', error => console.error(error))
+        .on('end', () => {
+          resolve(deleteSPARQL);
+        });
+    });
   }
 };

--- a/src/middleware/packages/triplestore/index.js
+++ b/src/middleware/packages/triplestore/index.js
@@ -3,8 +3,6 @@
 const jsonld = require('jsonld');
 const fetch = require('node-fetch');
 const { SparqlJsonParser } = require('sparqljson-parse');
-const rdfParser = require('rdf-parse').default;
-const streamifyString = require('streamify-string');
 const { MIME_TYPES, negotiateType, negotiateTypeMime } = require('@semapps/mime-types');
 
 const TripleStoreService = {

--- a/src/middleware/packages/triplestore/index.js
+++ b/src/middleware/packages/triplestore/index.js
@@ -82,32 +82,32 @@ const TripleStoreService = {
         return results.length;
       }
     },
-    update : {
-        visibility: 'public',
-        params: {
-          query: {
-            type: 'string'
-          },
-          webId: {
-            type: 'string',
-            optional: true
-          }
+    update: {
+      visibility: 'public',
+      params: {
+        query: {
+          type: 'string'
         },
-        async handler(ctx) {
-          const webId = ctx.params.webId || ctx.meta.webId;
-          const query = ctx.params.query;
-          const response = await fetch(this.settings.sparqlEndpoint + this.settings.mainDataset + '/update', {
-            method: 'POST',
-            body: query,
-            headers: {
-              'Content-Type': 'application/sparql-update',
-              'X-SemappsUser': webId,
-              Authorization: this.Authorization
-            }
-          });
-          if (!response.ok) throw new Error(response.statusText);
+        webId: {
+          type: 'string',
+          optional: true
         }
       },
+      async handler(ctx) {
+        const webId = ctx.params.webId || ctx.meta.webId;
+        const query = ctx.params.query;
+        const response = await fetch(this.settings.sparqlEndpoint + this.settings.mainDataset + '/update', {
+          method: 'POST',
+          body: query,
+          headers: {
+            'Content-Type': 'application/sparql-update',
+            'X-SemappsUser': webId,
+            Authorization: this.Authorization
+          }
+        });
+        if (!response.ok) throw new Error(response.statusText);
+      }
+    },
     query: {
       visibility: 'public',
       params: {
@@ -204,9 +204,7 @@ const TripleStoreService = {
     this.Authorization =
       'Basic ' + Buffer.from(this.settings.jenaUser + ':' + this.settings.jenaPassword).toString('base64');
   },
-  methods: {
-
-  }
+  methods: {}
 };
 
 module.exports = {

--- a/src/middleware/packages/triplestore/index.js
+++ b/src/middleware/packages/triplestore/index.js
@@ -56,68 +56,6 @@ const TripleStoreService = {
         if (!response.ok) throw new Error(response.statusText);
       }
     },
-    patch: {
-      visibility: 'public',
-      params: {
-        resource: {
-          type: 'object'
-        },
-        webId: {
-          type: 'string',
-          optional: true
-        },
-        contentType: {
-          type: 'string'
-        }
-      },
-      async handler(ctx) {
-        const webId = ctx.params.webId || ctx.meta.webId;
-        const contentType = ctx.params.contentType;
-        const query = await this.buildPatchQuery(ctx.params);
-        const response = await fetch(this.settings.sparqlEndpoint + this.settings.mainDataset + '/update', {
-          method: 'POST',
-          body: query,
-          headers: {
-            'Content-Type': 'application/sparql-update',
-            'X-SemappsUser': webId,
-            Authorization: this.Authorization
-          }
-        });
-        if (!response.ok) throw new Error(response.statusText);
-      }
-    },
-    delete: {
-      visibility: 'public',
-      params: {
-        uri: {
-          type: 'string'
-        },
-        webId: {
-          type: 'string',
-          optional: true
-        }
-      },
-      async handler(ctx) {
-        const { params } = ctx;
-        const webId = ctx.params.webId || ctx.meta.webId;
-        const response = await fetch(this.settings.sparqlEndpoint + this.settings.mainDataset + '/update', {
-          method: 'POST',
-          body: `DELETE
-              WHERE
-              { <${params.uri}> ?p ?v }
-              `,
-          headers: {
-            'Content-Type': 'application/sparql-update',
-            'X-SemappsUser': webId,
-            Authorization: this.Authorization
-          }
-        });
-
-        if (!response.ok) throw new Error(response.statusText);
-
-        return response;
-      }
-    },
     countTriplesOfSubject: {
       visibility: 'public',
       params: {
@@ -144,6 +82,32 @@ const TripleStoreService = {
         return results.length;
       }
     },
+    update : {
+        visibility: 'public',
+        params: {
+          query: {
+            type: 'string'
+          },
+          webId: {
+            type: 'string',
+            optional: true
+          }
+        },
+        async handler(ctx) {
+          const webId = ctx.params.webId || ctx.meta.webId;
+          const query = ctx.params.query;
+          const response = await fetch(this.settings.sparqlEndpoint + this.settings.mainDataset + '/update', {
+            method: 'POST',
+            body: query,
+            headers: {
+              'Content-Type': 'application/sparql-update',
+              'X-SemappsUser': webId,
+              Authorization: this.Authorization
+            }
+          });
+          if (!response.ok) throw new Error(response.statusText);
+        }
+      },
     query: {
       visibility: 'public',
       params: {
@@ -241,57 +205,7 @@ const TripleStoreService = {
       'Basic ' + Buffer.from(this.settings.jenaUser + ':' + this.settings.jenaPassword).toString('base64');
   },
   methods: {
-    buildPatchQuery(params) {
-      return new Promise((resolve, reject) => {
-        let deleteSPARQL = '';
-        let insertSPARQL = '';
-        let counter = 0;
-        let query;
-        const text =
-          typeof params.resource === 'string' || params.resource instanceof String
-            ? params.resource
-            : JSON.stringify(params.resource);
-        const textStream = streamifyString(text);
-        rdfParser
-          .parse(textStream, {
-            contentType: 'application/ld+json'
-          })
-          .on('data', quad => {
-            deleteSPARQL = deleteSPARQL.concat(
-              `DELETE WHERE  {<${quad.subject.value}> <${quad.predicate.value}> ?o};
-              `
-            );
-            if (insertSPARQL.length === 0) {
-              insertSPARQL = insertSPARQL.concat(`<${quad.subject.value}>`);
-            } else {
-              insertSPARQL = insertSPARQL.concat(';');
-            }
 
-            if (quad.object.value.startsWith('http')) {
-              insertSPARQL = insertSPARQL.concat(` <${quad.predicate.value}> <${quad.object.value}>`);
-            } else {
-              insertSPARQL = insertSPARQL.concat(
-                ` <${quad.predicate.value}> "${quad.object.value.replace(/(\r\n|\r|\n)/g, '\\n')}"`
-              );
-            }
-
-            if (quad.object.datatype !== undefined && !quad.object.value.startsWith('http')) {
-              insertSPARQL = insertSPARQL.concat(`^^<${quad.object.datatype.value}>`);
-            }
-
-            counter++;
-          })
-          .on('error', error => console.error(error))
-          .on('end', () => {
-            insertSPARQL = insertSPARQL.concat('.');
-            query = `
-            ${deleteSPARQL}
-            INSERT DATA {${insertSPARQL}};
-            `;
-            resolve(query);
-          });
-      });
-    }
   }
 };
 

--- a/src/middleware/packages/triplestore/package.json
+++ b/src/middleware/packages/triplestore/package.json
@@ -9,9 +9,7 @@
     "jsonld": "^1.8.1",
     "negotiator": "^0.6.2",
     "node-fetch": "^2.6.0",
-    "rdf-parse": "^1.2.1",
-    "sparqljson-parse": "^1.5.1",
-    "streamify-string": "^1.0.1"
+    "sparqljson-parse": "^1.5.1"
   },
   "publishConfig": {
     "access": "public"

--- a/src/middleware/tests/activitypub/follow.test.js
+++ b/src/middleware/tests/activitypub/follow.test.js
@@ -3,7 +3,7 @@ const { ACTIVITY_TYPES, OBJECT_TYPES } = require('@semapps/activitypub');
 const EventsWatcher = require('../middleware/EventsWatcher');
 const initialize = require('./initialize');
 
-jest.setTimeout(20000);
+jest.setTimeout(100000);
 
 const broker = new ServiceBroker({
   middlewares: [EventsWatcher]
@@ -33,7 +33,7 @@ describe('Posting to followers', () => {
 
     expect(sebastien.preferredUsername).toBe('srosset81');
     expect(simon.preferredUsername).toBe('simonLouvet');
-  }, 20000);
+  });
 
   test('Post follow request', async () => {
     let result = await broker.call('activitypub.outbox.post', {
@@ -58,7 +58,7 @@ describe('Posting to followers', () => {
     });
 
     expect(result.items).toContain(sebastien.id);
-  }, 20000);
+  });
 
   test('Send message to followers', async () => {
     let result = await broker.call('activitypub.outbox.post', {

--- a/src/middleware/tests/activitypub/object.test.js
+++ b/src/middleware/tests/activitypub/object.test.js
@@ -3,7 +3,7 @@ const { ACTIVITY_TYPES, OBJECT_TYPES } = require('@semapps/activitypub');
 const EventsWatcher = require('../middleware/EventsWatcher');
 const initialize = require('./initialize');
 
-jest.setTimeout(20000);
+jest.setTimeout(100000);
 
 const broker = new ServiceBroker({
   middlewares: [EventsWatcher]
@@ -25,7 +25,7 @@ describe('Create/Update/Delete objects', () => {
     });
 
     expect(sebastien.preferredUsername).toBe('srosset81');
-  }, 20000);
+  });
 
   test('Create object', async () => {
     await broker.call('activitypub.outbox.post', {

--- a/src/middleware/tests/ldp/ldp.test.js
+++ b/src/middleware/tests/ldp/ldp.test.js
@@ -126,6 +126,7 @@ describe('CRUD Project', () => {
   }, 20000);
 
   test('Replace One Project', async () => {
+    const slug = project1['@id'].match(new RegExp(`.*/(.*)`))[1];
     const urlParamsPut = {
       resource: {
         '@context': {
@@ -135,7 +136,9 @@ describe('CRUD Project', () => {
         description: 'myProjectUpdated'
       },
       accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
+      contentType: MIME_TYPES.JSON,
+      containerUri: `${CONFIG.HOME_URL}ldp/pair:Project`,
+      slug
     };
     await broker.call('ldp.resource.put', urlParamsPut);
     const updatedProject = await broker.call('ldp.resource.get', {

--- a/src/middleware/tests/ldp/ldp.test.js
+++ b/src/middleware/tests/ldp/ldp.test.js
@@ -136,9 +136,7 @@ describe('CRUD Project', () => {
         description: 'myProjectUpdated'
       },
       accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON,
-      containerUri: `${CONFIG.HOME_URL}ldp/pair:Project`,
-      slug
+      contentType: MIME_TYPES.JSON
     };
     await broker.call('ldp.resource.put', urlParamsPut);
     const updatedProject = await broker.call('ldp.resource.get', {

--- a/src/middleware/tests/package-lock.json
+++ b/src/middleware/tests/package-lock.json
@@ -1,8 +1,7 @@
 {
 	"name": "semapps-tests",
-	"version": "1.0.0",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.8.3",
@@ -1852,7 +1851,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1873,12 +1873,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1893,17 +1895,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2020,7 +2025,8 @@
 				"inherits": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2032,6 +2038,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2046,6 +2053,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2053,12 +2061,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2077,6 +2087,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2166,7 +2177,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2178,6 +2190,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2263,7 +2276,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2299,6 +2313,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2318,6 +2333,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2361,12 +2377,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/src/middleware/tests/package.json
+++ b/src/middleware/tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "SemApps integration tests",
   "scripts": {
-    "test": "jest --detectOpenHandles --verbose"
+    "test": "jest ldp --detectOpenHandles --verbose"
   },
   "author": "SemApps Team",
   "license": "Apache-2.0",

--- a/src/middleware/tests/package.json
+++ b/src/middleware/tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "SemApps integration tests",
   "scripts": {
-    "test": "jest ldp --detectOpenHandles --verbose"
+    "test": "jest --detectOpenHandles --verbose"
   },
   "author": "SemApps Team",
   "license": "Apache-2.0",

--- a/src/middleware/tests/package.json
+++ b/src/middleware/tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "SemApps integration tests",
   "scripts": {
-    "test": "jest --detectOpenHandles --forceExit"
+    "test": "jest --detectOpenHandles --verbose"
   },
   "author": "SemApps Team",
   "license": "Apache-2.0",


### PR DESCRIPTION
resolve #156 
- low level and utility SPARQL method in triplestore service + middle level SPARQL computing in ldp service
- PATCH support container move but requière containerUri
- PATCH reuse insert of tripleStore
- somme code clean up and LDP API cohesion