### PR TITLE
Emit events on LDP resources operations

### DIFF
--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -1,4 +1,4 @@
-const { MoleculerError } = require('moleculer').Errors;
+const { MIME_TYPES } = require('@semapps/mime-types');
 const { getContainerFromUri } = require('../../../utils');
 
 module.exports = {
@@ -29,27 +29,33 @@ module.exports = {
     async handler(ctx) {
       const { resourceUri, webId } = ctx.params;
 
-      const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
-        uri: resourceUri
+      // Save the current data, to be able to send it through the event
+      // If the resource does not exist, it will throw a 404 error
+      const oldData = await ctx.call('ldp.resource.get', {
+        resourceUri,
+        accept: MIME_TYPES.JSON,
+        queryDepth: 1
       });
 
-      if (triplesNb > 0) {
-        await ctx.call('ldp.container.detach', {
-          containerUri: getContainerFromUri(resourceUri),
-          resourceUri
-        });
+      await ctx.call('ldp.container.detach', {
+        containerUri: getContainerFromUri(resourceUri),
+        resourceUri,
+      });
 
-        await ctx.call('triplestore.update', {
-          query: `
-            DELETE
-            WHERE
-            { <${resourceUri}> ?p ?v }
-          `,
-          webId
-        });
-      } else {
-        throw new MoleculerError(`Not found ${resourceUri}`, 404, 'NOT_FOUND');
-      }
+      await ctx.call('triplestore.update', {
+        query: `
+          DELETE
+          WHERE
+          { <${resourceUri}> ?p ?v }
+        `,
+        webId
+      });
+
+      ctx.emit('ldp.resource.deleted', {
+        resourceUri,
+        oldData,
+        webId
+      });
     }
   }
 };

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -39,7 +39,7 @@ module.exports = {
 
       await ctx.call('ldp.container.detach', {
         containerUri: getContainerFromUri(resourceUri),
-        resourceUri,
+        resourceUri
       });
 
       await ctx.call('triplestore.update', {

--- a/src/middleware/packages/ldp/services/resource/actions/patch.js
+++ b/src/middleware/packages/ldp/services/resource/actions/patch.js
@@ -1,4 +1,4 @@
-const { MoleculerError } = require('moleculer').Errors;
+const { MIME_TYPES } = require('@semapps/mime-types');
 
 module.exports = {
   api: async function api(ctx) {
@@ -41,28 +41,41 @@ module.exports = {
     async handler(ctx) {
       const { resource, contentType, webId } = ctx.params;
 
-      const triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
-        uri: resource['@id']
+      // Save the current data, to be able to send it through the event
+      // If the resource does not exist, it will throw a 404 error
+      const oldData = await ctx.call('ldp.resource.get', {
+        resourceUri: resource['@id'],
+        accept: MIME_TYPES.JSON,
+        queryDepth: 1
       });
 
-      if (triplesNb > 0) {
-        const query = await this.buildDeleteQueryFromResource(resource);
+      const query = await this.buildDeleteQueryFromResource(resource);
+      await ctx.call('triplestore.update', {
+        query,
+        webId
+      });
 
-        await ctx.call('triplestore.update', {
-          query,
-          webId
-        });
+      await ctx.call('triplestore.insert', {
+        resource,
+        contentType,
+        webId
+      });
 
-        await ctx.call('triplestore.insert', {
-          resource,
-          contentType,
-          webId
-        });
+      // Get the new data, with the same formatting as the old data
+      const newData = await ctx.call('ldp.resource.get', {
+        resourceUri: resource['@id'],
+        accept: MIME_TYPES.JSON,
+        queryDepth: 1
+      });
 
-        return resource['@id'];
-      } else {
-        throw new MoleculerError('Not found', 404, 'NOT_FOUND');
-      }
+      ctx.emit('ldp.resource.updated', {
+        resourceUri: resource['@id'],
+        oldData,
+        newData,
+        webId
+      });
+
+      return resource['@id'];
     }
   }
 };

--- a/src/middleware/packages/ldp/services/resource/actions/post.js
+++ b/src/middleware/packages/ldp/services/resource/actions/post.js
@@ -79,6 +79,19 @@ module.exports = {
         webId
       });
 
+      // Get the standard-formatted data to send with event
+      const newData = await ctx.call('ldp.resource.get', {
+        resourceUri: resource['@id'],
+        accept: MIME_TYPES.JSON,
+        queryDepth: 1
+      });
+
+      ctx.emit('ldp.resource.created', {
+        resourceUri: resource['@id'],
+        newData,
+        webId
+      });
+
       return resource['@id'];
     }
   }


### PR DESCRIPTION
Closes #366

Remarques:
- Ce changement a un léger impact au niveau des performances, mais en général les opérations d'écritures sont plus rares et donc moins sensibles que les opérations d'écritures
- Pour les données qui sont envoyées, j'ai mis un `queryDepth` de 1, afin d'avoir des données plus pertinentes pour les services qui écouteront les événements.
- On ne différencie pas les opérations `PATCH` et `PUT` car cela devrait avoir peu d'importances pour les services qui écouteront les événements. Si besoin, on pourra rajouter cette info plus tard.