### PR TITLE
Dereference container option

### DIFF
--- a/src/middleware/boilerplates/pair-ldp-server/containers.js
+++ b/src/middleware/boilerplates/pair-ldp-server/containers.js
@@ -4,12 +4,12 @@ module.exports = [
   {
     path: '/organizations',
     acceptedTypes: ['pair:Organization', ACTOR_TYPES.ORGANIZATION],
-    dereference: [ 'sec:publicKey' ]
+    dereference: ['sec:publicKey']
   },
   {
     path: '/projects',
     acceptedTypes: ['pair:Project', ACTOR_TYPES.GROUP],
-    dereference: [ 'sec:publicKey' ]
+    dereference: ['sec:publicKey']
   },
   {
     path: '/events',
@@ -18,7 +18,7 @@ module.exports = [
   {
     path: '/users',
     acceptedTypes: ['pair:Person', ACTOR_TYPES.PERSON],
-    dereference: [ 'sec:publicKey' ]
+    dereference: ['sec:publicKey']
   },
   {
     path: '/themes',

--- a/src/middleware/boilerplates/pair-ldp-server/containers.js
+++ b/src/middleware/boilerplates/pair-ldp-server/containers.js
@@ -4,12 +4,12 @@ module.exports = [
   {
     path: '/organizations',
     acceptedTypes: ['pair:Organization', ACTOR_TYPES.ORGANIZATION],
-    queryDepth: 1
+    dereference: [ 'sec:publicKey' ]
   },
   {
     path: '/projects',
     acceptedTypes: ['pair:Project', ACTOR_TYPES.GROUP],
-    queryDepth: 1
+    dereference: [ 'sec:publicKey' ]
   },
   {
     path: '/events',
@@ -18,7 +18,7 @@ module.exports = [
   {
     path: '/users',
     acceptedTypes: ['pair:Person', ACTOR_TYPES.PERSON],
-    queryDepth: 1
+    dereference: [ 'sec:publicKey' ]
   },
   {
     path: '/themes',

--- a/src/middleware/boilerplates/pair-ldp-server/ontologies.json
+++ b/src/middleware/boilerplates/pair-ldp-server/ontologies.json
@@ -30,6 +30,11 @@
     "url": "http://schema.org/"
   },
   {
+    "prefix": "sec",
+    "owl": "",
+    "url": "https://w3id.org/security#"
+  },
+  {
     "prefix": "foaf",
     "owl": "",
     "url": "http://xmlns.com/foaf/0.1/"

--- a/src/middleware/packages/activitypub/containers.js
+++ b/src/middleware/packages/activitypub/containers.js
@@ -4,7 +4,7 @@ module.exports = [
   {
     path: '/actors',
     acceptedTypes: Object.values(ACTOR_TYPES),
-    dereference: [ 'sec:publicKey' ]
+    dereference: ['sec:publicKey']
   },
   {
     path: '/objects',

--- a/src/middleware/packages/activitypub/containers.js
+++ b/src/middleware/packages/activitypub/containers.js
@@ -3,7 +3,8 @@ const { ACTOR_TYPES, OBJECT_TYPES } = require('./constants');
 module.exports = [
   {
     path: '/actors',
-    acceptedTypes: Object.values(ACTOR_TYPES)
+    acceptedTypes: Object.values(ACTOR_TYPES),
+    dereference: [ 'sec:publicKey' ]
   },
   {
     path: '/objects',

--- a/src/middleware/packages/activitypub/services/actor.js
+++ b/src/middleware/packages/activitypub/services/actor.js
@@ -76,8 +76,7 @@ const ActorService = {
         resource: {
           '@id': actorUri,
           publicKey: {
-            // TODO expand the key, even if it has an ID (currently only blank nodes are expanded)
-            // id: actorUri + '#main-key',
+            '@id': actorUri + '#mainKey',
             owner: actorUri,
             publicKeyPem: publicKey
           }

--- a/src/middleware/packages/ldp/adapter.js
+++ b/src/middleware/packages/ldp/adapter.js
@@ -49,7 +49,7 @@ class TripleStoreAdapter {
   find(filters) {
     return this.broker.call(this.containerService + '.get', {
       containerUri: this.service.schema.settings.containerUri,
-      query: filters.query,
+      filters: filters.query,
       queryDepth: this.service.schema.settings.queryDepth,
       jsonContext: this.service.schema.settings.context,
       accept: MIME_TYPES.JSON

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -1,6 +1,6 @@
 const jsonld = require('jsonld');
 const { MIME_TYPES } = require('@semapps/mime-types');
-const { getPrefixRdf, getPrefixJSON, buildBlankNodesQuery } = require('../../../utils');
+const { getPrefixRdf, getPrefixJSON, buildBlankNodesQuery, buildDereferenceQuery, buildFiltersQuery } = require('../../../utils');
 
 module.exports = {
   api: async function api(ctx) {
@@ -10,7 +10,8 @@ module.exports = {
       ctx.meta.$responseType = ctx.meta.$responseType || accept;
       return await ctx.call('ldp.container.get', {
         containerUri,
-        accept
+        accept,
+        webId: ctx.meta.webId
       });
     } catch (e) {
       console.error(e);
@@ -22,37 +23,26 @@ module.exports = {
     visibility: 'public',
     params: {
       containerUri: { type: 'string', optional: true },
+      webId: { type: 'string', optional: true },
       accept: { type: 'string', optional: true },
-      query: { type: 'object', optional: true },
+      filters: { type: 'object', optional: true },
       queryDepth: { type: 'number', optional: true },
+      dereference: { type: 'array', optional: true },
       jsonContext: { type: 'multi', rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }], optional: true }
     },
     cache: {
       keys: ['containerUri', 'accept', 'queryDepth', 'query', 'jsonContext']
     },
     async handler(ctx) {
-      const { containerUri, query } = ctx.params;
-      const { accept, queryDepth, jsonContext } = {
+      const { containerUri, filters, webId } = ctx.params;
+      const { accept, dereference, queryDepth, jsonContext } = {
         ...(await ctx.call('ldp.getContainerOptions', { uri: containerUri })),
         ...ctx.params
       };
-      let [constructQuery, whereQuery] = buildBlankNodesQuery(queryDepth);
 
-      if (query) {
-        Object.keys(query).forEach((predicate, i) => {
-          if (query[predicate]) {
-            whereQuery += `
-              FILTER EXISTS { ?s1 ${predicate.startsWith('http') ? `<${predicate}>` : predicate} "${
-              query[predicate]
-            }" } .
-            `;
-          } else {
-            whereQuery += `
-              FILTER NOT EXISTS { ?s1 ${predicate.startsWith('http') ? `<${predicate}>` : predicate} ?unwanted${i} } .
-            `;
-          }
-        });
-      }
+      const blandNodeQuery = buildBlankNodesQuery(queryDepth);
+      const dereferenceQuery = buildDereferenceQuery(dereference);
+      const filtersQuery = buildFiltersQuery(filters);
 
       let result = await ctx.call('triplestore.query', {
         query: `
@@ -62,18 +52,22 @@ module.exports = {
               a ?containerType ;
               ldp:contains ?s1 .
             ?s1 ?p1 ?o1 .
-            ${constructQuery}
+            ${blandNodeQuery.construct}
+            ${dereferenceQuery.construct}
           }
           WHERE {
             <${containerUri}> a ldp:Container, ?containerType .
             OPTIONAL { 
               <${containerUri}> ldp:contains ?s1 .
               ?s1 ?p1 ?o1 .
-              ${whereQuery}
+              ${blandNodeQuery.where}
+              ${dereferenceQuery.where}
+              ${filtersQuery.where}
             }
           }
         `,
-        accept
+        accept,
+        webId
       });
 
       if (accept === MIME_TYPES.JSON) {

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -1,6 +1,12 @@
 const jsonld = require('jsonld');
 const { MIME_TYPES } = require('@semapps/mime-types');
-const { getPrefixRdf, getPrefixJSON, buildBlankNodesQuery, buildDereferenceQuery, buildFiltersQuery } = require('../../../utils');
+const {
+  getPrefixRdf,
+  getPrefixJSON,
+  buildBlankNodesQuery,
+  buildDereferenceQuery,
+  buildFiltersQuery
+} = require('../../../utils');
 
 module.exports = {
   api: async function api(ctx) {

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -1,7 +1,8 @@
 const ObjectID = require('bson').ObjectID;
 
 const buildBlankNodesQuery = depth => {
-  let construct = '', where = '';
+  let construct = '',
+    where = '';
   if (depth > 0) {
     for (let i = 1; i <= depth; i++) {
       construct += `
@@ -19,11 +20,15 @@ const buildBlankNodesQuery = depth => {
 };
 
 const buildDereferenceQuery = predicates => {
-  let construct = '', where = '';
-  if( predicates ) {
+  let construct = '',
+    where = '';
+  if (predicates) {
     predicates.forEach(predicate => {
       // Transform ontology:predicate to OntologyPredicate in order to use it as a variable name
-      const varName = predicate.split(':').map(s => s[0].toUpperCase() + s.slice(1)).join('');
+      const varName = predicate
+        .split(':')
+        .map(s => s[0].toUpperCase() + s.slice(1))
+        .join('');
 
       construct += `
         ?s1 ${predicate} ?s${varName} .
@@ -56,7 +61,7 @@ const buildFiltersQuery = filters => {
     });
   }
   return { where };
-}
+};
 
 // Generate a MongoDB-like object ID
 const generateId = () => new ObjectID().toString();

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -1,14 +1,13 @@
 const ObjectID = require('bson').ObjectID;
 
 const buildBlankNodesQuery = depth => {
-  let constructQuery = '',
-    whereQuery = '';
+  let construct = '', where = '';
   if (depth > 0) {
     for (let i = 1; i <= depth; i++) {
-      constructQuery += `
+      construct += `
         ?o${i} ?p${i + 1} ?o${i + 1} .
       `;
-      whereQuery += `
+      where += `
         OPTIONAL {
           FILTER((isBLANK(?o${i}))) .
           ?o${i} ?p${i + 1} ?o${i + 1} .
@@ -16,8 +15,48 @@ const buildBlankNodesQuery = depth => {
       `;
     }
   }
-  return [constructQuery, whereQuery];
+  return { construct, where };
 };
+
+const buildDereferenceQuery = predicates => {
+  let construct = '', where = '';
+  if( predicates ) {
+    predicates.forEach(predicate => {
+      // Transform ontology:predicate to OntologyPredicate in order to use it as a variable name
+      const varName = predicate.split(':').map(s => s[0].toUpperCase() + s.slice(1)).join('');
+
+      construct += `
+        ?s1 ${predicate} ?s${varName} .
+        ?s${varName} ?p${varName} ?o${varName} .  
+      `;
+      where += `
+        OPTIONAL { 
+          ?s1 ${predicate} ?s${varName} .
+          ?s${varName} ?p${varName} ?o${varName} . 
+        }
+      `;
+    });
+  }
+  return { construct, where };
+};
+
+const buildFiltersQuery = filters => {
+  let where = '';
+  if (filters) {
+    Object.keys(filters).forEach((predicate, i) => {
+      if (filters[predicate]) {
+        where += `
+          FILTER EXISTS { ?s1 ${predicate.startsWith('http') ? `<${predicate}>` : predicate} "${filters[predicate]}" } .
+        `;
+      } else {
+        where += `
+          FILTER NOT EXISTS { ?s1 ${predicate.startsWith('http') ? `<${predicate}>` : predicate} ?unwanted${i} } .
+        `;
+      }
+    });
+  }
+  return { where };
+}
 
 // Generate a MongoDB-like object ID
 const generateId = () => new ObjectID().toString();
@@ -38,6 +77,8 @@ const getContainerFromUri = str => str.match(new RegExp(`(.*)/.*`))[1];
 
 module.exports = {
   buildBlankNodesQuery,
+  buildDereferenceQuery,
+  buildFiltersQuery,
   generateId,
   getPrefixRdf,
   getPrefixJSON,

--- a/src/middleware/tests/ldp/container.test.js
+++ b/src/middleware/tests/ldp/container.test.js
@@ -150,7 +150,7 @@ describe('LDP container tests', () => {
     });
   });
 
-  test('Get container with query param', async () => {
+  test('Get container with filters param', async () => {
     await broker.call('ldp.resource.post', {
       containerUri: CONFIG.HOME_URL + 'resources',
       contentType: MIME_TYPES.JSON,
@@ -163,7 +163,7 @@ describe('LDP container tests', () => {
       }
     });
 
-    // Get without query param
+    // Get without filters param
     await expect(
       broker.call('ldp.container.get', {
         containerUri: CONFIG.HOME_URL + 'resources',
@@ -182,12 +182,12 @@ describe('LDP container tests', () => {
       ]
     });
 
-    // Get with query param
+    // Get with filters param
     await expect(
       broker.call('ldp.container.get', {
         containerUri: CONFIG.HOME_URL + 'resources',
         accept: MIME_TYPES.JSON,
-        query: {
+        filters: {
           'pair:label': 'My project 2'
         }
       })

--- a/src/middleware/tests/ontologies.json
+++ b/src/middleware/tests/ontologies.json
@@ -20,6 +20,11 @@
     "url": "http://schema.org/"
   },
   {
+    "prefix": "sec",
+    "owl": "",
+    "url": "https://w3id.org/security#"
+  },
+  {
     "prefix": "foaf",
     "owl": "",
     "url": "http://xmlns.com/foaf/0.1/"


### PR DESCRIPTION
Closes #316 

> Plutôt que d'utiliser `populate`, j'ai préféré `dereference`, qui est plus correct en terme de linked data.

Permet de se passer du paramètre `queryDepth` lorsqu'on sait quelle relation on veut déréférencer.
Cela augmente ainsi les performances de la requête SPARQL.
J'ai quand même laissé le paramètre `queryDepth` pour le moment, à voir si on le garde dans le futur.

## Breaking changes

Le paramètre `query` de l'action `ldp.container.get` a été renommé en `filters`, pour clarifier son usage.