### PR TITLE
Replace expand param with queryDepth

### DIFF
--- a/src/middleware/packages/activitypub/service.js
+++ b/src/middleware/packages/activitypub/service.js
@@ -88,7 +88,8 @@ const ActivityPubService = {
             [`GET ${this.settings.containers.actors}/:username/outbox`]: 'activitypub.outbox.list',
             [`GET ${this.settings.containers.actors}/:username/inbox`]: 'activitypub.inbox.list',
             [`GET ${this.settings.containers.actors}/:username/followers`]: 'activitypub.follow.listFollowers',
-            [`GET ${this.settings.containers.actors}/:username/following`]: 'activitypub.follow.listFollowing'
+            [`GET ${this.settings.containers.actors}/:username/following`]: 'activitypub.follow.listFollowing',
+            [`POST ${this.settings.containers.actors}/:username/inbox`]: 'activitypub.inbox.post'
           }
         },
         // Secured routes

--- a/src/middleware/packages/activitypub/services/activity.js
+++ b/src/middleware/packages/activitypub/services/activity.js
@@ -1,6 +1,6 @@
 const DbService = require('moleculer-db');
 const { TripleStoreAdapter } = require('@semapps/ldp');
-const { objectCurrentToId, objectIdToCurrent } = require('../functions');
+const { objectCurrentToId, objectIdToCurrent } = require('../utils');
 
 const ActivityService = {
   name: 'activitypub.activity',
@@ -8,7 +8,7 @@ const ActivityService = {
   adapter: new TripleStoreAdapter(),
   settings: {
     containerUri: null, // To be set by the user
-    expand: ['as:object'],
+    queryDepth: 3,
     context: 'https://www.w3.org/ns/activitystreams'
   },
   hooks: {

--- a/src/middleware/packages/activitypub/services/actor.js
+++ b/src/middleware/packages/activitypub/services/actor.js
@@ -9,7 +9,7 @@ const ActorService = {
   dependencies: ['activitypub.collection'],
   settings: {
     containerUri: null, // To be set by the user
-    expand: ['as:location'],
+    queryDepth: 1,
     context: 'https://www.w3.org/ns/activitystreams'
   },
   actions: {

--- a/src/middleware/packages/activitypub/services/collection.js
+++ b/src/middleware/packages/activitypub/services/collection.js
@@ -1,5 +1,6 @@
 const jsonld = require('jsonld');
 const { MIME_TYPES } = require('@semapps/mime-types');
+const { buildBlankNodesQuery } = require('@semapps/ldp');
 
 const CollectionService = {
   name: 'activitypub.collection',
@@ -71,29 +72,16 @@ const CollectionService = {
      * Returns a JSON-LD formatted collection stored in the triple store
      * @param id The full URI of the collection
      * @param dereferenceItems Should we dereference the items in the collection ?
-     * @param expand Array of items' properties we want to expand
+     * @param queryDepth Number of blank nodes we want to dereference
      */
     async get(ctx) {
-      const { id, dereferenceItems = false, expand } = ctx.params;
-      let constructOptions = '',
-        whereOptions = '';
+      const { id, dereferenceItems = false, queryDepth } = ctx.params;
+      let constructQuery = '', whereQuery = '';
 
       if (dereferenceItems) {
-        constructOptions = `?item ?iP ?iO .`;
-        whereOptions = `?item ?iP ?iO .`;
-
-        if (expand) {
-          constructOptions += `?iO ?siP ?siO .`;
-          whereOptions += `
-          OPTIONAL {
-            ?item ?propsToExpand ?iO .
-            FILTER(?propsToExpand IN (${expand.join(', ')})) .
-            # We don't want to expand URIs as it creates problems when compacting
-            FILTER(!(isIRI(?iO))) .
-            ?iO ?siP ?siO .
-          }
-        `;
-        }
+        const [ constructBnQuery, whereBnQuery ] = buildBlankNodesQuery(queryDepth);
+        constructQuery = '?s1 ?p1 ?o1 .' + constructBnQuery;
+        whereQuery = '?s1 ?p1 ?o1 .' + whereBnQuery;
       }
 
       let result = await ctx.call('triplestore.query', {
@@ -101,14 +89,14 @@ const CollectionService = {
           PREFIX as: <https://www.w3.org/ns/activitystreams#>
           CONSTRUCT {
             <${id}> a ?type ;
-              as:items ?item .
-            ${constructOptions}
+              as:items ?s1 .
+            ${constructQuery}
           }
           WHERE {
             <${id}> a ?type .
             OPTIONAL { 
-              <${id}> as:items ?item .
-              ${whereOptions}
+              <${id}> as:items ?s1 .
+              ${whereQuery}
             }
           }
         `,

--- a/src/middleware/packages/activitypub/services/collection.js
+++ b/src/middleware/packages/activitypub/services/collection.js
@@ -76,10 +76,11 @@ const CollectionService = {
      */
     async get(ctx) {
       const { id, dereferenceItems = false, queryDepth } = ctx.params;
-      let constructQuery = '', whereQuery = '';
+      let constructQuery = '',
+        whereQuery = '';
 
       if (dereferenceItems) {
-        const [ constructBnQuery, whereBnQuery ] = buildBlankNodesQuery(queryDepth);
+        const [constructBnQuery, whereBnQuery] = buildBlankNodesQuery(queryDepth);
         constructQuery = '?s1 ?p1 ?o1 .' + constructBnQuery;
         whereQuery = '?s1 ?p1 ?o1 .' + whereBnQuery;
       }

--- a/src/middleware/packages/activitypub/services/inbox.js
+++ b/src/middleware/packages/activitypub/services/inbox.js
@@ -1,6 +1,6 @@
 const urlJoin = require('url-join');
 const { PUBLIC_URI } = require('../constants');
-const { objectCurrentToId } = require('../functions');
+const { objectCurrentToId } = require('../utils');
 
 const InboxService = {
   name: 'activitypub.inbox',
@@ -47,7 +47,7 @@ const InboxService = {
       const collection = await ctx.call('activitypub.collection.get', {
         id: this.getInboxUri(ctx.params.username),
         dereferenceItems: true,
-        expand: ['as:object']
+        queryDepth: 3
       });
 
       if (collection) {

--- a/src/middleware/packages/activitypub/services/outbox.js
+++ b/src/middleware/packages/activitypub/services/outbox.js
@@ -1,6 +1,6 @@
 const urlJoin = require('url-join');
 const { OBJECT_TYPES, ACTIVITY_TYPES } = require('../constants');
-const { objectCurrentToId } = require('../functions');
+const { objectCurrentToId } = require('../utils');
 
 const OutboxService = {
   name: 'activitypub.outbox',
@@ -66,7 +66,7 @@ const OutboxService = {
       const collection = await ctx.call('activitypub.collection.get', {
         id: this.getOutboxUri(ctx.params.username),
         dereferenceItems: true,
-        expand: ['as:object']
+        queryDepth: 3
       });
 
       if (collection) {

--- a/src/middleware/packages/activitypub/utils.js
+++ b/src/middleware/packages/activitypub/utils.js
@@ -5,7 +5,7 @@ const objectCurrentToId = activityJson => {
       ...activityJson,
       object: {
         id: current,
-        ...object
+        ...objectCurrentToId(object)
       }
     };
   } else {
@@ -20,7 +20,7 @@ const objectIdToCurrent = activityJson => {
       ...activityJson,
       object: {
         current: id || arobaseId,
-        ...object
+        ...objectIdToCurrent(object)
       }
     };
   } else {

--- a/src/middleware/packages/ldp/adapter.js
+++ b/src/middleware/packages/ldp/adapter.js
@@ -49,7 +49,7 @@ class TripleStoreAdapter {
   find(filters) {
     return this.broker.call(this.containerService + '.get', {
       containerUri: this.service.schema.settings.containerUri,
-      expand: this.service.schema.settings.expand,
+      queryDepth: this.service.schema.settings.queryDepth,
       jsonContext: this.service.schema.settings.context,
       accept: MIME_TYPES.JSON
     });
@@ -71,7 +71,7 @@ class TripleStoreAdapter {
     }
     return this.broker.call(this.resourceService + '.get', {
       resourceUri: _id,
-      expand: this.service.schema.settings.expand,
+      queryDepth: this.service.schema.settings.queryDepth,
       jsonContext: this.service.schema.settings.context,
       accept: MIME_TYPES.JSON
     });
@@ -81,7 +81,7 @@ class TripleStoreAdapter {
    * Find all entities by IDs
    */
   findByIds(ids) {
-    throw new Error('Method not implemented');
+    return Promise.all(ids.map(id => this.findById(id)));
   }
 
   /**
@@ -93,14 +93,7 @@ class TripleStoreAdapter {
    *  - query
    */
   count(filters = {}) {
-    return this.broker
-      .call(this.containerService + '.get', {
-        containerUri: this.service.schema.settings.containerUri,
-        expand: this.service.schema.settings.expand,
-        jsonContext: this.service.schema.settings.context,
-        accept: MIME_TYPES.JSON
-      })
-      .then(result => result['ldp:contains'].length);
+    return this.find(filters).then(result => result['ldp:contains'].length);
   }
 
   /**
@@ -122,12 +115,7 @@ class TripleStoreAdapter {
           resourceUri
         });
 
-        return this.broker.call(this.resourceService + '.get', {
-          resourceUri,
-          expand: this.service.schema.settings.expand,
-          jsonContext: this.service.schema.settings.context,
-          accept: MIME_TYPES.JSON
-        });
+        return this.findById(resourceUri);
       });
   }
 
@@ -165,14 +153,7 @@ class TripleStoreAdapter {
         },
         contentType: MIME_TYPES.JSON
       })
-      .then(resourceUri => {
-        return this.broker.call(this.resourceService + '.get', {
-          resourceUri,
-          expand: this.service.schema.settings.expand,
-          jsonContext: this.service.schema.settings.context,
-          accept: MIME_TYPES.JSON
-        });
-      });
+      .then(resourceUri => this.findById(resourceUri));
   }
 
   /**

--- a/src/middleware/packages/ldp/index.js
+++ b/src/middleware/packages/ldp/index.js
@@ -1,4 +1,4 @@
-const { getPrefixJSON, generateId, getPrefixRdf } = require('./utils');
+const utils = require('./utils');
 
 module.exports = {
   LdpService: require('./service'),
@@ -6,7 +6,5 @@ module.exports = {
   LdpResourceService: require('./services/resource'),
   TripleStoreAdapter: require('./adapter'),
   getContainerRoutes: require('./routes/getContainerRoutes'),
-  getPrefixJSON,
-  getPrefixRdf,
-  generateId
+  ...utils
 };

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     async handler(ctx) {
       const { accept, containerUri, queryDepth, jsonContext } = ctx.params;
-      const [ constructQuery, whereQuery ] = buildBlankNodesQuery(queryDepth);
+      const [constructQuery, whereQuery] = buildBlankNodesQuery(queryDepth);
 
       const result = await ctx.call('triplestore.query', {
         query: `

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -1,7 +1,7 @@
 const { MoleculerError } = require('moleculer').Errors;
 const { MIME_TYPES } = require('@semapps/mime-types');
 const jsonld = require('jsonld');
-const { getPrefixRdf, getPrefixJSON } = require('../../../utils');
+const { getPrefixRdf, getPrefixJSON, buildBlankNodesQuery } = require('../../../utils');
 
 module.exports = {
   api: async function api(ctx) {
@@ -27,43 +27,29 @@ module.exports = {
       resourceUri: { type: 'string' },
       webId: { type: 'string', optional: true },
       accept: { type: 'string' },
-      expand: { type: 'array', optional: true },
+      queryDepth: { type: 'number', default: 0 },
       jsonContext: { type: 'multi', rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }], optional: true }
     },
     async handler(ctx) {
-      const { resourceUri, accept, webId, expand, jsonContext } = ctx.params;
+      const { resourceUri, accept, webId, queryDepth, jsonContext } = ctx.params;
 
       const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
         uri: resourceUri
       });
 
       if (triplesNb > 0) {
-        let constructOptions = '',
-          whereOptions = '';
-
-        if (expand) {
-          constructOptions = `?rO ?srP ?srO .`;
-          whereOptions = `
-            OPTIONAL {
-              ?item ?propsToExpand ?rO .
-              FILTER(?propsToExpand IN (${expand.join(', ')})) .
-              # We don't want to expand URIs as it creates problems when compacting
-              FILTER(!(isIRI(?rO))) .
-              ?rO ?srP ?srO .
-            }
-          `;
-        }
+        const [ constructQuery, whereQuery ] = buildBlankNodesQuery(queryDepth);
 
         let result = await ctx.call('triplestore.query', {
           query: `
             ${getPrefixRdf(this.settings.ontologies)}
             CONSTRUCT  {
-              <${resourceUri}> ?rP ?rO .
-              ${constructOptions}
+              <${resourceUri}> ?p1 ?o1 .
+              ${constructQuery}
             }
             WHERE {
-              <${resourceUri}> ?rP ?rO .
-              ${whereOptions}
+              <${resourceUri}> ?p1 ?o1 .
+              ${whereQuery}
             }
           `,
           accept,

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -38,7 +38,7 @@ module.exports = {
       });
 
       if (triplesNb > 0) {
-        const [ constructQuery, whereQuery ] = buildBlankNodesQuery(queryDepth);
+        const [constructQuery, whereQuery] = buildBlankNodesQuery(queryDepth);
 
         let result = await ctx.call('triplestore.query', {
           query: `

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -6,14 +6,14 @@ const buildBlankNodesQuery = depth => {
   if (depth > 0) {
     for (let i = 1; i <= depth; i++) {
       constructQuery += `
-      ?o${i} ?p${i + 1} ?o${i + 1} .
-    `;
-      whereQuery += `
-      OPTIONAL {
-        FILTER((isBLANK(?o${i}))) .
         ?o${i} ?p${i + 1} ?o${i + 1} .
-      }
-    `;
+      `;
+      whereQuery += `
+        OPTIONAL {
+          FILTER((isBLANK(?o${i}))) .
+          ?o${i} ?p${i + 1} ?o${i + 1} .
+        }
+      `;
     }
   }
   return [constructQuery, whereQuery];

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -1,5 +1,23 @@
 const uuid = require('uuid/v1');
 
+const buildBlankNodesQuery = depth => {
+  let constructQuery = '', whereQuery = '';
+  if( depth > 0 ) {
+    for( let i=1; i<=depth; i++ ) {
+      constructQuery += `
+      ?o${i} ?p${i+1} ?o${i+1} .
+    `;
+      whereQuery += `
+      OPTIONAL {
+        FILTER((isBLANK(?o${i}))) .
+        ?o${i} ?p${i+1} ?o${i+1} .
+      }
+    `;
+    }
+  }
+  return [ constructQuery, whereQuery ];
+};
+
 const generateId = () => {
   return uuid().substring(0, 8);
 };
@@ -15,6 +33,7 @@ const getPrefixJSON = ontologies => {
 };
 
 module.exports = {
+  buildBlankNodesQuery,
   generateId,
   getPrefixRdf,
   getPrefixJSON

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -1,21 +1,22 @@
 const uuid = require('uuid/v1');
 
 const buildBlankNodesQuery = depth => {
-  let constructQuery = '', whereQuery = '';
-  if( depth > 0 ) {
-    for( let i=1; i<=depth; i++ ) {
+  let constructQuery = '',
+    whereQuery = '';
+  if (depth > 0) {
+    for (let i = 1; i <= depth; i++) {
       constructQuery += `
-      ?o${i} ?p${i+1} ?o${i+1} .
+      ?o${i} ?p${i + 1} ?o${i + 1} .
     `;
       whereQuery += `
       OPTIONAL {
         FILTER((isBLANK(?o${i}))) .
-        ?o${i} ?p${i+1} ?o${i+1} .
+        ?o${i} ?p${i + 1} ?o${i + 1} .
       }
     `;
     }
   }
-  return [ constructQuery, whereQuery ];
+  return [constructQuery, whereQuery];
 };
 
 const generateId = () => {


### PR DESCRIPTION
Remplace le paramètre `expand` par `queryDepth` et automatise de cette manière la requête des blank nodes.

Cela permet de gérer facilement des objets complexes comme ça, qui sont assez fréquents avec ActivityPub, puisqu'une activité peut elle-même faire référence à d'autres activités.

```json
{
  "@context": [
    "https://www.w3.org/ns/activitystreams",
    {
      "pair": "http://virtual-assembly.org/ontologies/pair#"
    }
  ],
  "id": "http://localhost:3000/activities/6533b320",
  "type": "Announce",
  "actor": "http://localhost:3000/actors/match-bot",
  "object": {
    "id": "https://colibris.social/activities/51sdsdc5",
    "type": "Create",
    "object": {
      "id": "https://colibris.social/objects/douce-france-le-film",
      "type": "pair:Project",
      "pair:aboutPage": "https://www.colibris-lafabrique.org/les-projets/douce-france-le-film",
      "pair:description": "Un film documentaire pour le cinéma qui sera diffusé dans toutes les régions lors d'une grande tournée de ciné-débats : un film pour bousculer les idées reçues, débattre et inspirer !",
      "pair:interestOf": [
        "http://localhost:3000/themes/democratie",
        "http://localhost:3000/themes/habitat-and-oasis"
      ],
      "pair:label": "Douce France, le film !",
      "image": {
        "type": "Image",
        "url": "https://www.colibris-lafabrique.org/sites/default/files/styles/projet_large/public/projets/affiche_et_toi_tu_veux_quoi_sur_ton_territoire_.png?itok=ccgII27H"
      },
      "location": {
        "type": "Place",
        "latitude": "45.1869",
        "longitude": "5.72628"
      }
    },
    "to": "http://localhost:3000/actors/match-bot"
  },
  "published": "2020-04-16T15:53:20.463Z"
}
```
Dans le cas ci-dessus la requête nécessite une `queryDepth` de niveau 3 (Announce > Create > Project > Image et Place). Au niveau 0 (celui par défaut), seule l'activité Announce serait retournée, et l'activité Create serait un simple `_b0`.

Il serait aussi possible de généraliser la requête de tous les blank nodes, mais je me demandais si ça pouvait pas avoir un impact négative sur les performances ?