### PR TITLE
removing default localData and testData from Docker image

### DIFF
--- a/src/jena/fuseki-docker/Dockerfile
+++ b/src/jena/fuseki-docker/Dockerfile
@@ -85,8 +85,8 @@ COPY shiro.ini /jena-fuseki/
 COPY extra/commons-collections4-4.4.jar /jena-fuseki/extra/commons-collections4-4.4.jar
 COPY extra/jena-permissions-3.17.0.jar /jena-fuseki/extra/jena-permissions-3.17.0.jar
 COPY extra/semapps-jena-permissions-1.0.0.jar /jena-fuseki/extra/semapps-jena-permissions-1.0.0.jar
-COPY configuration/localData.ttl /jena-fuseki/configuration/localData.ttl
-COPY configuration/testData.ttl /jena-fuseki/configuration/testData.ttl
+#COPY configuration/localData.ttl /jena-fuseki/configuration/localData.ttl
+#COPY configuration/testData.ttl /jena-fuseki/configuration/testData.ttl
 COPY docker-entrypoint.sh /
 COPY docker-compact-entrypoint.sh /
 RUN chmod 755 /docker-entrypoint.sh

--- a/src/jena/fuseki-docker/docker-entrypoint.sh
+++ b/src/jena/fuseki-docker/docker-entrypoint.sh
@@ -27,14 +27,14 @@ if [ ! -d "$FUSEKI_BASE/extra" ] ; then
   rm -rf "$FUSEKI_BASE/system_files"
   cp -r "$FUSEKI_HOME/extra" "$FUSEKI_BASE/"
   mkdir -p "$FUSEKI_BASE/configuration"
-  cp "$FUSEKI_HOME/configuration/localData.ttl" "$FUSEKI_BASE/configuration/localData.ttl"
+#  cp "$FUSEKI_HOME/configuration/localData.ttl" "$FUSEKI_BASE/configuration/localData.ttl"
   echo ""
   echo "###################################"
 fi
 
 cp "$FUSEKI_HOME/extra/semapps-jena-permissions-1.0.0.jar" "$FUSEKI_BASE/extra/semapps-jena-permissions-1.0.0.jar"
 
-cp "$FUSEKI_HOME/configuration/testData.ttl" "$FUSEKI_BASE/configuration/testData.ttl"
+#cp "$FUSEKI_HOME/configuration/testData.ttl" "$FUSEKI_BASE/configuration/testData.ttl"
 
 # always copying semapps-jena-permissions-1.0.0.jar
 cp "$FUSEKI_HOME/extra/semapps-jena-permissions-1.0.0.jar" "$FUSEKI_BASE/extra/semapps-jena-permissions-1.0.0.jar"


### PR DESCRIPTION
closes #895 

make sure that in all of your projects, you call `fuseki-admin.createDataset` at least once, with the right `secure: true/false` parameter.

I published the new docker image now.