### PR TITLE
ActivityPub collection tests + improvements

### DIFF
--- a/src/middleware/packages/activitypub/services/collection.js
+++ b/src/middleware/packages/activitypub/services/collection.js
@@ -92,37 +92,63 @@ const CollectionService = {
      * @param queryDepth Number of blank nodes we want to dereference
      * @param page Page number. If none are defined, display the collection.
      * @param itemsPerPage Number of items to show per page
+     * @param sort Object with `predicate` and `order` properties to sort ordered collections
      */
     async get(ctx) {
-      const { id, dereferenceItems = false, queryDepth, page, itemsPerPage } = ctx.params;
+      const { id, dereferenceItems = false, queryDepth, page, itemsPerPage, sort } = ctx.params;
 
-      let result = await ctx.call('triplestore.query', {
+      let collection = await ctx.call('triplestore.query', {
         query: `
           PREFIX as: <https://www.w3.org/ns/activitystreams#>
           CONSTRUCT {
             <${id}> a as:Collection, ?collectionType .
-            <${id}> as:items ?itemUri .
+            <${id}> as:summary ?summary .
           }
           WHERE {
             <${id}> a as:Collection, ?collectionType .
-            OPTIONAL { <${id}> as:items ?itemUri . }
+            OPTIONAL { <${id}> as:summary ?summary . }
           }
         `,
         accept: MIME_TYPES.JSON
       });
 
-      const allItems = defaultToArray(result.items);
+      // No persisted collection found
+      if (!collection['@id']) return null;
+
+      if( this.isOrderedCollection(collection) && !sort ) {
+        throw new Error('A sort parameter must be provided for ordered collections');
+      }
+
+      // Caution: we must do a select query, because construct queries cannot be sorted
+      let result = await ctx.call('triplestore.query', {
+        query: `
+          PREFIX as: <https://www.w3.org/ns/activitystreams#>
+          SELECT DISTINCT ?itemUri 
+          WHERE {
+            <${id}> a as:Collection .
+            OPTIONAL { 
+              <${id}> as:items ?itemUri . 
+              ${sort ? `OPTIONAL { ?itemUri ${sort.predicate} ?order . }` : ''}
+            }
+          }
+          ${sort ? `ORDER BY ${sort.order}( ?order )` : ''}
+        `,
+        accept: MIME_TYPES.JSON
+      });
+
+      const allItems = result.filter(node => node.itemUri).map(node => node.itemUri.value);
       const numPages = !itemsPerPage ? 1 : allItems ? Math.ceil(allItems.length / itemsPerPage) : 0;
 
-      if (!result['@id'] || (page && page > numPages)) {
-        // No persisted collection found or the collection page does not exist
+      if (page && page > numPages) {
+        // The collection page does not exist
         return null;
       } else if (itemsPerPage && !page) {
         // Pagination is enabled but no page is selected, return the collection
         return {
           '@context': this.settings.context,
-          '@id': id,
-          '@type': this.isOrderedCollection(result) ? 'OrderedCollection' : 'Collection',
+          id,
+          type: this.isOrderedCollection(collection) ? 'OrderedCollection' : 'Collection',
+          summary: collection.summary,
           first: numPages > 0 ? id + '?page=1' : undefined,
           last: numPages > 0 ? id + '?page=' + numPages : undefined,
           totalItems: allItems ? allItems.length : 0
@@ -130,7 +156,7 @@ const CollectionService = {
       } else {
         let selectedItemsUris = allItems,
           selectedItems = [];
-        const itemsProp = this.isOrderedCollection(result) ? 'orderedItems' : 'items';
+        const itemsProp = this.isOrderedCollection(collection) ? 'orderedItems' : 'items';
 
         // If pagination is enabled, return a slice of the items
         if (itemsPerPage) {
@@ -159,7 +185,7 @@ const CollectionService = {
           return {
             '@context': this.settings.context,
             id: id + '?page=' + page,
-            type: this.isOrderedCollection(result) ? 'OrderedCollectionPage' : 'CollectionPage',
+            type: this.isOrderedCollection(collection) ? 'OrderedCollectionPage' : 'CollectionPage',
             partOf: id,
             prev: page > 1 ? id + '?page=' + (parseInt(page) - 1) : undefined,
             next: page < numPages ? id + '?page=' + (parseInt(page) + 1) : undefined,
@@ -171,7 +197,8 @@ const CollectionService = {
           return {
             '@context': this.settings.context,
             id: id,
-            type: this.isOrderedCollection(result) ? 'OrderedCollection' : 'Collection',
+            type: this.isOrderedCollection(collection) ? 'OrderedCollection' : 'Collection',
+            summary: collection.summary,
             [itemsProp]: selectedItems,
             totalItems: allItems ? allItems.length : 0
           };

--- a/src/middleware/packages/activitypub/services/collection.js
+++ b/src/middleware/packages/activitypub/services/collection.js
@@ -115,7 +115,7 @@ const CollectionService = {
       // No persisted collection found
       if (!collection['@id']) return null;
 
-      if( this.isOrderedCollection(collection) && !sort ) {
+      if (this.isOrderedCollection(collection) && !sort) {
         throw new Error('A sort parameter must be provided for ordered collections');
       }
 

--- a/src/middleware/packages/activitypub/services/inbox.js
+++ b/src/middleware/packages/activitypub/services/inbox.js
@@ -28,7 +28,7 @@ const InboxService = {
         return;
       }
 
-      if( !ctx.meta.skipSignatureValidation ) {
+      if (!ctx.meta.skipSignatureValidation) {
         const validDigest = await ctx.call('signature.verifyDigest', {
           body: JSON.stringify(activity),
           headers: ctx.meta.headers

--- a/src/middleware/packages/activitypub/services/inbox.js
+++ b/src/middleware/packages/activitypub/services/inbox.js
@@ -81,7 +81,8 @@ const InboxService = {
         page,
         itemsPerPage: this.settings.itemsPerPage,
         dereferenceItems: true,
-        queryDepth: 3
+        queryDepth: 3,
+        sort: { predicate: 'as:published', order: 'DESC' }
       });
 
       if (collection) {

--- a/src/middleware/packages/activitypub/services/outbox.js
+++ b/src/middleware/packages/activitypub/services/outbox.js
@@ -63,7 +63,8 @@ const OutboxService = {
         page,
         itemsPerPage: this.settings.itemsPerPage,
         dereferenceItems: true,
-        queryDepth: 3
+        queryDepth: 3,
+        sort: { predicate: 'as:published', order: 'DESC' }
       });
 
       if (collection) {

--- a/src/middleware/tests/activitypub/collection.test.js
+++ b/src/middleware/tests/activitypub/collection.test.js
@@ -22,17 +22,19 @@ describe('Handle collections', () => {
 
   test('Create ressources', async () => {
     for (let i = 0; i < 10; i++) {
-      items.push(await broker.call('ldp.resource.post', {
-        containerUri: CONFIG.HOME_URL + 'objects',
-        resource: {
-          '@context': 'https://www.w3.org/ns/activitystreams',
-          '@type': 'Note',
-          name: `Note #${i}`,
-          content: `Contenu de ma note #${i}`,
-          published: `2021-01-0${i}T00:00:00.000Z`,
-        },
-        contentType: MIME_TYPES.JSON,
-      }));
+      items.push(
+        await broker.call('ldp.resource.post', {
+          containerUri: CONFIG.HOME_URL + 'objects',
+          resource: {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            '@type': 'Note',
+            name: `Note #${i}`,
+            content: `Contenu de ma note #${i}`,
+            published: `2021-01-0${i}T00:00:00.000Z`
+          },
+          contentType: MIME_TYPES.JSON
+        })
+      );
     }
     expect(items).toHaveLength(10);
   });
@@ -117,12 +119,14 @@ describe('Handle collections', () => {
       id: collectionUri,
       type: 'Collection',
       summary: 'My non-ordered collection',
-      items: [{
-        id: items[0],
-        type: 'Note',
-        content: 'Contenu de ma note #0',
-        name: 'Note #0'
-      }],
+      items: [
+        {
+          id: items[0],
+          type: 'Note',
+          content: 'Contenu de ma note #0',
+          name: 'Note #0'
+        }
+      ],
       totalItems: 1
     });
   });

--- a/src/middleware/tests/activitypub/collection.test.js
+++ b/src/middleware/tests/activitypub/collection.test.js
@@ -1,0 +1,229 @@
+const { ServiceBroker } = require('moleculer');
+const { ACTIVITY_TYPES, OBJECT_TYPES } = require('@semapps/activitypub');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const EventsWatcher = require('../middleware/EventsWatcher');
+const initialize = require('./initialize');
+const CONFIG = require('../config');
+
+jest.setTimeout(50000);
+
+const broker = new ServiceBroker({
+  middlewares: [EventsWatcher]
+});
+beforeAll(initialize(broker));
+afterAll(async () => {
+  await broker.stop();
+});
+
+describe('Handle collections', () => {
+  let items = [];
+  const collectionUri = CONFIG.HOME_URL + 'my-collection';
+  const orderedCollectionUri = CONFIG.HOME_URL + 'my-ordered-collection';
+
+  test('Create ressources', async () => {
+    for (let i = 0; i < 10; i++) {
+      items.push(await broker.call('ldp.resource.post', {
+        containerUri: CONFIG.HOME_URL + 'objects',
+        resource: {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          '@type': 'Note',
+          name: `Note #${i}`,
+          content: `Contenu de ma note #${i}`,
+          published: `2021-01-0${i}T00:00:00.000Z`,
+        },
+        contentType: MIME_TYPES.JSON,
+      }));
+    }
+    expect(items).toHaveLength(10);
+  });
+
+  test('Create collection', async () => {
+    await broker.call('activitypub.collection.create', {
+      collectionUri,
+      ordered: false,
+      summary: 'My non-ordered collection'
+    });
+
+    const collectionExist = await broker.call('activitypub.collection.exist', {
+      collectionUri
+    });
+
+    expect(collectionExist).toBeTruthy();
+
+    const collection = await broker.call('activitypub.collection.get', {
+      id: collectionUri
+    });
+
+    expect(collection).toMatchObject({
+      id: collectionUri,
+      type: 'Collection',
+      summary: 'My non-ordered collection',
+      items: [],
+      totalItems: 0
+    });
+  });
+
+  test('Create ordered collection', async () => {
+    await broker.call('activitypub.collection.create', {
+      collectionUri: orderedCollectionUri,
+      ordered: true,
+      summary: 'My ordered collection'
+    });
+
+    const collectionExist = await broker.call('activitypub.collection.exist', {
+      collectionUri: orderedCollectionUri
+    });
+
+    expect(collectionExist).toBeTruthy();
+
+    const collection = await broker.call('activitypub.collection.get', {
+      id: orderedCollectionUri,
+      sort: { predicate: 'as:published', order: 'DESC' }
+    });
+
+    expect(collection).toMatchObject({
+      id: orderedCollectionUri,
+      type: 'OrderedCollection',
+      summary: 'My ordered collection',
+      orderedItems: [],
+      totalItems: 0
+    });
+  });
+
+  test('Attach item to collection', async () => {
+    await broker.call('activitypub.collection.attach', {
+      collectionUri,
+      item: items[0]
+    });
+
+    let collection = await broker.call('activitypub.collection.get', {
+      id: collectionUri
+    });
+
+    expect(collection).toMatchObject({
+      id: collectionUri,
+      type: 'Collection',
+      summary: 'My non-ordered collection',
+      items: [items[0]],
+      totalItems: 1
+    });
+
+    collection = await broker.call('activitypub.collection.get', {
+      id: collectionUri,
+      dereferenceItems: true
+    });
+
+    expect(collection).toMatchObject({
+      id: collectionUri,
+      type: 'Collection',
+      summary: 'My non-ordered collection',
+      items: [{
+        id: items[0],
+        type: 'Note',
+        content: 'Contenu de ma note #0',
+        name: 'Note #0'
+      }],
+      totalItems: 1
+    });
+  });
+
+  test('Detach item from collection', async () => {
+    await broker.call('activitypub.collection.detach', {
+      collectionUri,
+      item: items[0]
+    });
+
+    const collection = await broker.call('activitypub.collection.get', {
+      id: collectionUri
+    });
+
+    expect(collection).toMatchObject({
+      id: collectionUri,
+      type: 'Collection',
+      summary: 'My non-ordered collection',
+      items: [],
+      totalItems: 0
+    });
+  });
+
+  test('Handle order', async () => {
+    await broker.call('activitypub.collection.attach', {
+      collectionUri: orderedCollectionUri,
+      item: items[4]
+    });
+
+    await broker.call('activitypub.collection.attach', {
+      collectionUri: orderedCollectionUri,
+      item: items[0]
+    });
+
+    await broker.call('activitypub.collection.attach', {
+      collectionUri: orderedCollectionUri,
+      item: items[2]
+    });
+
+    await broker.call('activitypub.collection.attach', {
+      collectionUri: orderedCollectionUri,
+      item: items[6]
+    });
+
+    let collection = await broker.call('activitypub.collection.get', {
+      id: orderedCollectionUri,
+      sort: { predicate: 'as:published', order: 'DESC' }
+    });
+
+    expect(collection).toMatchObject({
+      id: orderedCollectionUri,
+      orderedItems: [items[6], items[4], items[2], items[0]],
+      totalItems: 4
+    });
+
+    collection = await broker.call('activitypub.collection.get', {
+      id: orderedCollectionUri,
+      sort: { predicate: 'as:published', order: 'ASC' }
+    });
+
+    expect(collection).toMatchObject({
+      id: orderedCollectionUri,
+      orderedItems: [items[0], items[2], items[4], items[6]],
+      totalItems: 4
+    });
+  });
+
+  test('Handle pagination', async () => {
+    for (let i = 0; i < 10; i++) {
+      await broker.call('activitypub.collection.attach', {
+        collectionUri,
+        item: items[i]
+      });
+    }
+
+    let collection = await broker.call('activitypub.collection.get', {
+      id: collectionUri,
+      itemsPerPage: 4
+    });
+
+    expect(collection).toMatchObject({
+      id: collectionUri,
+      first: collectionUri + '?page=1',
+      last: collectionUri + '?page=3',
+      totalItems: 10
+    });
+
+    collection = await broker.call('activitypub.collection.get', {
+      id: collectionUri,
+      itemsPerPage: 4,
+      page: 1
+    });
+
+    expect(collection).toMatchObject({
+      id: collectionUri + '?page=1',
+      type: 'CollectionPage',
+      partOf: collectionUri,
+      prev: undefined,
+      next: collectionUri + '?page=2',
+      totalItems: 10
+    });
+    expect(collection.items).toHaveLength(4);
+  });
+});

--- a/src/middleware/tests/activitypub/follow.test.js
+++ b/src/middleware/tests/activitypub/follow.test.js
@@ -157,6 +157,6 @@ describe('Posting to followers', () => {
       collectionUri: simon.followers
     });
 
-    expect(result.items).toBeUndefined();
+    expect(result.items).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #556 

- Add tests for the `activitypub.collection` service.
- Sort OrderedCollections (a new `sort` parameter must be provided)
- Fix display of the collection summary