### PR TITLE
allows to display an helper text and an error

### DIFF
--- a/src/frontend/packages/geo-components/src/LocationInput.js
+++ b/src/frontend/packages/geo-components/src/LocationInput.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { FieldTitle, useInput, useTranslate, useLocale } from 'react-admin';
+import { FieldTitle, InputHelperText, useInput, useTranslate, useLocale } from 'react-admin';
 import { TextField, Typography, Grid, makeStyles } from '@material-ui/core';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
@@ -24,7 +24,7 @@ const selectOptionText = (option, optionText) => {
   }
 };
 
-const LocationInput = ({ mapboxConfig, record, resource, source, label, basePath, parse, optionText, ...rest }) => {
+const LocationInput = ({ mapboxConfig, record, resource, source, label, basePath, parse, optionText, helperText, ...rest }) => {
   const classes = useStyles();
   const locale = useLocale();
   const translate = useTranslate();
@@ -35,7 +35,8 @@ const LocationInput = ({ mapboxConfig, record, resource, source, label, basePath
   // Do not pass the `parse` prop to useInput, as we manually call it on the onChange prop below
   const {
     input: { value, onChange },
-    isRequired
+    isRequired,
+    meta: { error, submitError, touched },
   } = useInput({ resource, source });
 
   const fetchMapbox = useMemo(
@@ -108,6 +109,14 @@ const LocationInput = ({ mapboxConfig, record, resource, source, label, basePath
               label !== false && (
                 <FieldTitle label={label} source={source} resource={resource} isRequired={isRequired} />
               )
+            }
+            error={!!(touched && (error || submitError))}
+            helperText={
+                <InputHelperText
+                    touched={touched}
+                    error={error || submitError}
+                    helperText={helperText}
+                />
             }
             {...rest}
           />

--- a/src/frontend/packages/geo-components/src/LocationInput.js
+++ b/src/frontend/packages/geo-components/src/LocationInput.js
@@ -34,7 +34,7 @@ const LocationInput = ({ mapboxConfig, record, resource, source, label, basePath
 
   // Do not pass the `parse` prop to useInput, as we manually call it on the onChange prop below
   const {
-    input: { value, onChange },
+    input: { value, onChange, onBlur, onFocus },
     isRequired,
     meta: { error, submitError, touched },
   } = useInput({ resource, source });
@@ -104,6 +104,22 @@ const LocationInput = ({ mapboxConfig, record, resource, source, label, basePath
         return (
           <TextField
             {...params}
+            inputProps={{
+              ...params.inputProps,
+              onBlur: (e) => {
+                onBlur(e);
+                if (params.inputProps.onBlur) {
+                  params.inputProps.onBlur(e)
+                }
+              },
+              onFocus: (e) => {
+                onFocus(e);
+                if (params.inputProps.onFocus) {
+                  params.inputProps.onFocus(e)
+                }
+              },
+            }
+            }
             label={
               label !== '' &&
               label !== false && (


### PR DESCRIPTION
This allows displaying helper text and error under `LocationInput`

copy from : https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/input/TextInput.tsx#L68