### PR TITLE
Return more data from LDP actions

### DIFF
--- a/src/middleware/packages/activitypub/services/activity.js
+++ b/src/middleware/packages/activitypub/services/activity.js
@@ -17,7 +17,6 @@ const ActivityService = {
     newResourcesPermissions: {},
     controlledActions: {
       // Activities shouldn't be handled manually
-      create: 'activitypub.activity.forbidden',
       patch: 'activitypub.activity.forbidden',
       put: 'activitypub.activity.forbidden',
       delete: 'activitypub.activity.forbidden'
@@ -27,20 +26,6 @@ const ActivityService = {
   actions: {
     forbidden() {
       throw new E.ForbiddenError();
-    },
-    async create(ctx) {
-      let { activity } = ctx.params;
-      const containerUri = await this.getContainerUri(activity.actor);
-
-      return await ctx.call('ldp.container.post', {
-        containerUri,
-        resource: {
-          '@context': this.settings.context,
-          ...objectIdToCurrent(activity)
-        },
-        contentType: MIME_TYPES.JSON,
-        webId: 'system'
-      });
     },
     async getRecipients(ctx) {
       const { activity } = ctx.params;
@@ -93,6 +78,9 @@ const ActivityService = {
         if (typeof ctx.params.resourceUri === 'object') {
           ctx.params.resourceUri = ctx.params.resourceUri.id || ctx.params.resourceUri['@id'];
         }
+      },
+      create(ctx) {
+        ctx.params.resource = objectIdToCurrent(ctx.params.resource);
       }
     },
     after: {

--- a/src/middleware/packages/activitypub/services/actor.js
+++ b/src/middleware/packages/activitypub/services/actor.js
@@ -41,7 +41,7 @@ const ActorService = {
       const currentData = await this.actions.get({ actorUri, webId: 'system' }, { parentCtx: ctx });
       const actorData = this.settings.selectActorData(currentData);
 
-      if( actorData ) {
+      if (actorData) {
         await ctx.call('ldp.resource.patch', {
           resource: {
             '@id': actorUri,

--- a/src/middleware/packages/activitypub/services/object.js
+++ b/src/middleware/packages/activitypub/services/object.js
@@ -104,11 +104,12 @@ const ObjectService = {
         }
 
         case ACTIVITY_TYPES.UPDATE: {
-          objectUri = await ctx.call('ldp.resource.patch', {
+          await ctx.call('ldp.resource.patch', {
             resource: activity.object,
             contentType: MIME_TYPES.JSON,
             webId: actorUri
           });
+          objectUri = activity.object['@id'] || activity.object.id;
           break;
         }
 

--- a/src/middleware/packages/activitypub/services/outbox.js
+++ b/src/middleware/packages/activitypub/services/outbox.js
@@ -1,8 +1,8 @@
 const { MoleculerError } = require('moleculer').Errors;
 const ControlledCollectionMixin = require('../mixins/controlled-collection');
-const { collectionPermissionsWithAnonRead, objectIdToCurrent} = require('../utils');
+const { collectionPermissionsWithAnonRead, objectIdToCurrent } = require('../utils');
 const { ACTOR_TYPES } = require('../constants');
-const {MIME_TYPES} = require("@semapps/mime-types");
+const { MIME_TYPES } = require('@semapps/mime-types');
 
 const OutboxService = {
   name: 'activitypub.outbox',
@@ -49,7 +49,9 @@ const OutboxService = {
       // TODO use it to order the ordered collections
       activity.published = new Date().toISOString();
 
-      const activitiesContainerUri = await this.broker.call('activitypub.activity.getContainerUri', { webId: actorUri });
+      const activitiesContainerUri = await this.broker.call('activitypub.activity.getContainerUri', {
+        webId: actorUri
+      });
 
       const activityUri = await ctx.call('activitypub.activity.post', {
         containerUri: activitiesContainerUri,

--- a/src/middleware/packages/activitypub/services/outbox.js
+++ b/src/middleware/packages/activitypub/services/outbox.js
@@ -1,7 +1,8 @@
 const { MoleculerError } = require('moleculer').Errors;
 const ControlledCollectionMixin = require('../mixins/controlled-collection');
-const { collectionPermissionsWithAnonRead } = require('../utils');
+const { collectionPermissionsWithAnonRead, objectIdToCurrent} = require('../utils');
 const { ACTOR_TYPES } = require('../constants');
+const {MIME_TYPES} = require("@semapps/mime-types");
 
 const OutboxService = {
   name: 'activitypub.outbox',
@@ -48,7 +49,15 @@ const OutboxService = {
       // TODO use it to order the ordered collections
       activity.published = new Date().toISOString();
 
-      const activityUri = await ctx.call('activitypub.activity.create', { activity });
+      const activitiesContainerUri = await this.broker.call('activitypub.activity.getContainerUri', { webId: actorUri });
+
+      const activityUri = await ctx.call('activitypub.activity.post', {
+        containerUri: activitiesContainerUri,
+        resource: activity,
+        contentType: MIME_TYPES.JSON,
+        webId: 'system'
+      });
+
       activity = await ctx.call('activitypub.activity.get', { resourceUri: activityUri, webId: 'system' });
 
       // Attach the newly-created activity to the outbox

--- a/src/middleware/packages/ldp/mixins/controlled-container.js
+++ b/src/middleware/packages/ldp/mixins/controlled-container.js
@@ -37,7 +37,7 @@ module.exports = {
   },
   actions: {
     async post(ctx) {
-      if(!ctx.params.containerUri) {
+      if (!ctx.params.containerUri) {
         ctx.params.containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
       }
       return await ctx.call('ldp.container.post', ctx.params);
@@ -62,7 +62,7 @@ module.exports = {
     },
     getContainerUri(ctx) {
       return ctx.call('ldp.registry.getUri', { path: this.settings.path, webId: ctx.params.webId || ctx.meta.webId });
-    },
+    }
   },
   methods: {
     async waitForContainerCreation(containerUri) {

--- a/src/middleware/packages/ldp/mixins/controlled-container.js
+++ b/src/middleware/packages/ldp/mixins/controlled-container.js
@@ -36,8 +36,11 @@ module.exports = {
     });
   },
   actions: {
-    post(ctx) {
-      return ctx.call('ldp.container.post', ctx.params);
+    async post(ctx) {
+      if(!ctx.params.containerUri) {
+        ctx.params.containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
+      }
+      return await ctx.call('ldp.container.post', ctx.params);
     },
     list(ctx) {
       return ctx.call('ldp.container.get', ctx.params);
@@ -56,12 +59,12 @@ module.exports = {
     },
     delete(ctx) {
       return ctx.call('ldp.resource.delete', ctx.params);
-    }
+    },
+    getContainerUri(ctx) {
+      return ctx.call('ldp.registry.getUri', { path: this.settings.path, webId: ctx.params.webId || ctx.meta.webId });
+    },
   },
   methods: {
-    async getContainerUri(webId) {
-      return this.broker.call('ldp.registry.getUri', { path: this.settings.path, webId });
-    },
     async waitForContainerCreation(containerUri) {
       let containerExist, containerAttached;
 

--- a/src/middleware/packages/ldp/services/container/actions/post.js
+++ b/src/middleware/packages/ldp/services/container/actions/post.js
@@ -12,8 +12,7 @@ module.exports = {
           containerUri,
           slug: ctx.meta.headers.slug,
           resource,
-          contentType: ctx.meta.headers['content-type'],
-          createResourceAction: controlledActions.create
+          contentType: ctx.meta.headers['content-type']
         });
       } else {
         if (ctx.params.files.length > 1) {
@@ -23,8 +22,7 @@ module.exports = {
           containerUri,
           slug: ctx.meta.headers.slug || ctx.params.files[0].filename,
           file: ctx.params.files[0],
-          contentType: MIME_TYPES.JSON,
-          createResourceAction: controlledActions.create
+          contentType: MIME_TYPES.JSON
         });
       }
       ctx.meta.$responseHeaders = {
@@ -67,14 +65,10 @@ module.exports = {
       disassembly: {
         type: 'array',
         optional: true
-      },
-      createResourceAction: {
-        type: 'string',
-        default: 'ldp.resource.create'
       }
     },
     async handler(ctx) {
-      let { resource, containerUri, slug, contentType, file, createResourceAction } = ctx.params;
+      let { resource, containerUri, slug, contentType, file } = ctx.params;
       const webId = ctx.params.webId || ctx.meta.webId || 'anon';
 
       const resourceUri = await ctx.call('ldp.resource.generateId', { containerUri, slug });
@@ -98,7 +92,9 @@ module.exports = {
           resource = await ctx.call('ldp.resource.upload', { resourceUri, file });
         }
 
-        await ctx.call(createResourceAction, {
+        const { controlledActions } = await ctx.call('ldp.registry.getByUri', { containerUri });
+
+        await ctx.call(controlledActions.create || 'ldp.resource.create', {
           resource: {
             '@id': resourceUri,
             ...resource

--- a/src/middleware/packages/ldp/services/resource/actions/create.js
+++ b/src/middleware/packages/ldp/services/resource/actions/create.js
@@ -68,11 +68,7 @@ module.exports = {
       webId
     };
 
-    ctx.emit(
-      'ldp.resource.created',
-      returnValues,
-      { meta: { webId: null, dataset: null } }
-    );
+    ctx.emit('ldp.resource.created', returnValues, { meta: { webId: null, dataset: null } });
 
     return returnValues;
   }

--- a/src/middleware/packages/ldp/services/resource/actions/create.js
+++ b/src/middleware/packages/ldp/services/resource/actions/create.js
@@ -23,7 +23,7 @@ module.exports = {
 
     const resourceUri = resource.id || resource['@id'];
 
-    const { disassembly, jsonContext } = {
+    const { disassembly, jsonContext, controlledActions } = {
       ...(await ctx.call('ldp.registry.getByUri', { resourceUri })),
       ...ctx.params
     };
@@ -52,27 +52,28 @@ module.exports = {
     });
 
     const newData = await ctx.call(
-      'ldp.resource.get',
+      controlledActions.get || 'ldp.resource.get',
       {
         resourceUri,
         accept: MIME_TYPES.JSON,
-        queryDepth: 1,
         forceSemantic: true,
         webId
       },
       { meta: { $cache: false } }
     );
 
+    const returnValues = {
+      resourceUri: resource['@id'],
+      newData,
+      webId
+    };
+
     ctx.emit(
       'ldp.resource.created',
-      {
-        resourceUri: resource['@id'],
-        newData,
-        webId
-      },
+      returnValues,
       { meta: { webId: null, dataset: null } }
     );
 
-    return newData;
+    return returnValues;
   }
 };

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -105,11 +105,7 @@ module.exports = {
         webId
       };
 
-      ctx.emit(
-        'ldp.resource.deleted',
-        returnValues,
-        { meta: { webId: null, dataset: null } }
-      );
+      ctx.emit('ldp.resource.deleted', returnValues, { meta: { webId: null, dataset: null } });
 
       return returnValues;
     }

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -99,15 +99,19 @@ module.exports = {
         fs.unlinkSync(oldData['semapps:localPath']);
       }
 
+      const returnValues = {
+        resourceUri,
+        oldData,
+        webId
+      };
+
       ctx.emit(
         'ldp.resource.deleted',
-        {
-          resourceUri,
-          oldData,
-          webId
-        },
+        returnValues,
         { meta: { webId: null, dataset: null } }
       );
+
+      return returnValues;
     }
   }
 };

--- a/src/middleware/packages/middlewares/index.js
+++ b/src/middleware/packages/middlewares/index.js
@@ -30,11 +30,11 @@ const negotiateContentType = (req, res, next) => {
 };
 
 const throw403 = msg => {
-  throw new MoleculerError('Access denied', 403, 'ACCESS_DENIED', { status: 'Forbidden', text: msg });
+  throw new MoleculerError(msg, 403, 'ACCESS_DENIED', { status: 'Forbidden', text: msg });
 };
 
 const throw500 = msg => {
-  throw new MoleculerError('Server error', 500, 'INTERNAL_SERVER_ERROR', { status: 'Server Error', text: msg });
+  throw new MoleculerError(msg, 500, 'INTERNAL_SERVER_ERROR', { status: 'Server Error', text: msg });
 };
 
 const negotiateAccept = (req, res, next) => {

--- a/src/middleware/packages/webacl/middlewares/webacl.js
+++ b/src/middleware/packages/webacl/middlewares/webacl.js
@@ -213,7 +213,7 @@ const WebAclMiddleware = config => ({
 
           case 'activitypub.activity.create':
             const activity = await ctx.call('activitypub.activity.get', {
-              resourceUri: actionReturnValue,
+              resourceUri: actionReturnValue.resourceUri,
               webId: 'system'
             });
             const recipients = await ctx.call('activitypub.activity.getRecipients', { activity });
@@ -223,7 +223,7 @@ const WebAclMiddleware = config => ({
             // https://github.com/assemblee-virtuelle/semapps/issues/908
             for (let recipient of recipients) {
               await ctx.call('webacl.resource.addRights', {
-                resourceUri: actionReturnValue,
+                resourceUri: actionReturnValue.resourceUri,
                 additionalRights: {
                   user: {
                     uri: recipient,
@@ -237,7 +237,7 @@ const WebAclMiddleware = config => ({
             // If activity is public, give anonymous read right
             if (await ctx.call('activitypub.activity.isPublic', { activity })) {
               await ctx.call('webacl.resource.addRights', {
-                resourceUri: actionReturnValue,
+                resourceUri: actionReturnValue.resourceUri,
                 additionalRights: {
                   anon: {
                     read: true

--- a/src/middleware/tests/activitypub/initialize.js
+++ b/src/middleware/tests/activitypub/initialize.js
@@ -37,6 +37,12 @@ const initialize = async () => {
       url: CONFIG.SPARQL_ENDPOINT,
       user: CONFIG.JENA_USER,
       password: CONFIG.JENA_PASSWORD
+    },
+    async started() {
+      await this.actions.createDataset({
+        dataset: CONFIG.MAIN_DATASET,
+        secure: true
+      });
     }
   });
   await broker.createService(AuthLocalService, {

--- a/src/middleware/tests/ldp/api.test.js
+++ b/src/middleware/tests/ldp/api.test.js
@@ -20,7 +20,19 @@ let expressMocked = undefined;
 
 beforeAll(async () => {
   broker.createService(JsonLdService);
-  broker.createService(FusekiAdminService);
+  broker.createService(FusekiAdminService, {
+    settings: {
+      url: CONFIG.SPARQL_ENDPOINT,
+      user: CONFIG.JENA_USER,
+      password: CONFIG.JENA_PASSWORD
+    },
+    async started() {
+      await this.actions.createDataset({
+        dataset: CONFIG.MAIN_DATASET,
+        secure: true
+      });
+    }
+  });
   broker.createService(TripleStoreService, {
     settings: {
       sparqlEndpoint: CONFIG.SPARQL_ENDPOINT,

--- a/src/middleware/tests/ldp/initialize.js
+++ b/src/middleware/tests/ldp/initialize.js
@@ -22,7 +22,19 @@ const initialize = async () => {
 
   await broker.createService(ApiGatewayService);
   await broker.createService(JsonLdService);
-  await broker.createService(FusekiAdminService);
+  await broker.createService(FusekiAdminService, {
+    settings: {
+      url: CONFIG.SPARQL_ENDPOINT,
+      user: CONFIG.JENA_USER,
+      password: CONFIG.JENA_PASSWORD
+    },
+    async started() {
+      await this.actions.createDataset({
+        dataset: CONFIG.MAIN_DATASET,
+        secure: true
+      });
+    }
+  });
   await broker.createService(TripleStoreService, {
     settings: {
       sparqlEndpoint: CONFIG.SPARQL_ENDPOINT,

--- a/src/middleware/tests/webId/webId.test.js
+++ b/src/middleware/tests/webId/webId.test.js
@@ -24,7 +24,19 @@ const broker = new ServiceBroker({
 beforeAll(async () => {
   broker.createService(ApiGatewayService);
   broker.createService(JsonLdService);
-  broker.createService(FusekiAdminService);
+  broker.createService(FusekiAdminService, {
+    settings: {
+      url: CONFIG.SPARQL_ENDPOINT,
+      user: CONFIG.JENA_USER,
+      password: CONFIG.JENA_PASSWORD
+    },
+    async started() {
+      await this.actions.createDataset({
+        dataset: CONFIG.MAIN_DATASET,
+        secure: true
+      });
+    }
+  });
   broker.createService(TripleStoreService, {
     settings: {
       sparqlEndpoint: CONFIG.SPARQL_ENDPOINT,

--- a/src/middleware/tests/webacl/groupCRUD.test.js
+++ b/src/middleware/tests/webacl/groupCRUD.test.js
@@ -28,7 +28,19 @@ let expressMocked = undefined;
 
 beforeAll(async () => {
   broker.createService(JsonLdService);
-  broker.createService(FusekiAdminService);
+  broker.createService(FusekiAdminService, {
+    settings: {
+      url: CONFIG.SPARQL_ENDPOINT,
+      user: CONFIG.JENA_USER,
+      password: CONFIG.JENA_PASSWORD
+    },
+    async started() {
+      await this.actions.createDataset({
+        dataset: CONFIG.MAIN_DATASET,
+        secure: true
+      });
+    }
+  });
   broker.createService(TripleStoreService, {
     settings: {
       sparqlEndpoint: CONFIG.SPARQL_ENDPOINT,

--- a/src/middleware/tests/webacl/resourceCRUD.test.js
+++ b/src/middleware/tests/webacl/resourceCRUD.test.js
@@ -29,7 +29,19 @@ let expressMocked = undefined;
 
 beforeAll(async () => {
   broker.createService(JsonLdService);
-  broker.createService(FusekiAdminService);
+  broker.createService(FusekiAdminService, {
+    settings: {
+      url: CONFIG.SPARQL_ENDPOINT,
+      user: CONFIG.JENA_USER,
+      password: CONFIG.JENA_PASSWORD
+    },
+    async started() {
+      await this.actions.createDataset({
+        dataset: CONFIG.MAIN_DATASET,
+        secure: true
+      });
+    }
+  });
   broker.createService(TripleStoreService, {
     settings: {
       sparqlEndpoint: CONFIG.SPARQL_ENDPOINT,

--- a/src/middleware/tests/webacl/sparql-injection.test.js
+++ b/src/middleware/tests/webacl/sparql-injection.test.js
@@ -28,7 +28,19 @@ let expressMocked = undefined;
 
 beforeAll(async () => {
   broker.createService(JsonLdService);
-  broker.createService(FusekiAdminService);
+  broker.createService(FusekiAdminService, {
+    settings: {
+      url: CONFIG.SPARQL_ENDPOINT,
+      user: CONFIG.JENA_USER,
+      password: CONFIG.JENA_PASSWORD
+    },
+    async started() {
+      await this.actions.createDataset({
+        dataset: CONFIG.MAIN_DATASET,
+        secure: true
+      });
+    }
+  });
   broker.createService(TripleStoreService, {
     settings: {
       sparqlEndpoint: CONFIG.SPARQL_ENDPOINT,

--- a/website/docs/middleware/ldp/container.md
+++ b/website/docs/middleware/ldp/container.md
@@ -74,3 +74,19 @@ You can also pass parameters defined in the [container options](index#container-
 ##### Return
 Triples, Turtle or JSON-LD depending on `accept` type.
 
+
+### `ldp.container.post`
+* Generate an URI, create the resource (calling `ldp.resource.create`), and attach it to a container
+* Content-type can be triples, turtle or JSON-LD (see `@semapps/mime-types` package)
+
+##### Parameters
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `resource` | `Object`  | **required** | Resource to create |
+| `containerUri` | `string` | **required** | Container where the resource will be created |
+| `contentType` | `string` | **required** | Type of provided resource (`application/ld+json`, `text/turtle` or `application/n-triples`) |
+| `webId` | `string` | Logged user's webId  | User doing the action |
+| `slug` | `String` |  | Specific ID tu use for URI instead generated UUID |
+
+##### Return
+`String` : URI of the created resource

--- a/website/docs/middleware/ldp/resource.md
+++ b/website/docs/middleware/ldp/resource.md
@@ -24,21 +24,23 @@ You can also pass parameters defined in the [container options](index#container-
 Triples, Turtle or JSON-LD depending on `accept` type.
 
 
-### `ldp.container.post`
-* Create a resource
-* Content-type can be triples, turtle or JSON-LD (see `@semapps/mime-types` package)
+### `ldp.resource.create`
+* This action is called internally by `ldp.container.post`
+* If called directly, the full URI must be provided in the `resource` object
 
 ##### Parameters
-| Property | Type | Default | Description |
-| -------- | ---- | ------- | ----------- |
-| `resource` | `String` or `Object`  | **required** | Resource to create |
-| `containerUri` | `string` | **required** | Container where the resource will be created |
-| `contentType` | `string` | **required** | Type of provided resource (`application/ld+json`, `text/turtle` or `application/n-triples`) |
-| `webId` | `string` | Logged user's webId  | User doing the action |
-| `slug` | `String` |  | Specific ID tu use for URI instead generated UUID |
+| Property | Type | Default | Description                                                                                 |
+| -------- | ---- | ------- |---------------------------------------------------------------------------------------------|
+| `resource` | `Object`  | **required** | Resource to create (with an ID)                                                             |
+| `contentType` | `String` | **required** | Type of provided resource (`application/ld+json`, `text/turtle` or `application/n-triples`) |
+| `webId` | `String` | Logged user's webId | User doing the action                                                                       |
 
-##### Return
-`String` : URI of the created resource
+##### Return values
+| Property      | Type     | Description                 |
+|---------------|----------|-----------------------------|
+| `resourceUri` | `String` | URI of the created resource |
+| `newData`     | `Object` | New value of the resource   |
+| `webId`       | `String` | User who did the action     |
 
 
 ### `ldp.resource.patch`
@@ -49,11 +51,16 @@ Triples, Turtle or JSON-LD depending on `accept` type.
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `resource` | `String` or `Object`  | **required** | Resource to update |
-| `contentType` | `string` | **required** | Type of provided resource (`application/ld+json`, `text/turtle` or `application/n-triples`) |
-| `webId` | `string` | Logged user's webId | User doing the action |
+| `contentType` | `String` | **required** | Type of provided resource (`application/ld+json`, `text/turtle` or `application/n-triples`) |
+| `webId` | `String` | Logged user's webId | User doing the action |
 
-##### Return
-`String` : URI of the updated resource
+##### Return values
+| Property      | Type     | Description                 |
+|---------------|----------|-----------------------------|
+| `resourceUri` | `String` | URI of the updated resource |
+| `newData`     | `Object` | New value of the resource   |
+| `oldData`     | `Object` | Old value of the resource   |
+| `webId`       | `String` | User who did the action     |
 
 
 ### `ldp.resource.put`
@@ -68,8 +75,13 @@ Triples, Turtle or JSON-LD depending on `accept` type.
 | `contentType` | `string` | **required** | Type of provided resource (`application/ld+json`, `text/turtle` or `application/n-triples`) |
 | `webId` | `string` | Logged user's webId | User doing the action |
 
-##### Return
-`String` : URI of the updated resource
+##### Return values
+| Property      | Type     | Description                 |
+|---------------|----------|-----------------------------|
+| `resourceUri` | `String` | URI of the updated resource |
+| `newData`     | `Object` | New value of the resource   |
+| `oldData`     | `Object` | Old value of the resource   |
+| `webId`       | `String` | User who did the action     |
 
 
 ### `ldp.resource.delete`
@@ -80,3 +92,10 @@ Triples, Turtle or JSON-LD depending on `accept` type.
 | -------- | ---- | ------- | ----------- |
 | `resourceUri` | `String`| **required** | URI of resource to delete |
 | `webId` | `string` | Logged user's webId | User doing the action |
+
+##### Return values
+| Property      | Type     | Description                 |
+|---------------|----------|-----------------------------|
+| `resourceUri` | `String` | URI of the deleted resource |
+| `oldData`     | `Object` | Old value of the resource   |
+| `webId`       | `String` | User who did the action     |

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/contribute/code.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/contribute/code.md
@@ -1,5 +1,5 @@
 ---
-title: Contributer au coeur de SemApps
+title: Contribuer au coeur de SemApps
 ---
 
 Si vous êtes développeur, vous pouvez choisir d'utiliser SemApps comme librairie pour votre propre projet. Dans ce cas, ce [guide](guides/ldp-server.md) sera pour vous d'une grande utilité.


### PR DESCRIPTION
Return more informations (`newData`, `oldData`...) from the following actions:

- `ldp.resource.create`
- `ldp.resource.patch`
- `ldp.resource.put`
- `ldp.resource.delete`

This allows to do more things with the ControlledContainerMixin.

This introduces **breaking changes** but only if you called these actions directly and did something with the return values.

Also:
- Fix and improve the documentation.
- Fix several broken tests.
- Improve ActivityPub ActivityService
- Allow not to pass the `containerUri` to controlled containers 