### PR TITLE
Generate WebACL cache

### DIFF
--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -82,11 +82,12 @@ module.exports = {
               let resource = await ctx.call('ldp.resource.get', {
                 resourceUri,
                 webId,
-                accept,
-                queryDepth,
-                dereference,
-                jsonContext,
-                forceSemantic: true
+                forceSemantic: true,
+                // We pass the following parameters only if they are explicit
+                accept: ctx.params.accept,
+                queryDepth: ctx.params.queryDepth,
+                dereference: ctx.params.dereference,
+                jsonContext: ctx.params.jsonContext
               });
 
               // If we have a child container, remove the ldp:contains property and add a ldp:Resource type
@@ -99,7 +100,7 @@ module.exports = {
 
               resources.push(resource);
             } catch (e) {
-              console.log('error requesting resource: ', resourceUri, e);
+              console.log('Error requesting resource: ', resourceUri);
               // Ignore a resource if it is not found
               if (e.name !== 'MoleculerError') throw e;
             }

--- a/src/middleware/packages/ldp/services/container/actions/getUris.js
+++ b/src/middleware/packages/ldp/services/container/actions/getUris.js
@@ -1,0 +1,22 @@
+const { MIME_TYPES } = require('@semapps/mime-types');
+
+module.exports = {
+  visibility: 'public',
+  async handler(ctx) {
+    const { containerUri } = ctx.params;
+
+    const result = await ctx.call('triplestore.query', {
+      query: `
+        PREFIX ldp: <http://www.w3.org/ns/ldp#>
+        SELECT ?resourceUri
+        WHERE {
+          <${containerUri}> ldp:contains ?resourceUri .
+        }
+      `,
+      accept: MIME_TYPES.JSON,
+      webId: 'system'
+    });
+
+    return result.map(node => node.resourceUri.value);
+  }
+};

--- a/src/middleware/packages/ldp/services/container/index.js
+++ b/src/middleware/packages/ldp/services/container/index.js
@@ -6,6 +6,7 @@ const createAction = require('./actions/create');
 const detachAction = require('./actions/detach');
 const existAction = require('./actions/exist');
 const getAction = require('./actions/get');
+const getUrisAction = require('./actions/getUris');
 const headAction = require('./actions/head');
 const getAllAction = require('./actions/getAll');
 const getOptionsAction = require('./actions/getOptions');
@@ -28,6 +29,7 @@ module.exports = {
     exist: existAction,
     getOptions: getOptionsAction,
     getAll: getAllAction,
+    getUris: getUrisAction,
     // Actions accessible through the API
     api_get: getAction.api,
     api_head: headAction.api,

--- a/src/middleware/packages/webacl/services/cache/index.js
+++ b/src/middleware/packages/webacl/services/cache/index.js
@@ -22,25 +22,25 @@ module.exports = {
       const { webId } = ctx.params;
       this.logger.info('Generating cache for user ' + webId);
       const containers = await ctx.call('ldp.container.getAll');
-      for( let containerUri of containers ) {
+      for (let containerUri of containers) {
         this.logger.info('Generating cache for container ' + containerUri);
         const resources = await ctx.call('ldp.container.getUris', { containerUri });
-        for( let resourceUri of resources ) {
+        for (let resourceUri of resources) {
           await ctx.call('webacl.resource.hasRights', {
             resourceUri,
             rights: { read: true },
             webId
-          })
+          });
         }
       }
     },
     async generateForAll(ctx) {
       const { usersContainer } = ctx.params;
       const users = await ctx.call('ldp.getAllResourcesUris', { containerUri: usersContainer });
-      for( let webId of users ) {
+      for (let webId of users) {
         await this.actions.generateForUser({ webId }, { parentCtx: ctx });
       }
-    },
+    }
   },
   events: {
     async 'webacl.resource.updated'(ctx) {

--- a/src/middleware/packages/webacl/services/resource/actions/hasRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/hasRights.js
@@ -81,7 +81,8 @@ module.exports = {
 
     return await ctx.call('webacl.resource.hasRights', {
       resourceUri: urlJoin(this.settings.baseUrl, ...slugParts),
-      rights: ctx.params.rights
+      rights: ctx.params.rights,
+      webId: ctx.meta.webId
     });
   },
   action: {
@@ -102,7 +103,7 @@ module.exports = {
       webId: { type: 'string', optional: true }
     },
     cache: {
-      keys: ['resourceUri', 'rights', 'webId', '#webId']
+      keys: ['resourceUri', 'rights', 'webId']
     },
     async handler(ctx) {
       let { resourceUri, webId, rights } = ctx.params;


### PR DESCRIPTION
New commands to automatically generate the WebACL cache necessary to

- `call webacl.cache.generateForUser --webId ...`
- `call webacl.cache.generateForAll --usersContainer ...`

If you wish to automatically generate cache for all new users, you should add this event listener somewhere in your code:

```js
  events: {
    async 'auth.registered'(ctx) {
      const { webId } = ctx.params;
      await ctx.call('webacl.cache.generateForUser', { webId });
    }
  }
```

> The cache key for the `webacl.resource.addRights` command has been changed. You may consider flushing all cache for this command before generating new cache.