### PR TITLE
Add default JSON context parameter

### DIFF
--- a/src/middleware/packages/activitypub/services/actor.js
+++ b/src/middleware/packages/activitypub/services/actor.js
@@ -55,7 +55,7 @@ const ActorService = {
     before: {
       create: [
         function parseSlugFromHeader(ctx) {
-          if( ctx.meta && ctx.meta.headers && ctx.meta.headers.slug ) {
+          if (ctx.meta && ctx.meta.headers && ctx.meta.headers.slug) {
             ctx.params.slug = ctx.meta.headers.slug;
           }
         }

--- a/src/middleware/packages/activitypub/services/object.js
+++ b/src/middleware/packages/activitypub/services/object.js
@@ -47,7 +47,7 @@ const ObjectService = {
     before: {
       create: [
         function parseSlugFromHeader(ctx) {
-          if( ctx.meta && ctx.meta.headers && ctx.meta.headers.slug ) {
+          if (ctx.meta && ctx.meta.headers && ctx.meta.headers.slug) {
             ctx.params.slug = ctx.meta.headers.slug;
           }
         }

--- a/src/middleware/packages/ldp/service.js
+++ b/src/middleware/packages/ldp/service.js
@@ -9,17 +9,19 @@ module.exports = {
     baseUrl: null,
     ontologies: [],
     containers: ['/resources'],
-    defaultAccept: 'text/turtle'
+    defaultAccept: 'text/turtle',
+    defaultJsonContext: null
   },
   async created() {
-    const { baseUrl, ontologies, containers, defaultAccept } = this.schema.settings;
+    const { baseUrl, ontologies, containers, defaultAccept, defaultJsonContext } = this.schema.settings;
 
     await this.broker.createService(LdpContainerService, {
       settings: {
         baseUrl,
         ontologies,
         containers,
-        defaultAccept
+        defaultAccept,
+        defaultJsonContext
       }
     });
 
@@ -27,7 +29,8 @@ module.exports = {
       settings: {
         baseUrl,
         ontologies,
-        defaultAccept
+        defaultAccept,
+        defaultJsonContext
       }
     });
   },

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -72,7 +72,7 @@ module.exports = {
 
       if (accept === MIME_TYPES.JSON) {
         result = await jsonld.frame(result, {
-          '@context': jsonContext || getPrefixJSON(this.settings.ontologies),
+          '@context': jsonContext || this.settings.defaultJsonContext || getPrefixJSON(this.settings.ontologies),
           '@id': containerUri
         });
 

--- a/src/middleware/packages/ldp/services/container/index.js
+++ b/src/middleware/packages/ldp/services/container/index.js
@@ -12,7 +12,8 @@ module.exports = {
     baseUrl: null,
     ontologies: [],
     containers: ['resources'],
-    defaultAccept: null
+    defaultAccept: null,
+    defaultJsonContext: null
   },
   dependencies: ['triplestore'],
   actions: {

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -59,7 +59,7 @@ module.exports = {
         // If we asked for JSON-LD, frame it using the correct context in order to have clean, consistent results
         if (accept === MIME_TYPES.JSON) {
           result = await jsonld.frame(result, {
-            '@context': jsonContext || getPrefixJSON(this.settings.ontologies),
+            '@context': jsonContext || this.settings.defaultJsonContext || getPrefixJSON(this.settings.ontologies),
             '@id': resourceUri
           });
 

--- a/src/middleware/packages/ldp/services/resource/index.js
+++ b/src/middleware/packages/ldp/services/resource/index.js
@@ -11,7 +11,8 @@ module.exports = {
   settings: {
     baseUrl: null,
     ontologies: [],
-    defaultAccept: null
+    defaultAccept: null,
+    defaultJsonContext: null
   },
   dependencies: ['triplestore'],
   actions: {


### PR DESCRIPTION
Permet de passer un fichier de contexte JSON qui sera utilisé pour formatter les résultats en JSON-LD.

Ce fichier sera appliqué sur TOUTES les données, à moins qu'un paramètre `jsonContext` soit passé aux actions `ldp.resource.get` et `ldp.container.get`.