### PR TITLE
Fix LDP container and AP collection returned types

### DIFF
--- a/src/middleware/packages/activitypub/services/collection.js
+++ b/src/middleware/packages/activitypub/services/collection.js
@@ -104,12 +104,12 @@ const CollectionService = {
         query: `
           PREFIX as: <https://www.w3.org/ns/activitystreams#>
           CONSTRUCT {
-            <${id}> a ?type ;
+            <${id}> a ?collectionType ;
               as:items ?s1 .
             ${constructQuery}
           }
           WHERE {
-            <${id}> a ?type .
+            <${id}> a as:Collection, ?collectionType .
             OPTIONAL { 
               <${id}> as:items ?s1 .
               ${whereQuery}

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -53,13 +53,13 @@ module.exports = {
           ${getPrefixRdf(this.settings.ontologies)}
           CONSTRUCT  {
             <${containerUri}>
-              a ldp:BasicContainer ;
+              a ?containerType ;
               ldp:contains ?s1 .
             ?s1 ?p1 ?o1 .
             ${constructQuery}
           }
           WHERE {
-            <${containerUri}> a ldp:BasicContainer .
+            <${containerUri}> a ldp:Container, ?containerType .
             OPTIONAL { 
               <${containerUri}> ldp:contains ?s1 .
               ?s1 ?p1 ?o1 .

--- a/src/middleware/tests/ldp/container.test.js
+++ b/src/middleware/tests/ldp/container.test.js
@@ -64,7 +64,7 @@ describe('LDP container tests', () => {
       })
     ).resolves.toMatchObject({
       '@id': CONFIG.HOME_URL + 'objects',
-      '@type': 'ldp:BasicContainer'
+      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ]
     });
   });
 
@@ -89,7 +89,7 @@ describe('LDP container tests', () => {
     ).resolves.toMatchObject({
       '@context': getPrefixJSON(ontologies),
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': 'ldp:BasicContainer',
+      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
       'ldp:contains': [
         {
           '@id': resourceUri,
@@ -139,7 +139,7 @@ describe('LDP container tests', () => {
         '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
       },
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': 'http://www.w3.org/ns/ldp#BasicContainer',
+      '@type': [ 'http://www.w3.org/ns/ldp#Container', 'http://www.w3.org/ns/ldp#BasicContainer' ],
       'http://www.w3.org/ns/ldp#contains': [
         {
           '@id': resourceUri,
@@ -171,7 +171,7 @@ describe('LDP container tests', () => {
       })
     ).resolves.toMatchObject({
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': 'ldp:BasicContainer',
+      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
       'ldp:contains': [
         {
           'pair:label': 'My project 2'
@@ -193,7 +193,7 @@ describe('LDP container tests', () => {
       })
     ).resolves.toMatchObject({
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': 'ldp:BasicContainer',
+      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
       'ldp:contains': [
         {
           'pair:label': 'My project 2'
@@ -217,7 +217,7 @@ describe('LDP container tests', () => {
     ).resolves.toMatchObject({
       '@context': getPrefixJSON(ontologies),
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': 'ldp:BasicContainer',
+      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
       'ldp:contains': [
         {
           'pair:label': 'My project 2'

--- a/src/middleware/tests/ldp/container.test.js
+++ b/src/middleware/tests/ldp/container.test.js
@@ -64,7 +64,7 @@ describe('LDP container tests', () => {
       })
     ).resolves.toMatchObject({
       '@id': CONFIG.HOME_URL + 'objects',
-      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ]
+      '@type': ['ldp:Container', 'ldp:BasicContainer']
     });
   });
 
@@ -89,7 +89,7 @@ describe('LDP container tests', () => {
     ).resolves.toMatchObject({
       '@context': getPrefixJSON(ontologies),
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
+      '@type': ['ldp:Container', 'ldp:BasicContainer'],
       'ldp:contains': [
         {
           '@id': resourceUri,
@@ -139,7 +139,7 @@ describe('LDP container tests', () => {
         '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
       },
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': [ 'http://www.w3.org/ns/ldp#Container', 'http://www.w3.org/ns/ldp#BasicContainer' ],
+      '@type': ['http://www.w3.org/ns/ldp#Container', 'http://www.w3.org/ns/ldp#BasicContainer'],
       'http://www.w3.org/ns/ldp#contains': [
         {
           '@id': resourceUri,
@@ -171,7 +171,7 @@ describe('LDP container tests', () => {
       })
     ).resolves.toMatchObject({
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
+      '@type': ['ldp:Container', 'ldp:BasicContainer'],
       'ldp:contains': [
         {
           'pair:label': 'My project 2'
@@ -193,7 +193,7 @@ describe('LDP container tests', () => {
       })
     ).resolves.toMatchObject({
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
+      '@type': ['ldp:Container', 'ldp:BasicContainer'],
       'ldp:contains': [
         {
           'pair:label': 'My project 2'
@@ -217,7 +217,7 @@ describe('LDP container tests', () => {
     ).resolves.toMatchObject({
       '@context': getPrefixJSON(ontologies),
       '@id': CONFIG.HOME_URL + 'resources',
-      '@type': [ 'ldp:Container', 'ldp:BasicContainer' ],
+      '@type': ['ldp:Container', 'ldp:BasicContainer'],
       'ldp:contains': [
         {
           'pair:label': 'My project 2'


### PR DESCRIPTION
Currently containers return only the `ldp:BasicContainer` type, which broke compatibility with SiB.

With this fix, it returns `[ "ldp:Container", "ldp:BasicContainer" ]`

I also harmonized the code of AP collections