### PR TITLE
upgrade make & docker environement

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Default env variables for docker-compose files
 MIDDLEWARE=runner
-FRONTEND=playground
+FRONTEND=dms

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ prettier:
 	npm run prettier --prefix ./src/middleware
 
 bootstrap:
+	npm run bootstrap --prefix ./src/frontend
 	npm run bootstrap --prefix ./src/middleware
 
 # For tests we currently only need fuseki

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,13 +49,14 @@ services:
     environment:
       - PORT=5000
     volumes:
-      - ./src/frontend/${FRONTEND}:/app
+      - ./src/frontend:/app/
     networks:
       - semapps
     ports:
       - "5000:5000"
     expose:
       - "5000"
+    command: bash -c "npm rebuild && npm install && npm run bootstrap && npm start --prefix ./${FRONTEND}"
 
 volumes:
   rdf_data:

--- a/src/frontend/Dockerfile.dev
+++ b/src/frontend/Dockerfile.dev
@@ -1,7 +1,9 @@
-FROM node:12.16-alpine
+FROM node:13.14-alpine
 
 WORKDIR /app
 
 RUN apk add --update --no-cache git bash yarn nano
+
+RUN apk add --update --no-cache autoconf libtool automake alpine-sdk
 
 CMD npm install && npm start

--- a/src/frontend/packages/react-admin/package-lock.json
+++ b/src/frontend/packages/react-admin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@semapps/react-admin",
-	"version": "0.1.0",
+	"version": "0.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
resolve #265 

ajout de 
```RUN apk add --update --no-cache autoconf libtool automake alpine-sdk```
dans le dockerfile du front end pour supporter des compilation lors du bootstrap dans le docker

modification du montage de volume dans docker compose
```
    volumes:
      - ./src/frontend:/app/
```
pour monter les front possible et les packages

lancement du docker compose avec
```
command: bash -c "npm rebuild && npm install && npm run bootstrap && npm start --prefix ./${FRONTEND}"
```
pour mettre à jour les node_modules issues du host avec  l'OS/version docker du docker, installer les dépendance de la racine (notamment lerna), installer les dépendances des projets enfants + lien symboliques lerna , lancer la front choisi dans le .env

ajout de 
```
bootstrap:
	npm run bootstrap --prefix ./src/frontend
```
dans le make file pour que le make init bootrap également le front
