### PR TITLE
Authorizer bot

### DIFF
--- a/src/middleware/packages/ldp/mixins/document-tagger.js
+++ b/src/middleware/packages/ldp/mixins/document-tagger.js
@@ -12,9 +12,18 @@ module.exports = {
       const now = new Date();
 
       let triples = [];
-      triples.push(`<${resourceUri}> <${this.settings.documentPredicates.created}> "${now.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .`);
-      triples.push(`<${resourceUri}> <${this.settings.documentPredicates.updated}> "${now.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .`);
-      if( webId && webId.startsWith('http') ) triples.push(`<${resourceUri}> <${this.settings.documentPredicates.creator}> <${webId}> .`);
+      triples.push(
+        `<${resourceUri}> <${
+          this.settings.documentPredicates.created
+        }> "${now.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .`
+      );
+      triples.push(
+        `<${resourceUri}> <${
+          this.settings.documentPredicates.updated
+        }> "${now.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .`
+      );
+      if (webId && webId.startsWith('http'))
+        triples.push(`<${resourceUri}> <${this.settings.documentPredicates.creator}> <${webId}> .`);
 
       await ctx.call('triplestore.insert', {
         resource: triples.join('\n'),
@@ -27,27 +36,23 @@ module.exports = {
       await ctx.call('triplestore.update', {
         query: `
           DELETE { <${resourceUri}> <${this.settings.documentPredicates.updated}> ?updated }
-          INSERT { <${resourceUri}> <${this.settings.documentPredicates.updated}> "${now.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> }
+          INSERT { <${resourceUri}> <${
+          this.settings.documentPredicates.updated
+        }> "${now.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> }
           WHERE { <${resourceUri}> <${this.settings.documentPredicates.updated}> ?updated }
         `,
         webId: 'system'
-      })
+      });
     }
   },
   events: {
     async 'ldp.resource.created'(ctx) {
       const { resourceUri, webId } = ctx.params;
-      this.actions.tagCreatedResource(
-        { resourceUri, webId },
-        { parentCtx: ctx }
-      );
+      this.actions.tagCreatedResource({ resourceUri, webId }, { parentCtx: ctx });
     },
     async 'ldp.resource.updated'(ctx) {
       const { resourceUri } = ctx.params;
-      this.actions.tagUpdatedResource(
-        { resourceUri },
-        { parentCtx: ctx }
-      );
+      this.actions.tagUpdatedResource({ resourceUri }, { parentCtx: ctx });
     }
   }
 };

--- a/src/middleware/packages/webacl/bots/authorizer.js
+++ b/src/middleware/packages/webacl/bots/authorizer.js
@@ -1,0 +1,91 @@
+module.exports = {
+  name: 'authorizer',
+  settings: {
+    rules: []
+  },
+  dependencies: ['webacl.resource'],
+  methods: {
+    matchRule(rule, record) {
+      if (typeof rule.match === 'function') {
+        // If match is a function, pass it the record
+        return rule.match(record);
+      } else {
+        // If match is an object, go through all entries and check they match with the record
+        return Object.keys(rule.match).every(predicate => {
+          const value = rule.match[predicate];
+          return Array.isArray(record[predicate]) ? record[predicate].includes(value) : record[predicate] === value;
+        });
+      }
+    },
+    getUsers(rule, record) {
+      let users;
+      if (typeof rule.users === 'function') {
+        // If users is a function, pass it the record
+        users = rule.users(record);
+      } else {
+        users = rule.users;
+      }
+      if( !users ) return [];
+      return Array.isArray(users) ? users : [users];
+    }
+  },
+  events: {
+    async 'ldp.resource.created'(ctx) {
+      const { resourceUri, newData } = ctx.params;
+      for (let rule of this.settings.rules) {
+        if (this.matchRule(rule, newData)) {
+          const users = this.getUsers(rule, newData);
+          for( let user of users ) {
+            await ctx.call('webacl.resource.addRights', {
+              resourceUri,
+              additionalRights: {
+                user: {
+                  uri: user,
+                  ...rule.rights
+                }
+              },
+              webId: 'system'
+            });
+          }
+        }
+      }
+    },
+    async 'ldp.resource.updated'(ctx) {
+      const { resourceUri, newData, oldData } = ctx.params;
+
+      for (let rule of this.settings.rules) {
+        if (this.matchRule(rule, newData)) {
+          const newUsers = this.getUsers(rule, newData);
+          const oldUsers = this.getUsers(rule, oldData);
+
+          const usersToAdd = newUsers.filter(t1 => !oldUsers.some(t2 => t1 === t2));
+          for( let userUri of usersToAdd ) {
+            await ctx.call('webacl.resource.addRights', {
+              resourceUri,
+              additionalRights: {
+                user: {
+                  uri: userUri,
+                  ...rule.rights
+                }
+              },
+              webId: 'system'
+            });
+          }
+
+          const usersToRemove = oldUsers.filter(t1 => !newUsers.some(t2 => t1 === t2));
+          for( let userUri of usersToRemove ) {
+            await ctx.call('webacl.resource.removeRights', {
+              resourceUri,
+              rights: {
+                user: {
+                  uri: userUri,
+                  ...rule.rights
+                }
+              }
+            });
+          }
+        }
+      }
+    }
+  }
+};

--- a/src/middleware/packages/webacl/bots/authorizer.js
+++ b/src/middleware/packages/webacl/bots/authorizer.js
@@ -25,7 +25,7 @@ module.exports = {
       } else {
         users = rule.users;
       }
-      if( !users ) return [];
+      if (!users) return [];
       return Array.isArray(users) ? users : [users];
     }
   },
@@ -35,7 +35,7 @@ module.exports = {
       for (let rule of this.settings.rules) {
         if (this.matchRule(rule, newData)) {
           const users = this.getUsers(rule, newData);
-          for( let user of users ) {
+          for (let user of users) {
             await ctx.call('webacl.resource.addRights', {
               resourceUri,
               additionalRights: {
@@ -59,7 +59,7 @@ module.exports = {
           const oldUsers = this.getUsers(rule, oldData);
 
           const usersToAdd = newUsers.filter(t1 => !oldUsers.some(t2 => t1 === t2));
-          for( let userUri of usersToAdd ) {
+          for (let userUri of usersToAdd) {
             await ctx.call('webacl.resource.addRights', {
               resourceUri,
               additionalRights: {
@@ -73,7 +73,7 @@ module.exports = {
           }
 
           const usersToRemove = oldUsers.filter(t1 => !newUsers.some(t2 => t1 === t2));
-          for( let userUri of usersToRemove ) {
+          for (let userUri of usersToRemove) {
             await ctx.call('webacl.resource.removeRights', {
               resourceUri,
               rights: {

--- a/src/middleware/packages/webacl/index.js
+++ b/src/middleware/packages/webacl/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   GroupsManagerBot: require('./bots/groups-manager'),
+  AuthorizerBot: require('./bots/authorizer'),
   WebAclService: require('./service'),
   WebAclMiddleware: require('./middlewares/webacl'),
   CacherMiddleware: require('./middlewares/cacher')

--- a/src/middleware/packages/webacl/services/resource/actions/addRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/addRights.js
@@ -4,43 +4,9 @@ const {
   getAclUriFromResourceUri,
   convertBodyToTriples,
   filterTriplesForResource,
-  FULL_AGENT_URI,
-  FULL_AGENTCLASS_URI,
-  FULL_AGENT_GROUP,
-  FULL_ACL_ANYAGENT,
-  FULL_FOAF_AGENT
+  processRights
 } = require('../../../utils');
 const urlJoin = require('url-join');
-
-const processNewRights = (newRights, aclUri) => {
-  list = [];
-  if (newRights.anon) {
-    if (newRights.anon.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
-    if (newRights.anon.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
-    if (newRights.anon.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
-    if (newRights.anon.control) list.push({ auth: aclUri + 'Control', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
-  }
-  if (newRights.user && newRights.user.uri) {
-    if (newRights.user.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENT_URI, o: newRights.user.uri });
-    if (newRights.user.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENT_URI, o: newRights.user.uri });
-    if (newRights.user.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENT_URI, o: newRights.user.uri });
-    if (newRights.user.control) list.push({ auth: aclUri + 'Control', p: FULL_AGENT_URI, o: newRights.user.uri });
-  }
-  if (newRights.anyUser) {
-    if (newRights.anyUser.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
-    if (newRights.anyUser.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
-    if (newRights.anyUser.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
-    if (newRights.anyUser.control)
-      list.push({ auth: aclUri + 'Control', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
-  }
-  if (newRights.group && newRights.group.uri) {
-    if (newRights.group.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENT_GROUP, o: newRights.group.uri });
-    if (newRights.group.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENT_GROUP, o: newRights.group.uri });
-    if (newRights.group.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENT_GROUP, o: newRights.group.uri });
-    if (newRights.group.control) list.push({ auth: aclUri + 'Control', p: FULL_AGENT_GROUP, o: newRights.group.uri });
-  }
-  return list;
-};
 
 module.exports = {
   api: async function api(ctx) {
@@ -110,9 +76,9 @@ module.exports = {
 
         if (!addedRights) {
           // we process additionalRights only if addedRights was not set.
-          addedRights = processNewRights(additionalRights, aclUri + '#');
+          addedRights = processRights(additionalRights, aclUri + '#');
           if (isContainer && additionalRights.default)
-            addedRights = addedRights.concat(processNewRights(additionalRights.default, aclUri + '#Default'));
+            addedRights = addedRights.concat(processRights(additionalRights.default, aclUri + '#Default'));
           if (addedRights.length === 0) new MoleculerError('No additional permissions to add!', 400, 'BAD_REQUEST');
         } else {
           // filter out all the addedRights that are not for the resource
@@ -146,12 +112,12 @@ module.exports = {
 
         // we set new rights for a non existing resource
         let aclUri = getAclUriFromResourceUri(this.settings.baseUrl, resourceUri) + '#';
-        difference = processNewRights(newRights, aclUri);
+        difference = processRights(newRights, aclUri);
         // we do add default container permissions if any is set in newRights. but we cannot know for sure
         // that the resource that will be created will be a container. we don't want to add default permissions on a resource !
         // please be careful, as programmers, not to call newRights with 'default' perms for a resource.
         // it should only be used for containers
-        if (newRights.default) difference = difference.concat(processNewRights(newRights.default, aclUri + 'Default'));
+        if (newRights.default) difference = difference.concat(processRights(newRights.default, aclUri + 'Default'));
         currentAuths = {};
 
         if (difference.length === 0)

--- a/src/middleware/packages/webacl/services/resource/actions/removeRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/removeRights.js
@@ -1,0 +1,32 @@
+const { getAclUriFromResourceUri, processRights } = require("../../../utils");
+
+module.exports = {
+  action: {
+    visibility: 'public',
+    params: {
+      resourceUri: { type: 'string', optional: false },
+      rights: { type: 'object', optional: false }
+    },
+    async handler(ctx) {
+      let { resourceUri , rights} = ctx.params;
+
+      let aclUri = getAclUriFromResourceUri(this.settings.baseUrl, resourceUri);
+
+      const processedRights = processRights(rights, aclUri + '#');
+
+      await ctx.call('triplestore.update', {
+        query: `
+          PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+          DELETE DATA {
+            GRAPH ${this.settings.graphName} {
+              ${processedRights.map(right => `<${right.auth}> <${right.p}> <${right.o}> .`).join('\n')}
+            }
+          }
+        `,
+        webId: 'system'
+      });
+
+      ctx.emit('webacl.resource.updated', { uri: resourceUri });
+    }
+  }
+};

--- a/src/middleware/packages/webacl/services/resource/actions/removeRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/removeRights.js
@@ -1,4 +1,4 @@
-const { getAclUriFromResourceUri, processRights } = require("../../../utils");
+const { getAclUriFromResourceUri, processRights } = require('../../../utils');
 
 module.exports = {
   action: {
@@ -8,7 +8,7 @@ module.exports = {
       rights: { type: 'object', optional: false }
     },
     async handler(ctx) {
-      let { resourceUri , rights} = ctx.params;
+      let { resourceUri, rights } = ctx.params;
 
       let aclUri = getAclUriFromResourceUri(this.settings.baseUrl, resourceUri);
 

--- a/src/middleware/packages/webacl/services/resource/index.js
+++ b/src/middleware/packages/webacl/services/resource/index.js
@@ -4,6 +4,7 @@ const setRightsAction = require('./actions/setRights');
 const addRightsAction = require('./actions/addRights');
 const hasRightsAction = require('./actions/hasRights');
 const deleteAllRightsAction = require('./actions/deleteAllRights');
+const removeRightsAction = require('./actions/removeRights');
 const { MoleculerError } = require('moleculer').Errors;
 const {
   getAuthorizationNode,
@@ -28,6 +29,7 @@ module.exports = {
   dependencies: ['triplestore', 'jsonld'],
   actions: {
     deleteAllRights: deleteAllRightsAction.action,
+    removeRights: removeRightsAction.action,
     // Actions accessible through the API
     api_hasRights: hasRightsAction.api,
     hasRights: hasRightsAction.action,
@@ -70,7 +72,6 @@ module.exports = {
         return false;
       } else return true;
     },
-
     async getExistingPerms(ctx, resourceUri, baseUrl, graphName, isContainer) {
       let resourceAclUri = getAclUriFromResourceUri(baseUrl, resourceUri);
 
@@ -94,7 +95,6 @@ module.exports = {
           return { auth: a.auth.value, p: a.p.value, o: a.o.value };
         });
     },
-
     compileAuthorizationNodesMap(nodes) {
       let result = {};
       for (const node of nodes) {
@@ -102,7 +102,6 @@ module.exports = {
       }
       return result;
     },
-
     generateNewAuthNode(auth) {
       let split = auth.split('#');
       let resUrl = split[0].replace('/_acl', '');

--- a/src/middleware/packages/webacl/utils.js
+++ b/src/middleware/packages/webacl/utils.js
@@ -264,8 +264,7 @@ const processRights = (rights, aclUri) => {
     if (rights.anyUser.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
     if (rights.anyUser.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
     if (rights.anyUser.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
-    if (rights.anyUser.control)
-      list.push({ auth: aclUri + 'Control', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
+    if (rights.anyUser.control) list.push({ auth: aclUri + 'Control', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
   }
   if (rights.group && rights.group.uri) {
     if (rights.group.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENT_GROUP, o: rights.group.uri });

--- a/src/middleware/packages/webacl/utils.js
+++ b/src/middleware/packages/webacl/utils.js
@@ -246,6 +246,36 @@ async function sanitizeSPARQL(text) {
     throw new MoleculerError('sparql injection detected. go away', 400, 'SPARQL_INJECTION');
 }
 
+const processRights = (rights, aclUri) => {
+  let list = [];
+  if (rights.anon) {
+    if (rights.anon.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
+    if (rights.anon.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
+    if (rights.anon.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
+    if (rights.anon.control) list.push({ auth: aclUri + 'Control', p: FULL_AGENTCLASS_URI, o: FULL_FOAF_AGENT });
+  }
+  if (rights.user && rights.user.uri) {
+    if (rights.user.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENT_URI, o: rights.user.uri });
+    if (rights.user.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENT_URI, o: rights.user.uri });
+    if (rights.user.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENT_URI, o: rights.user.uri });
+    if (rights.user.control) list.push({ auth: aclUri + 'Control', p: FULL_AGENT_URI, o: rights.user.uri });
+  }
+  if (rights.anyUser) {
+    if (rights.anyUser.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
+    if (rights.anyUser.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
+    if (rights.anyUser.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
+    if (rights.anyUser.control)
+      list.push({ auth: aclUri + 'Control', p: FULL_AGENTCLASS_URI, o: FULL_ACL_ANYAGENT });
+  }
+  if (rights.group && rights.group.uri) {
+    if (rights.group.read) list.push({ auth: aclUri + 'Read', p: FULL_AGENT_GROUP, o: rights.group.uri });
+    if (rights.group.write) list.push({ auth: aclUri + 'Write', p: FULL_AGENT_GROUP, o: rights.group.uri });
+    if (rights.group.append) list.push({ auth: aclUri + 'Append', p: FULL_AGENT_GROUP, o: rights.group.uri });
+    if (rights.group.control) list.push({ auth: aclUri + 'Control', p: FULL_AGENT_GROUP, o: rights.group.uri });
+  }
+  return list;
+};
+
 module.exports = {
   getSlugFromUri,
   getContainerFromUri,
@@ -262,6 +292,7 @@ module.exports = {
   aclGroupExists,
   removeAgentGroupOrAgentFromAuthorizations,
   sanitizeSPARQL,
+  processRights,
   FULL_TYPE_URI,
   FULL_ACCESSTO_URI,
   FULL_DEFAULT_URI,

--- a/website/docs/middleware/webacl/authorizer.md
+++ b/website/docs/middleware/webacl/authorizer.md
@@ -1,0 +1,42 @@
+---
+title: AuthorizerBot
+---
+
+Automatically give permissions to users, based on the record being created or updated.
+
+## Usage
+
+```js
+const { AuthorizerBot } = require('@semapps/webacl');
+
+module.exports = {
+  mixins: [AuthorizerBot],
+  settings: {
+    rules: [
+      {
+        // If the resource match...
+        match: { type: 'pair:Event' },
+        // ... give these permissions...
+        rights: {
+          read: true,
+          append: true,
+          write: true,
+          control: true
+        },
+        // ... to these users ...
+        users: record => record['pair:involvedIn']
+      },
+      {
+        // Use a function to match resources
+        match: record => record['pair:hasStatus'] === 'http://localhost:3000/status/special',
+        rights: {
+          read: true,
+          write: true
+        },
+        // Use a string for the users
+        users: 'http://localhost:3000/users/special-user'
+      }
+    ]
+  }
+};
+```

--- a/website/docs/middleware/webacl/index.md
+++ b/website/docs/middleware/webacl/index.md
@@ -16,8 +16,11 @@ This package allows you to handle rights through the [WebACL standard](https://g
 ## Sub-services
 - [WebAclResourceService](resource.md)
 - [WebAclGroupService](group.md)
-- [GroupsManagerBot](groups-manager.md) (optional)
 - WebAclCacheCleanerService
+
+## Bots
+- [AuthorizerBot](authorizer.md)
+- [GroupsManagerBot](groups-manager.md)
 
 ## Install
 

--- a/website/docs/middleware/webacl/resource.md
+++ b/website/docs/middleware/webacl/resource.md
@@ -137,6 +137,20 @@ Null
 Null
 
 
+### `webacl.resource.removeRights`
+- This action can only be called by other Moleculer services.
+- If you remove a right which doesn't exist, no error will be thrown.
+
+##### Parameters
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `resourceUri` | `String` | **required** | URI of the resource |
+| `rights` | `Object` | **required** | Object with the rights to remove (see above) |
+
+##### Return
+Null
+
+
 ### `webacl.resource.deleteAllRights`
 - Remove all rights on a given resource.
 - Only the `system` webId can call this action
@@ -174,7 +188,7 @@ Sent when the ACL for a resource or container are updated.
 
 ### `webacl.resource.deleted`
 
-Sent when the ACL for a resource or container are updated.
+Sent when the ACL for a resource or container are deleted.
 
 ##### Parameters
 | Property | Type | Description |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
           'middleware/webacl/index',
           'middleware/webacl/resource',
           'middleware/webacl/group',
+          'middleware/webacl/authorizer',
           'middleware/webacl/groups-manager',
         ],
       },


### PR DESCRIPTION
Closes https://github.com/assemblee-virtuelle/semapps/issues/829

Bot qui permet d'ajouter ou de supprimer automatiquement des permissions de certaines ressources. [Documentation](https://website-git-authorizer-bot-semapps.vercel.app/docs/middleware/webacl/authorizer)

J'ai aussi ajouté une action `webacl.resource.removeRights` pour supprimer certains droits d'une ressource (j'espère que j'ai fait les choses correctement @nikoPLP)

> PR financée par les CDLT