### PR TITLE
Option to customize new resources permissions

### DIFF
--- a/src/middleware/packages/ldp/services/container/actions/getOptions.js
+++ b/src/middleware/packages/ldp/services/container/actions/getOptions.js
@@ -5,7 +5,6 @@ module.exports = {
   params: {
     uri: { type: 'string' }
   },
-  cache: true,
   async handler(ctx) {
     const { uri } = ctx.params;
 

--- a/src/middleware/packages/ldp/services/container/defaultOptions.js
+++ b/src/middleware/packages/ldp/services/container/defaultOptions.js
@@ -2,5 +2,41 @@ module.exports = {
   accept: 'text/turtle',
   jsonContext: null,
   queryDepth: 0,
-  dereference: []
+  dereference: [],
+  newResourcesPermissions: webId => {
+    switch (webId) {
+      case 'anon':
+        return {
+          anon : {
+            read: true,
+            write: true
+          }
+        };
+      case 'system':
+        return {
+          anon : {
+            read: true
+          },
+          anyUser: {
+            read: true,
+            write: true
+          }
+        };
+      default:
+        return {
+          anon : {
+            read: true
+          },
+          anyUser: {
+            read: true
+          },
+          user: {
+            uri: webId,
+            read: true,
+            write: true,
+            control: true
+          }
+        };
+    }
+  }
 };

--- a/src/middleware/packages/ldp/services/container/defaultOptions.js
+++ b/src/middleware/packages/ldp/services/container/defaultOptions.js
@@ -7,14 +7,14 @@ module.exports = {
     switch (webId) {
       case 'anon':
         return {
-          anon : {
+          anon: {
             read: true,
             write: true
           }
         };
       case 'system':
         return {
-          anon : {
+          anon: {
             read: true
           },
           anyUser: {
@@ -24,7 +24,7 @@ module.exports = {
         };
       default:
         return {
-          anon : {
+          anon: {
             read: true
           },
           anyUser: {

--- a/src/middleware/packages/webacl/middlewares/webacl.js
+++ b/src/middleware/packages/webacl/middlewares/webacl.js
@@ -26,11 +26,10 @@ const addRightsToNewCollection = async (ctx, collectionUri, webId) => {
 };
 
 const addRightsToNewResource = async (ctx, containerUri, resourceUri, webId) => {
-  const { newResourcesPermissions } = await ctx.call('ldp.container.getOptions', { uri: containerUri })
+  const { newResourcesPermissions } = await ctx.call('ldp.container.getOptions', { uri: containerUri });
 
-  const newRights = typeof newResourcesPermissions === 'function'
-    ? newResourcesPermissions(webId)
-    : newResourcesPermissions;
+  const newRights =
+    typeof newResourcesPermissions === 'function' ? newResourcesPermissions(webId) : newResourcesPermissions;
 
   await ctx.call('webacl.resource.addRights', {
     webId: 'system',

--- a/src/middleware/packages/webacl/services/resource/index.js
+++ b/src/middleware/packages/webacl/services/resource/index.js
@@ -17,10 +17,7 @@ const {
   ACL_NS
 } = require('../../utils');
 
-const filterAclsOnlyAgent = acl => {
-  if (agentPredicates.includes(acl.p.value)) return true;
-  return false;
-};
+const filterAclsOnlyAgent = acl => agentPredicates.includes(acl.p.value);
 
 module.exports = {
   name: 'webacl.resource',

--- a/website/docs/middleware/ldp/index.md
+++ b/website/docs/middleware/ldp/index.md
@@ -74,7 +74,7 @@ module.exports = {
 | `jsonContext` | `[Any]` |  | JSON context to use to format results |
 | `dereference`| `[Array]` | `[]` | Properties to dereference, prefixed with their ontology. You can define sub-predicates separated by `/` |
 | `queryDepth` | `Integer` | 0 | Depth of blank nodes to dereference (Deprecated. Will be removed in a future minor release.) |
-| `newResourcesPermissions` | `Object` or `Function` |  | If the WebACL service is activated, permissions to add to new resources. [See the docs here](../webacl/index.md) |
+| `newResourcesPermissions` | `Object` or `Function` |  | If the WebACL service is activated, permissions to add to new resources. [See the docs here](../webacl/index.md#default-permissions-for-new-resources) |
 
 ## API routes
 

--- a/website/docs/middleware/ldp/index.md
+++ b/website/docs/middleware/ldp/index.md
@@ -73,7 +73,8 @@ module.exports = {
 | `accept` | `String` | `text/turtle` | Type to return (`application/ld+json`, `text/turtle` or `application/n-triples`) |
 | `jsonContext` | `[Any]` |  | JSON context to use to format results |
 | `dereference`| `[Array]` | `[]` | Properties to dereference, prefixed with their ontology. You can define sub-predicates separated by `/` |
-| `queryDepth` | `Integer` | 0 | Depth of blank nodes to dereference |
+| `queryDepth` | `Integer` | 0 | Depth of blank nodes to dereference (Deprecated. Will be removed in a future minor release.) |
+| `newResourcesPermissions` | `Object` or `Function` |  | If the WebACL service is activated, permissions to add to new resources. [See the docs here](../webacl/index.md) |
 
 ## API routes
 

--- a/website/docs/middleware/webacl/index.md
+++ b/website/docs/middleware/webacl/index.md
@@ -100,7 +100,7 @@ By default, new resources are created with these rights:
 If you wish to change these options, you can set the `newResourcesPermissions` parameter in [LdpService's `defaultContainerOptions`](../ldp/index.md#settings), or to a particular container.
 
 This `newResourcesPermissions` parameter can be:
-- An object in the form expected by the `additionalRights` parameters of the [`webacl.resource.addRights` action](resource.md) (with keys "anon", "anyUser", "user", "group")
+- An object in the form expected by the `additionalRights` parameters of the [`webacl.resource.addRights`](resource.md#webaclresourceaddrights) action (with keys "anon", "anyUser", "user", "group")
 - A function which receives the WebID of the creator (or "anon" if the user is not authenticated, or "system") and returns an object in the same shape
 
 

--- a/website/docs/middleware/webacl/index.md
+++ b/website/docs/middleware/webacl/index.md
@@ -84,6 +84,26 @@ See the [Moleculer caching documentation](https://moleculer.services/docs/0.14/c
 | `baseUrl`|`String` | **required**| Base URL of the LDP server |
 
 
+## Default permissions for new resources
+
+By default, new resources are created with these rights:
+
+- If the resource is created by an anonymous user:
+  - `acl:Read` and `acl:Write` permissions are granted to all users
+- If the resource is created by an authenticated user:
+  - `acl:Read` permission is granted to anonymous users
+  - `acl:Write` and `acl:Control` permissions are granted to the creator
+- If the resource is created by the system (direct calls from other services):
+  - `acl:Read` permission is granted to anonymous users
+  - `acl:Write` permission is granted to authenticated users
+
+If you wish to change these options, you can set the `newResourcesPermissions` parameter in [LdpService's `defaultContainerOptions`](../ldp/index.md), or to a particular container.
+
+This `newResourcesPermissions` parameter can be:
+- An object in the form expected by the `additionalRights` parameters of the [`webacl.resource.addRights` action](resource.md) (with keys "anon", "anyUser", "user", "group")
+- A function which receives the WebID of the creator (or "anon" if the user is not authenticated, or "system") and returns an object in the same shape
+
+
 ## General notes
 
 - The SemApps middleware will always connect to the SPARQL endpoint with a Basic Authorization header containing the `admin` user and its password.

--- a/website/docs/middleware/webacl/index.md
+++ b/website/docs/middleware/webacl/index.md
@@ -97,7 +97,7 @@ By default, new resources are created with these rights:
   - `acl:Read` permission is granted to anonymous users
   - `acl:Write` permission is granted to authenticated users
 
-If you wish to change these options, you can set the `newResourcesPermissions` parameter in [LdpService's `defaultContainerOptions`](../ldp/index.md), or to a particular container.
+If you wish to change these options, you can set the `newResourcesPermissions` parameter in [LdpService's `defaultContainerOptions`](../ldp/index.md#settings), or to a particular container.
 
 This `newResourcesPermissions` parameter can be:
 - An object in the form expected by the `additionalRights` parameters of the [`webacl.resource.addRights` action](resource.md) (with keys "anon", "anyUser", "user", "group")


### PR DESCRIPTION
Voir la [documentation](https://website-git-customize-new-resources-permissions-semapps.vercel.app/docs/middleware/webacl/index#default-permissions-for-new-resources)

Enlève aussi le cache sur `ldp.container.getOptions` afin de pouvoir utiliser des fonctions (il ne devrait y avoir pratiquement aucun impact sur les performances, getOptions se contentant de lire des configurations passées en dur au service LDP).