### PR TITLE
bugfix le connecteur OIDC ne supportait plus les endpoint oidc avec secret

### DIFF
--- a/src/middleware/packages/connector/OidcConnector.js
+++ b/src/middleware/packages/connector/OidcConnector.js
@@ -16,8 +16,7 @@ class OidcConnector extends Connector {
     let config = {
       client_id: this.settings.clientId,
       client_secret: this.settings.clientSecret,
-      redirect_uri: this.settings.redirectUri,
-      token_endpoint_auth_method: 'none'
+      redirect_uri: this.settings.redirectUri
     };
     if (!config.client_secret) {
       config.token_endpoint_auth_method = 'none';


### PR DESCRIPTION
token_endpoint_auth_method ne doit pas être valué dans le cas ou client_secret l'est