### PR TITLE
fuseki_compact docker container + Max memory for JAVA config in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,19 @@ services:
       - semapps
     environment:
       ADMIN_PASSWORD: "admin"
+      JAVA_MX_RAM: "4G"
+
+  fuseki_compact:
+    build:
+      context: ./src/jena/fuseki-docker
+      dockerfile: Dockerfile
+    entrypoint: /docker-compact-entrypoint.sh  
+    image: semapps/jena-fuseki-webacl
+    container_name: fuseki_compact
+    volumes:
+      - ./data/rdf_data:/fuseki
+    networks:
+      - semapps
 
   middleware:
     build:

--- a/src/jena/fuseki-docker/Dockerfile
+++ b/src/jena/fuseki-docker/Dockerfile
@@ -33,6 +33,8 @@ ENV ASF_MIRROR_US https://downloads.apache.org/
 ENV ASF_ARCHIVE http://archive.apache.org/dist/
 #
 
+ENV JENA_SHA512 321c763fa3b3532fa06bb146363722e58e10289194f622f2e29117b610521e62e7ea51b9d06cd366570ed143f2ebbeded22e5302d2375b49da253b7ddef86d34
+
 # Config and data
 VOLUME /fuseki
 ENV FUSEKI_BASE /fuseki
@@ -45,9 +47,7 @@ WORKDIR /tmp
 # sha512 checksum
 RUN echo "$FUSEKI_SHA512  fuseki.tar.gz" > fuseki.tar.gz.sha512
 # Download/check/unpack/move in one go (to reduce image size)
-RUN     (curl -sS --fail $ASF_MIRROR_US/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz || \
-         curl -sS --fail $ASF_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz \
-        ) > fuseki.tar.gz && \
+RUN     curl -sS --fail $ASF_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz > fuseki.tar.gz && \
         sha512sum -c fuseki.tar.gz.sha512 && \
         tar zxf fuseki.tar.gz && \
         mv apache-jena-fuseki* $FUSEKI_HOME && \
@@ -55,6 +55,21 @@ RUN     (curl -sS --fail $ASF_MIRROR_US/jena/binaries/apache-jena-fuseki-$FUSEKI
         cd $FUSEKI_HOME && rm -rf fuseki.war
 
 RUN chmod 755  /jena-fuseki/fuseki-server
+
+RUN sed -i 's|JVM_ARGS=${JVM_ARGS:--Xmx4G}|JVM_ARGS=${JVM_ARGS:--Xmx${JAVA_MX_RAM}}|g' /jena-fuseki/fuseki-server 
+
+RUN echo "$JENA_SHA512  jena.tar.gz" > jena.tar.gz.sha512
+
+RUN     curl -sS --fail $ASF_ARCHIVE/jena/binaries/apache-jena-$FUSEKI_VERSION.tar.gz > jena.tar.gz && \
+        sha512sum -c jena.tar.gz.sha512 && \
+        tar zxf jena.tar.gz && \
+        cp -R apache-jena-$FUSEKI_VERSION/bin/* $FUSEKI_HOME/bin && \
+        cp -R apache-jena-$FUSEKI_VERSION/lib $FUSEKI_HOME/ && \
+        rm jena.tar.gz* && \
+        rm -r  apache-jena-$FUSEKI_VERSION
+
+RUN chmod 755 $FUSEKI_HOME/bin/tdb2.*
+
 # Test the install by testing it's ping resource
 #RUN  /jena-fuseki/fuseki-server & \
 #     sleep 4 && \
@@ -73,8 +88,9 @@ COPY extra/semapps-jena-permissions-1.0.0.jar /jena-fuseki/extra/semapps-jena-pe
 COPY configuration/localData.ttl /jena-fuseki/configuration/localData.ttl
 COPY configuration/testData.ttl /jena-fuseki/configuration/testData.ttl
 COPY docker-entrypoint.sh /
+COPY docker-compact-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh
-
+RUN chmod 755 /docker-compact-entrypoint.sh
 
 COPY load.sh /jena-fuseki/
 COPY tdbloader /jena-fuseki/

--- a/src/jena/fuseki-docker/docker-compact-entrypoint.sh
+++ b/src/jena/fuseki-docker/docker-compact-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -e
+
+cd /fuseki
+
+/jena-fuseki/bin/tdb2.tdbcompact --loc=/fuseki/databases/localData
+

--- a/src/jena/fuseki-docker/docker-entrypoint.sh
+++ b/src/jena/fuseki-docker/docker-entrypoint.sh
@@ -75,7 +75,7 @@ do
     curl -s 'http://localhost:3030/$/datasets'\
          -H "Authorization: Basic $(echo -n admin:${ADMIN_PASSWORD} | base64)" \
          -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8'\
-         --data "dbName=${dataset}&dbType=tdb"
+         --data "dbName=${dataset}&dbType=tdb2"
 done
 
 wait


### PR DESCRIPTION
with this pull request, we finally fix #854 the compact issue.

Pour faire la mise a jour:
- git pull
- a la racine de la repo git, faire 
```
docker-compose build fuseki
docker-compose up fuseki
docker stop fuseki
docker-compose up fuseki-compact
docker start fuseki
```

Pour ajouter un cron recurrent, toutes les semaines, le dimanche a 3am (faire ca dans la session ssh, pas dans le shell docker) :
`crontab -e`
ajouter la ligne:
`0 3 * * 0 docker stop fuseki; docker start -i fuseki_compact; docker start fuseki`

De plus, cette pull request ajoute un parametre dans le fichier docker-compose.yaml qui permet de definir la quantité de RAM que fuseki est censé utilisé au maximum. 
Augmentez ou diminuez `JAVA_MX_RAM` selon vos besoins. La bonne valeur se trouve autour de 70% du total de la RAM physique présente sur la machine.
Il faut refaire `docker-compose build fuseki; docker-compose up fuseki` une fois la valeur changée.
