### PR TITLE
Fix WebFinger service

### DIFF
--- a/src/middleware/packages/activitypub/services/actor.js
+++ b/src/middleware/packages/activitypub/services/actor.js
@@ -111,7 +111,7 @@ const ActorService = {
           },
           { meta: { $cache: false } }
         );
-      } while( !actor.publicKey );
+      } while (!actor.publicKey);
       return actor;
     },
     async generateMissingActorsData(ctx) {

--- a/src/middleware/packages/activitypub/services/dispatch.js
+++ b/src/middleware/packages/activitypub/services/dispatch.js
@@ -36,7 +36,7 @@ const DispatchService = {
           }
         }
 
-        if( localRecipients.length > 0 ) {
+        if (localRecipients.length > 0) {
           this.broker.emit('activitypub.inbox.received', { activity, recipients: localRecipients });
         }
       }

--- a/src/middleware/packages/activitypub/services/follow.js
+++ b/src/middleware/packages/activitypub/services/follow.js
@@ -96,7 +96,7 @@ const FollowService = {
 
       switch (activityType) {
         case ACTIVITY_TYPES.FOLLOW: {
-          if( this.isLocalActor(activity.object) ) {
+          if (this.isLocalActor(activity.object)) {
             const { '@context': context, username, ...activityObject } = activity;
             await ctx.call('activitypub.outbox.post', {
               collectionUri: urlJoin(activity.object, 'outbox'),

--- a/src/middleware/packages/webfinger/package-lock.json
+++ b/src/middleware/packages/webfinger/package-lock.json
@@ -4,10 +4,256 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"url-join": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+		"@semapps/mime-types": {
+			"version": "0.1.41",
+			"resolved": "https://registry.npmjs.org/@semapps/mime-types/-/mime-types-0.1.41.tgz",
+			"integrity": "sha512-LjCEj+pgRFuHtaVjm6ojkwRZnYQT0x7eXANiB08CviOtTMsue38uilXHKUz/V554qCuKlexY3MMrl38MAcdo8A==",
+			"requires": {
+				"moleculer": "^0.14.3",
+				"negotiator": "^0.6.2"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"args": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+			"integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+			"requires": {
+				"camelcase": "5.0.0",
+				"chalk": "2.4.2",
+				"leven": "2.1.0",
+				"mri": "1.1.4"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"camelcase": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"eventemitter2": {
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
+			"integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ=="
+		},
+		"fastest-validator": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/fastest-validator/-/fastest-validator-1.9.0.tgz",
+			"integrity": "sha512-PI0Lq3HOcaTVXoRBsoRN1HoDpFB0XWVtXvi+PIU2EVMoi20oogShIdc7Pu1kuBAEHV8P83/L1lSkZsaXmYBcYg=="
+		},
+		"fn-args": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
+			"integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw=="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"ipaddr.js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+			"integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w=="
+		},
+		"kleur": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+		},
+		"lodash": {
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"moleculer": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/moleculer/-/moleculer-0.14.12.tgz",
+			"integrity": "sha512-FLoznJIwYPcBZ28b/oSddmNypAfxzwXoQL1zWvOgQvQX74PgsuLIGTeADU5LB0G2ALvQPnojTiDNv0igF6WYHQ==",
+			"requires": {
+				"args": "^5.0.1",
+				"es6-error": "^4.1.1",
+				"eventemitter2": "^6.4.3",
+				"fastest-validator": "^1.9.0",
+				"fn-args": "^5.0.0",
+				"glob": "^7.1.6",
+				"ipaddr.js": "^2.0.0",
+				"kleur": "^4.1.3",
+				"lodash": "^4.17.20",
+				"lru-cache": "^6.0.0",
+				"node-fetch": "^2.6.1",
+				"recursive-watch": "^1.1.4"
+			}
+		},
+		"mri": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+			"integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+		},
+		"negotiator": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"recursive-watch": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.4.tgz",
+			"integrity": "sha512-fWejAmdLi7B/jipBUjTLnqId+PK+573fbGNbdaNA/AiAnQAx6OYOLCGWRs0W5+PyM1rLzZSWK2f40QpHSR49PQ==",
+			"requires": {
+				"ttl": "^1.3.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"ttl": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/ttl/-/ttl-1.3.1.tgz",
+			"integrity": "sha512-+bGy9iDAqg3WSfc2ZrprToSPJhZjqy7vUv9wupQzsiv+BVPVx1T2a6G4T0290SpQj+56Toaw9BiLO5j5Bd7QzA=="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		}
 	}
 }

--- a/src/middleware/packages/webfinger/package.json
+++ b/src/middleware/packages/webfinger/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Virtual Assembly",
   "dependencies": {
-    "url-join": "^4.0.1"
+    "@semapps/mime-types": "0.1.41"
   },
   "publishConfig": {
     "access": "public"

--- a/src/middleware/packages/webfinger/service.js
+++ b/src/middleware/packages/webfinger/service.js
@@ -1,15 +1,15 @@
-const urlJoin = require('url-join');
+const { MIME_TYPES } = require('@semapps/mime-types');
 
 const WebfingerService = {
   name: 'webfinger',
   settings: {
-    usersContainer: null,
-    domainName: null // If not set, will be extracted from usersContainer
+    baseUrl: null,
+    domainName: null // If not set, will be extracted from baseUrl
   },
-  dependencies: ['activitypub.actor'],
+  dependencies: ['triplestore', 'ldp'],
   started() {
     if (!this.settings.domainName) {
-      this.settings.domainName = new URL(this.settings.usersContainer).host;
+      this.settings.domainName = new URL(this.settings.baseUrl).host;
     }
   },
   actions: {
@@ -18,35 +18,49 @@ const WebfingerService = {
 
       const usernameMatchRegex = new RegExp(`^acct:([\\w-_.]*)@${this.settings.domainName}$`);
       const matches = resource.match(usernameMatchRegex);
+
       if (matches) {
         const userName = matches[1];
-        const userUri = urlJoin(this.settings.usersContainer, userName);
+        const result = await ctx.call('triplestore.query', {
+          query: `
+            PREFIX as: <https://www.w3.org/ns/activitystreams#>
+            SELECT ?userUri
+            WHERE {
+              ?userUri a ?type .
+              ?userUri as:preferredUsername "${userName}" .
+              FILTER( ?type IN (as:Application, as:Group, as:Organization, as:Person, as:Service) ) .
+            }
+          `,
+          accept: MIME_TYPES.JSON
+        });
 
-        let actor;
-        try {
-          actor = await ctx.call('activitypub.actor.get', { id: userUri });
-        } catch (e) {
-          actor = null;
-        }
+        if( result.length > 0 ) {
+          const userUri = result[0].userUri.value;
 
-        if (actor) {
-          return {
-            subject: resource,
-            aliases: [userUri],
-            links: [
-              {
-                rel: 'self',
-                type: 'application/activity+json',
-                href: userUri
-              }
-            ]
-          };
-        } else {
-          ctx.meta.$statusCode = 404;
+          let actor;
+          try {
+            actor = await ctx.call('ldp.resource.get', { resourceUri: userUri });
+          } catch (e) {
+            actor = null;
+          }
+
+          if (actor) {
+            return {
+              subject: resource,
+              aliases: [userUri],
+              links: [
+                {
+                  rel: 'self',
+                  type: 'application/activity+json',
+                  href: userUri
+                }
+              ]
+            };
+          }
         }
-      } else {
-        ctx.meta.$statusCode = 404;
       }
+
+      ctx.meta.$statusCode = 404;
     },
     async getRemoteUri(ctx) {
       const { account } = ctx.params;

--- a/src/middleware/packages/webfinger/service.js
+++ b/src/middleware/packages/webfinger/service.js
@@ -35,7 +35,7 @@ const WebfingerService = {
           accept: MIME_TYPES.JSON
         });
 
-        if( result.length > 0 ) {
+        if (result.length > 0) {
           const userUri = result[0].userUri.value;
 
           let actor;

--- a/src/middleware/packages/webfinger/service.js
+++ b/src/middleware/packages/webfinger/service.js
@@ -9,6 +9,7 @@ const WebfingerService = {
   dependencies: ['triplestore', 'ldp'],
   started() {
     if (!this.settings.domainName) {
+      if (!this.settings.baseUrl) throw new Error('If no domainName is defined, the baseUrl must be set');
       this.settings.domainName = new URL(this.settings.baseUrl).host;
     }
   },

--- a/website/docs/packages/webfinger.md
+++ b/website/docs/packages/webfinger.md
@@ -27,8 +27,8 @@ const { WebfingerService } = require('@semapps/webfinger');
 module.exports = {
   mixins: [WebfingerService],
   settings: {
-    usersContainer: "http://localhost:3000/actors/",
-    domainName: "localhost" // Not necessary if it is the same as usersContainer
+    baseUrl: "https://mydomain.com",
+    domainName: "mydomain.com" // Not necessary if it is the same as usersContainer
   }
 }
 ```
@@ -54,7 +54,7 @@ module.exports = {
 
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
-| `usersContainer` | `String` | **required** | Container where the actors can be found
+| `baseUrl` | `String` |  | Base URL of the server. Used to find the domain name if it is not set.
 | `domainName` | `String` |  | Domain name used for the user@domain webfinger identifier. If not set, the domain name will be guessed from the users' container.
 
 


### PR DESCRIPTION
Adapt WebFinger service to recent ActivityPub services changes.

### Breaking changes

A `baseUrl` setting is now required, except if the `domainName` setting is set.
The `usersContainer` setting is now longer used.