### PR TITLE
Fix findUnusedUri and refactor a bit

### DIFF
--- a/src/middleware/packages/ldp/services/resource/actions/post.js
+++ b/src/middleware/packages/ldp/services/resource/actions/post.js
@@ -1,4 +1,5 @@
 const { MoleculerError } = require('moleculer').Errors;
+const urlJoin = require('url-join');
 const { MIME_TYPES } = require('@semapps/mime-types');
 const { generateId } = require('../../../utils');
 
@@ -49,8 +50,8 @@ module.exports = {
       const { resource, containerUri, slug, contentType, webId } = ctx.params;
 
       // Generate ID and make sure it doesn't exist already
-      resource['@id'] = `${containerUri.replace(/\/$/, '')}/${slug || generateId()}`;
-      resource['@id'] = await this.findUnusedUri(ctx, resource['@id']);
+      resource['@id'] = urlJoin(containerUri, slug || generateId());
+      resource['@id'] = await this.findAvailableUri(ctx, resource['@id']);
 
       const containerExist = await ctx.call('ldp.container.exist', { containerUri });
       if (!containerExist) {


### PR DESCRIPTION
Si on voulait utiliser l'ID http://localhost:3000/resources/1 mais qu'une ressource http://localhost:3000/resources/1588 existait déjà, cela incrémentait pour http://localhost:3000/resources/12. 

Cette PR fixe le problème. Je la merge immédiatement @simonLouvet car je dois faire une mise en prod.
