### PR TITLE
Fix and improve ldp.container.get action

### DIFF
--- a/src/middleware/packages/ldp/services/container/actions/clear.js
+++ b/src/middleware/packages/ldp/services/container/actions/clear.js
@@ -11,12 +11,13 @@ module.exports = {
         PREFIX as: <https://www.w3.org/ns/activitystreams#> 
         PREFIX ldp: <http://www.w3.org/ns/ldp#>
         DELETE {
+          ?container ldp:contains ?s1 .
           ?s1 ?p1 ?o1 .
         }
         WHERE { 
           FILTER(?container IN (<${containerUri}>, <${containerUri + '/'}>)) .
           ?container ldp:contains ?s1 .
-          ?s1 ?p1 ?o1 . 
+          OPTIONAL { ?s1 ?p1 ?o1 . } 
         } 
       `
     });

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -99,7 +99,9 @@ module.exports = {
         );
 
         // If the ldp:contains is a single object, wrap it in an array for easier handling on the front side
-        const ldpContainsKey = Object.keys(result).find(key => ['http://www.w3.org/ns/ldp#contains', 'ldp:contains', 'contains'].includes(key));
+        const ldpContainsKey = Object.keys(result).find(key =>
+          ['http://www.w3.org/ns/ldp#contains', 'ldp:contains', 'contains'].includes(key)
+        );
         if (ldpContainsKey && !Array.isArray(result[ldpContainsKey])) {
           result[ldpContainsKey] = [result[ldpContainsKey]];
         }

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -88,9 +88,9 @@ module.exports = {
                   jsonContext
                 })
               );
-            } catch(e) {
+            } catch (e) {
               // Ignore a resource if it is not found
-              if(!(e instanceof MoleculerError)) throw e;
+              if (!(e instanceof MoleculerError)) throw e;
             }
           }
         }

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -91,6 +91,7 @@ module.exports = {
         return jsonld.compact(
           {
             '@id': containerUri,
+            '@type': ['ldp:Container', 'ldp:BasicContainer'],
             'ldp:contains': resources
           },
           jsonContext || getPrefixJSON(this.settings.ontologies)

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -73,20 +73,23 @@ module.exports = {
 
         // Request each resources
         let resources = [];
-        if( result && result.contains ) {
-          for( const resourceUri of result.contains ) {
-            resources.push(await ctx.call('ldp.resource.get', {
-              resourceUri,
-              webId,
-              accept,
-              queryDepth,
-              dereference,
-              jsonContext
-            }));
+        if (result && result.contains) {
+          for (const resourceUri of result.contains) {
+            resources.push(
+              await ctx.call('ldp.resource.get', {
+                resourceUri,
+                webId,
+                accept,
+                queryDepth,
+                dereference,
+                jsonContext
+              })
+            );
           }
         }
 
-        return jsonld.compact({
+        return jsonld.compact(
+          {
             '@id': containerUri,
             'ldp:contains': resources
           },

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -80,7 +80,7 @@ const getSlugFromUri = str => str.match(new RegExp(`.*/(.*)`))[1];
 
 const getContainerFromUri = str => str.match(new RegExp(`(.*)/.*`))[1];
 
-const defaultToArray = value => !value ? undefined : Array.isArray(value) ? value : [value];
+const defaultToArray = value => (!value ? undefined : Array.isArray(value) ? value : [value]);
 
 module.exports = {
   buildBlankNodesQuery,

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -80,6 +80,8 @@ const getSlugFromUri = str => str.match(new RegExp(`.*/(.*)`))[1];
 
 const getContainerFromUri = str => str.match(new RegExp(`(.*)/.*`))[1];
 
+const defaultToArray = value => !value ? undefined : Array.isArray(value) ? value : [value];
+
 module.exports = {
   buildBlankNodesQuery,
   buildDereferenceQuery,
@@ -88,5 +90,6 @@ module.exports = {
   getPrefixRdf,
   getPrefixJSON,
   getSlugFromUri,
-  getContainerFromUri
+  getContainerFromUri,
+  defaultToArray
 };

--- a/src/middleware/tests/ldp/container.test.js
+++ b/src/middleware/tests/ldp/container.test.js
@@ -237,6 +237,6 @@ describe('LDP container tests', () => {
       accept: MIME_TYPES.JSON
     });
 
-    expect(container['ldp:contains']).toBeUndefined();
+    expect(container['ldp:contains']).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #497

Comme indiqué dans le commentaire, j'ai essayé d'utiliser au maximum les possibilités du framing JSON-LD (https://w3c.github.io/json-ld-framing/) afin de fixer le bug, mais rien ne marchait. J'ai donc dissocié le traitement pour du JSON-LD et pour les autres formats. 

A noter que les performances sont un peu moins bonnes si on n'utilise pas de cache. Mais dès que les ressources sont en cache, le chargement est presque instantané.

Je mergerai et je déploierai ça demain matin, sauf si tu as des objections.