### PR TITLE
New option to make a container read-only

### DIFF
--- a/src/middleware/packages/activitypub/services/activity.js
+++ b/src/middleware/packages/activitypub/services/activity.js
@@ -15,6 +15,7 @@ const ActivityService = {
     dereference: ['as:object/as:object'],
     permissions: {},
     newResourcesPermissions: {},
+    readOnly: true,
     controlledActions: {
       // Activities shouldn't be handled manually
       patch: 'activitypub.activity.forbidden',

--- a/src/middleware/packages/ldp/mixins/controlled-container.js
+++ b/src/middleware/packages/ldp/mixins/controlled-container.js
@@ -5,12 +5,13 @@ module.exports = {
   settings: {
     path: null,
     acceptedTypes: null,
-    accept: null,
+    accept: MIME_TYPES.JSON,
     jsonContext: null,
     dereference: null,
     permissions: null,
     newResourcesPermissions: null,
-    controlledActions: {}
+    controlledActions: {},
+    readOnly: false,
   },
   dependencies: ['ldp'],
   async started() {
@@ -18,7 +19,7 @@ module.exports = {
       path: this.settings.path,
       name: this.name,
       acceptedTypes: this.settings.acceptedTypes,
-      accept: MIME_TYPES.JSON || this.settings.accept,
+      accept: this.settings.accept,
       jsonContext: this.settings.jsonContext,
       dereference: this.settings.dereference,
       permissions: this.settings.permissions,
@@ -32,7 +33,8 @@ module.exports = {
         put: this.name + '.put',
         delete: this.name + '.delete',
         ...this.settings.controlledActions
-      }
+      },
+      readOnly: this.settings.readOnly
     });
   },
   actions: {

--- a/src/middleware/packages/ldp/routes/getContainerRoute.js
+++ b/src/middleware/packages/ldp/routes/getContainerRoute.js
@@ -27,10 +27,10 @@ function getContainerRoute(containerUri, readOnly = false) {
     'HEAD /': [addContainerUriMiddleware(containerUri), 'ldp.container.api_head']
   };
 
-  if( !readOnly ) {
+  if (!readOnly) {
     aliases = {
       ...aliases,
-      'POST /': [...middlewares, 'ldp.container.api_post'],
+      'POST /': [...middlewares, 'ldp.container.api_post']
     };
   }
 
@@ -42,7 +42,7 @@ function getContainerRoute(containerUri, readOnly = false) {
       'HEAD /:id': [addContainerUriMiddleware(containerUri), 'ldp.resource.api_head']
     };
 
-    if( !readOnly ) {
+    if (!readOnly) {
       aliases = {
         ...aliases,
         'PUT /:id': [...middlewares, 'ldp.resource.api_put'],

--- a/src/middleware/packages/ldp/routes/getContainerRoute.js
+++ b/src/middleware/packages/ldp/routes/getContainerRoute.js
@@ -8,7 +8,7 @@ const {
   addContainerUriMiddleware
 } = require('@semapps/middlewares');
 
-function getContainerRoute(containerUri) {
+function getContainerRoute(containerUri, readOnly = false) {
   const containerPath = new URL(containerUri).pathname;
 
   const middlewares = [
@@ -24,20 +24,32 @@ function getContainerRoute(containerUri) {
   // Container aliases
   let aliases = {
     'GET /': [...middlewares, 'ldp.container.api_get'],
-    'POST /': [...middlewares, 'ldp.container.api_post'],
     'HEAD /': [addContainerUriMiddleware(containerUri), 'ldp.container.api_head']
   };
+
+  if( !readOnly ) {
+    aliases = {
+      ...aliases,
+      'POST /': [...middlewares, 'ldp.container.api_post'],
+    };
+  }
 
   // If this is not the root container, add resource aliases
   if (containerPath !== '/') {
     aliases = {
       ...aliases,
       'GET /:id': [...middlewares, 'ldp.resource.api_get'],
-      'PUT /:id': [...middlewares, 'ldp.resource.api_put'],
-      'PATCH /:id': [...middlewares, 'ldp.resource.api_patch'],
-      'DELETE /:id': [...middlewares, 'ldp.resource.api_delete'],
       'HEAD /:id': [addContainerUriMiddleware(containerUri), 'ldp.resource.api_head']
     };
+
+    if( !readOnly ) {
+      aliases = {
+        ...aliases,
+        'PUT /:id': [...middlewares, 'ldp.resource.api_put'],
+        'PATCH /:id': [...middlewares, 'ldp.resource.api_patch'],
+        'DELETE /:id': [...middlewares, 'ldp.resource.api_delete']
+      };
+    }
   }
 
   return {

--- a/src/middleware/packages/ldp/routes/getResourcesRoute.js
+++ b/src/middleware/packages/ldp/routes/getResourcesRoute.js
@@ -24,9 +24,9 @@ function getResourcesRoute(containerUri, readOnly = false) {
   let aliases = {
     'GET /:id': [...middlewares, 'ldp.resource.api_get'],
     'HEAD /:id': [addContainerUriMiddleware(containerUri), 'ldp.resource.api_head']
-  }
+  };
 
-  if( !readOnly ) {
+  if (!readOnly) {
     aliases = {
       ...aliases,
       'PUT /:id': [...middlewares, 'ldp.resource.api_put'],

--- a/src/middleware/packages/ldp/routes/getResourcesRoute.js
+++ b/src/middleware/packages/ldp/routes/getResourcesRoute.js
@@ -8,7 +8,7 @@ const {
   addContainerUriMiddleware
 } = require('@semapps/middlewares');
 
-function getResourcesRoute(containerUri) {
+function getResourcesRoute(containerUri, readOnly = false) {
   const containerPath = new URL(containerUri).pathname;
 
   const middlewares = [
@@ -21,6 +21,20 @@ function getResourcesRoute(containerUri) {
     addContainerUriMiddleware(containerUri)
   ];
 
+  let aliases = {
+    'GET /:id': [...middlewares, 'ldp.resource.api_get'],
+    'HEAD /:id': [addContainerUriMiddleware(containerUri), 'ldp.resource.api_head']
+  }
+
+  if( !readOnly ) {
+    aliases = {
+      ...aliases,
+      'PUT /:id': [...middlewares, 'ldp.resource.api_put'],
+      'PATCH /:id': [...middlewares, 'ldp.resource.api_patch'],
+      'DELETE /:id': [...middlewares, 'ldp.resource.api_delete']
+    };
+  }
+
   return {
     path: containerPath,
     // Disable the body parsers so that we can parse the body ourselves
@@ -28,13 +42,7 @@ function getResourcesRoute(containerUri) {
     bodyParsers: false,
     authorization: false,
     authentication: true,
-    aliases: {
-      'GET /:id': [...middlewares, 'ldp.resource.api_get'],
-      'PUT /:id': [...middlewares, 'ldp.resource.api_put'],
-      'PATCH /:id': [...middlewares, 'ldp.resource.api_patch'],
-      'DELETE /:id': [...middlewares, 'ldp.resource.api_delete'],
-      'HEAD /:id': [addContainerUriMiddleware(containerUri), 'ldp.resource.api_head']
-    }
+    aliases
   };
 }
 

--- a/src/middleware/packages/ldp/services/registry/actions/register.js
+++ b/src/middleware/packages/ldp/services/registry/actions/register.js
@@ -15,7 +15,8 @@ module.exports = {
     disassembly: { type: 'array', optional: true },
     permissions: { type: 'object', optional: true },
     newResourcesPermissions: { type: 'multi', rules: [{ type: 'object' }, { type: 'function' }], optional: true },
-    controlledActions: { type: 'object', optional: true }
+    controlledActions: { type: 'object', optional: true },
+    readOnly: { type: 'boolean', optional: true }
   },
   async handler(ctx) {
     let { path, fullPath, name, podsContainer, ...options } = ctx.params;
@@ -27,7 +28,7 @@ module.exports = {
 
     if (this.settings.podProvider && podsContainer === true) {
       name = 'actors';
-      await this.broker.call('api.addRoute', { route: getResourcesRoute(this.settings.baseUrl) });
+      await this.broker.call('api.addRoute', { route: getResourcesRoute(this.settings.baseUrl, options.readOnly) });
     } else if (this.settings.podProvider) {
       // 1. Ensure the container has been created for each user
       const accounts = await ctx.call('auth.account.find');
@@ -42,14 +43,14 @@ module.exports = {
 
       // 2. Create the API route
       const containerUriWithParams = urlJoin(this.settings.baseUrl, fullPath);
-      await this.broker.call('api.addRoute', { route: getContainerRoute(containerUriWithParams) });
+      await this.broker.call('api.addRoute', { route: getContainerRoute(containerUriWithParams, options.readOnly) });
     } else {
       // 1. Ensure the container has been created
       const containerUri = urlJoin(this.settings.baseUrl, path);
       await this.createAndAttachContainer(ctx, containerUri, path);
 
       // 2. Create the API route
-      await this.broker.call('api.addRoute', { route: getContainerRoute(containerUri) });
+      await this.broker.call('api.addRoute', { route: getContainerRoute(containerUri, options.readOnly) });
     }
 
     const pathRegex = pathToRegexp(fullPath);

--- a/src/middleware/packages/ldp/services/registry/defaultOptions.js
+++ b/src/middleware/packages/ldp/services/registry/defaultOptions.js
@@ -3,6 +3,7 @@ module.exports = {
   jsonContext: null,
   queryDepth: 0,
   dereference: [],
+  readOnly: false,
   newResourcesPermissions: webId => {
     switch (webId) {
       case 'anon':

--- a/src/middleware/packages/notifications/services/digest/service.js
+++ b/src/middleware/packages/notifications/services/digest/service.js
@@ -105,7 +105,7 @@ const Service = {
               numNotifications: notifications.length,
               categories: Object.keys(notificationsByCategories),
               subscription
-            })
+            });
           }
         }
       }

--- a/website/docs/middleware/ldp/index.md
+++ b/website/docs/middleware/ldp/index.md
@@ -44,8 +44,7 @@ module.exports = {
       {
         prefix: 'ldp',
         url: 'http://www.w3.org/ns/ldp#',
-      },
-      ...
+      }
     ],
     containers: [
       {
@@ -71,13 +70,15 @@ module.exports = {
 
 ## Container options
 
-| Property | Type | Default | Description |
-| -------- | ---- | ------- | ----------- |
-| `accept` | `String` | `text/turtle` | Type to return (`application/ld+json`, `text/turtle` or `application/n-triples`) |
-| `jsonContext` | `[Any]` |  | JSON context to use to format results |
-| `dereference`| `[Array]` | `[]` | Properties to dereference, prefixed with their ontology. You can define sub-predicates separated by `/` |
-| `queryDepth` | `Integer` | 0 | Depth of blank nodes to dereference (Deprecated. Will be removed in a future minor release.) |
-| `newResourcesPermissions` | `Object` or `Function` |  | If the WebACL service is activated, permissions to add to new resources. [See the docs here](../webacl/index.md#default-permissions-for-new-resources) |
+| Property                  | Type                   | Default       | Description                                                                                                                                            |
+|---------------------------|------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `accept`                  | `String`               | `text/turtle` | Type to return (`application/ld+json`, `text/turtle` or `application/n-triples`)                                                                       |
+| `jsonContext`             | `[Any]`                |               | JSON context to use to format results                                                                                                                  |
+| `dereference`             | `[Array]`              | `[]`          | Blank nodes to dereference, prefixed with their ontology. You can define sub-predicates separated by `/`                                               |
+| `queryDepth`              | `Integer`              | 0             | Depth of blank nodes to dereference (Deprecated. Will be removed in a future minor release.)                                                           |
+| `permissions`             | `Object` or `Function` |               | If the WebACL service is activated, permissions of the container itself                                                                                |
+| `newResourcesPermissions` | `Object` or `Function` |               | If the WebACL service is activated, permissions to add to new resources. [See the docs here](../webacl/index.md#default-permissions-for-new-resources) |
+| `readOnly`                | `Boolean`              | `false`       | Do not set `POST`, `PATCH`, `PUT` and `DELETE` routes for the container and its resources                                                              |
 
 ## API routes
 
@@ -92,3 +93,4 @@ These routes are automatically added to the `ApiGateway` service.
 | `PUT /<container>/<resource>` | `ldp.resource.put` |
 | `DELETE /<container>/<resource>` | `ldp.resource.delete` |
 
+> Note: If the `readOnly` container option is set (see above), only `GET` routes are added.


### PR DESCRIPTION
Lorsque `readOnly` est `true`, n'ajoute pas les routes API autres que GET.

On peut encore appeler directement les actions.

Utile pour les instances sans WebACL, où la majorité des données sont en lecture seule, mais dans lesquelles on ne veut pas que n'importe qui puisse faire des modifications (c'est le cas pour l'instance Colibris)