### PR TITLE
Cache LDP resources and containers

### DIFF
--- a/src/middleware/packages/inference/service.js
+++ b/src/middleware/packages/inference/service.js
@@ -70,7 +70,7 @@ module.exports = {
     // Since the inverse links are added or removed directly in the triple store,
     // we need to invalidate manually the cache of the affected resources
     cleanResourcesCache(ctx, triples) {
-      if( this.broker.cacher ) {
+      if (this.broker.cacher) {
         for (let triple of triples) {
           const resourceUri = triple.subject.id;
           ctx.call('ldp.cache-cleaner.cleanResource', { resourceUri });

--- a/src/middleware/packages/inference/service.js
+++ b/src/middleware/packages/inference/service.js
@@ -67,6 +67,16 @@ module.exports = {
     generateDeleteQuery(triples) {
       return `DELETE WHERE { ${this.triplesToString(triples)} }`;
     },
+    // Since the inverse links are added or removed directly in the triple store,
+    // we need to invalidate manually the cache of the affected resources
+    cleanResourcesCache(ctx, triples) {
+      if( this.broker.cacher ) {
+        for (let triple of triples) {
+          const resourceUri = triple.subject.id;
+          ctx.call('ldp.cache-cleaner.cleanResource', { resourceUri });
+        }
+      }
+    },
     async filterMissingResources(ctx, triples) {
       let existingTriples = [];
       for (let triple of triples) {
@@ -74,6 +84,10 @@ module.exports = {
         if (resourceExist) existingTriples.push(triple);
       }
       return existingTriples;
+    },
+    // Exclude from triples1 the triples which also exist in triples2
+    getTriplesDifference(triples1, triples2) {
+      return triples1.filter(t1 => !triples2.some(t2 => t1.equals(t2)));
     }
   },
   events: {
@@ -86,8 +100,10 @@ module.exports = {
       // Avoid adding inverse link to non-existent resources
       triplesToAdd = await this.filterMissingResources(ctx, triplesToAdd);
 
-      if (triplesToAdd.length > 0)
+      if (triplesToAdd.length > 0) {
         await ctx.call('triplestore.update', { query: this.generateInsertQuery(triplesToAdd), webId });
+        this.cleanResourcesCache(ctx, triplesToAdd);
+      }
     },
     async 'ldp.resource.deleted'(ctx) {
       let { oldData, webId } = ctx.params;
@@ -95,8 +111,10 @@ module.exports = {
 
       let triplesToRemove = this.generateInverseTriples(oldData[0]);
 
-      if (triplesToRemove.length > 0)
+      if (triplesToRemove.length > 0) {
         await ctx.call('triplestore.update', { query: this.generateDeleteQuery(triplesToRemove), webId });
+        this.cleanResourcesCache(ctx, triplesToRemove);
+      }
     },
     async 'ldp.resource.updated'(ctx) {
       let { oldData, newData, webId } = ctx.params;
@@ -106,17 +124,22 @@ module.exports = {
       let triplesToRemove = this.generateInverseTriples(oldData[0]);
       let triplesToAdd = this.generateInverseTriples(newData[0]);
 
-      // TODO Filter out triples which are removed and added
-      // This will allow to identify resources which are really updated
-      // See https://graphy.link/memory.dataset.fast#method_difference
+      // Filter out triples which are removed and added at the same time
+      let filteredTriplesToAdd = this.getTriplesDifference(triplesToAdd, triplesToRemove);
+      let filteredTriplesToRemove = this.getTriplesDifference(triplesToRemove, triplesToAdd);
 
       // Avoid adding inverse link to non-existent resources
-      triplesToAdd = await this.filterMissingResources(ctx, triplesToAdd);
+      filteredTriplesToAdd = await this.filterMissingResources(ctx, filteredTriplesToAdd);
 
-      if (triplesToRemove.length > 0)
-        await ctx.call('triplestore.update', { query: this.generateDeleteQuery(triplesToRemove), webId });
-      if (triplesToAdd.length > 0)
-        await ctx.call('triplestore.update', { query: this.generateInsertQuery(triplesToAdd), webId });
+      if (filteredTriplesToRemove.length > 0) {
+        await ctx.call('triplestore.update', { query: this.generateDeleteQuery(filteredTriplesToRemove), webId });
+        this.cleanResourcesCache(ctx, filteredTriplesToRemove);
+      }
+
+      if (filteredTriplesToAdd.length > 0) {
+        await ctx.call('triplestore.update', { query: this.generateInsertQuery(filteredTriplesToAdd), webId });
+        this.cleanResourcesCache(ctx, filteredTriplesToAdd);
+      }
     }
   }
 };

--- a/src/middleware/packages/ldp/service.js
+++ b/src/middleware/packages/ldp/service.js
@@ -36,7 +36,7 @@ module.exports = {
     });
 
     // Only create this service if a cacher is defined
-    if( this.broker.cacher ) {
+    if (this.broker.cacher) {
       await this.broker.createService(LdpCacheCleanerService);
     }
   },

--- a/src/middleware/packages/ldp/service.js
+++ b/src/middleware/packages/ldp/service.js
@@ -1,6 +1,7 @@
 const urlJoin = require('url-join');
 const LdpContainerService = require('./services/container');
 const LdpResourceService = require('./services/resource');
+const LdpCacheCleanerService = require('./services/cache-cleaner');
 const getContainerRoutes = require('./routes/getContainerRoutes');
 
 module.exports = {
@@ -33,6 +34,11 @@ module.exports = {
         defaultJsonContext
       }
     });
+
+    // Only create this service if a cacher is defined
+    if( this.broker.cacher ) {
+      await this.broker.createService(LdpCacheCleanerService);
+    }
   },
   actions: {
     getApiRoutes() {

--- a/src/middleware/packages/ldp/services/cache-cleaner/index.js
+++ b/src/middleware/packages/ldp/services/cache-cleaner/index.js
@@ -4,7 +4,7 @@ module.exports = {
   name: 'ldp.cache-cleaner',
   actions: {
     async cleanResource(ctx) {
-      if( this.broker.cacher ) {
+      if (this.broker.cacher) {
         const { resourceUri } = ctx.params;
         await this.broker.cacher.clean(`ldp.resource.get:${resourceUri}**`);
 
@@ -15,7 +15,7 @@ module.exports = {
       }
     },
     async cleanContainer(ctx) {
-      if( this.broker.cacher ) {
+      if (this.broker.cacher) {
         const { containerUri } = ctx.params;
         await this.broker.cacher.clean(`ldp.container.get:${containerUri}**`);
       }

--- a/src/middleware/packages/ldp/services/cache-cleaner/index.js
+++ b/src/middleware/packages/ldp/services/cache-cleaner/index.js
@@ -1,0 +1,42 @@
+const { getContainerFromUri } = require('../../utils');
+
+module.exports = {
+  name: 'ldp.cache-cleaner',
+  actions: {
+    async cleanResource(ctx) {
+      if( this.broker.cacher ) {
+        const { resourceUri } = ctx.params;
+        await this.broker.cacher.clean(`ldp.resource.get:${resourceUri}**`);
+
+        // Also clean the container containing the resource
+        // TODO search all containers containing the resource
+        const containerUri = getContainerFromUri(resourceUri);
+        await this.actions.cleanContainer({ containerUri });
+      }
+    },
+    async cleanContainer(ctx) {
+      if( this.broker.cacher ) {
+        const { containerUri } = ctx.params;
+        await this.broker.cacher.clean(`ldp.container.get:${containerUri}**`);
+      }
+    }
+  },
+  events: {
+    async 'ldp.resource.deleted'(ctx) {
+      const { resourceUri } = ctx.params;
+      await this.actions.cleanResource({ resourceUri });
+    },
+    async 'ldp.resource.updated'(ctx) {
+      const { resourceUri } = ctx.params;
+      await this.actions.cleanResource({ resourceUri });
+    },
+    async 'ldp.container.attached'(ctx) {
+      const { containerUri } = ctx.params;
+      await this.actions.cleanContainer({ containerUri });
+    },
+    async 'ldp.container.detached'(ctx) {
+      const { containerUri } = ctx.params;
+      await this.actions.cleanContainer({ containerUri });
+    }
+  }
+};

--- a/src/middleware/packages/ldp/services/container/actions/attach.js
+++ b/src/middleware/packages/ldp/services/container/actions/attach.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -10,13 +8,18 @@ module.exports = {
     const { containerUri, resourceUri } = ctx.params;
 
     const resourceExists = await ctx.call('ldp.resource.exist', { resourceUri });
-    if (!resourceExists) throw new Error('Cannot detach non-existing resource: ' + resourceUri);
+    if (!resourceExists) throw new Error('Cannot attach non-existing resource: ' + resourceUri);
 
     const containerExists = await this.actions.exist({ containerUri });
     if (!containerExists) throw new Error('Cannot attach to a non-existing container: ' + containerUri);
 
-    return await ctx.call('triplestore.insert', {
+    await ctx.call('triplestore.insert', {
       resource: `<${containerUri}> <http://www.w3.org/ns/ldp#contains> <${resourceUri}>`
+    });
+
+    ctx.emit('ldp.container.attached', {
+      containerUri,
+      resourceUri
     });
   }
 };

--- a/src/middleware/packages/ldp/services/container/actions/detach.js
+++ b/src/middleware/packages/ldp/services/container/actions/detach.js
@@ -17,5 +17,10 @@ module.exports = {
         { <${containerUri}> <http://www.w3.org/ns/ldp#contains> <${resourceUri}> }
       `
     });
+
+    ctx.emit('ldp.container.detached', {
+      containerUri,
+      resourceUri
+    });
   }
 };

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -28,6 +28,9 @@ module.exports = {
       queryDepth: { type: 'number', default: 0 },
       jsonContext: { type: 'multi', rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }], optional: true }
     },
+    cache: {
+      keys: ['containerUri', 'accept', 'queryDepth', 'query', 'jsonContext']
+    },
     async handler(ctx) {
       const { accept, containerUri, query, queryDepth, jsonContext } = ctx.params;
       let [constructQuery, whereQuery] = buildBlankNodesQuery(queryDepth);

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -30,6 +30,9 @@ module.exports = {
       queryDepth: { type: 'number', default: 0 },
       jsonContext: { type: 'multi', rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }], optional: true }
     },
+    cache: {
+      keys: ['resourceUri', 'accept', 'queryDepth', 'jsonContext']
+    },
     async handler(ctx) {
       const { resourceUri, accept, webId, queryDepth, jsonContext } = ctx.params;
 

--- a/src/middleware/packages/ldp/services/resource/actions/patch.js
+++ b/src/middleware/packages/ldp/services/resource/actions/patch.js
@@ -69,7 +69,7 @@ module.exports = {
           accept: MIME_TYPES.JSON,
           queryDepth: 1
         },
-        { meta: { $cache: false }}
+        { meta: { $cache: false } }
       );
 
       ctx.emit('ldp.resource.updated', {

--- a/src/middleware/packages/ldp/services/resource/actions/patch.js
+++ b/src/middleware/packages/ldp/services/resource/actions/patch.js
@@ -62,11 +62,15 @@ module.exports = {
       });
 
       // Get the new data, with the same formatting as the old data
-      const newData = await ctx.call('ldp.resource.get', {
-        resourceUri: resource['@id'],
-        accept: MIME_TYPES.JSON,
-        queryDepth: 1
-      });
+      const newData = await ctx.call(
+        'ldp.resource.get',
+        {
+          resourceUri: resource['@id'],
+          accept: MIME_TYPES.JSON,
+          queryDepth: 1
+        },
+        { meta: { $cache: false }}
+      );
 
       ctx.emit('ldp.resource.updated', {
         resourceUri: resource['@id'],

--- a/src/middleware/packages/ldp/services/resource/actions/post.js
+++ b/src/middleware/packages/ldp/services/resource/actions/post.js
@@ -80,11 +80,15 @@ module.exports = {
       });
 
       // Get the standard-formatted data to send with event
-      const newData = await ctx.call('ldp.resource.get', {
-        resourceUri: resource['@id'],
-        accept: MIME_TYPES.JSON,
-        queryDepth: 1
-      });
+      const newData = await ctx.call(
+        'ldp.resource.get',
+        {
+          resourceUri: resource['@id'],
+          accept: MIME_TYPES.JSON,
+          queryDepth: 1
+        },
+        { meta: { $cache: false }}
+      );
 
       ctx.emit('ldp.resource.created', {
         resourceUri: resource['@id'],

--- a/src/middleware/packages/ldp/services/resource/actions/post.js
+++ b/src/middleware/packages/ldp/services/resource/actions/post.js
@@ -87,7 +87,7 @@ module.exports = {
           accept: MIME_TYPES.JSON,
           queryDepth: 1
         },
-        { meta: { $cache: false }}
+        { meta: { $cache: false } }
       );
 
       ctx.emit('ldp.resource.created', {

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -69,7 +69,7 @@ module.exports = {
           accept: MIME_TYPES.JSON,
           queryDepth: 1
         },
-        { meta: { $cache: false }}
+        { meta: { $cache: false } }
       );
 
       ctx.emit('ldp.resource.updated', {

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -62,11 +62,15 @@ module.exports = {
       });
 
       // Get the new data, with the same formatting as the old data
-      const newData = await ctx.call('ldp.resource.get', {
-        resourceUri: resource['@id'],
-        accept: MIME_TYPES.JSON,
-        queryDepth: 1
-      });
+      const newData = await ctx.call(
+        'ldp.resource.get',
+        {
+          resourceUri: resource['@id'],
+          accept: MIME_TYPES.JSON,
+          queryDepth: 1
+        },
+        { meta: { $cache: false }}
+      );
 
       ctx.emit('ldp.resource.updated', {
         resourceUri: resource['@id'],


### PR DESCRIPTION
Closes #376 

- Mets en cache les resources et containers LDP
- Lorsqu'une ressource est éditée ou effacée, invalide le cache de la ressource
- Lorsqu'une ressource est ajoutée, éditée ou effacée, invalide le cache du container
- Lorsqu'un lien inverse est ajouté ou supprimé, invalide le cache des ressources affectées

Pour tester le cache, il faut [ajouter un cacher](https://moleculer.services/docs/0.14/caching.html) dans la config Moleculer.

> J'ai amélioré le service inference pour éviter qu'il ajoute et supprime le même lien. Pour cela je fais une différence entre les triples à ajouter et les triples à supprimer.