### PR TITLE
Fix update single mirrored resources

### DIFF
--- a/src/middleware/packages/activitypub/services/registry.js
+++ b/src/middleware/packages/activitypub/services/registry.js
@@ -164,7 +164,6 @@ const RegistryService = {
   events: {
     async 'ldp.resource.created'(ctx) {
       const { resourceUri, newData, webId } = ctx.params;
-      if (ctx.meta.isMirror || !resourceUri) return;
       const collections = this.getCollectionsByType(newData.type || newData['@type']);
       for (let collection of collections) {
         if (this.isActor(newData.type || newData['@type'])) {
@@ -177,7 +176,6 @@ const RegistryService = {
     },
     async 'ldp.resource.updated'(ctx) {
       const { resourceUri, newData, oldData, webId } = ctx.params;
-      if (ctx.meta.isMirror || !resourceUri) return;
       // Check if we need to create collection only if the type has changed
       if (this.hasTypeChanged(oldData, newData)) {
         const collections = this.getCollectionsByType(newData.type || newData['@type']);
@@ -193,7 +191,6 @@ const RegistryService = {
     },
     async 'ldp.resource.deleted'(ctx) {
       const { oldData } = ctx.params;
-      if (ctx.meta.isMirror) return;
       const collections = this.getCollectionsByType(oldData.type || oldData['@type']);
       for (let collection of collections) {
         await this.actions.deleteCollection({ objectUri: oldData.id || oldData['@id'], collection });

--- a/src/middleware/packages/inference/service.js
+++ b/src/middleware/packages/inference/service.js
@@ -132,7 +132,6 @@ module.exports = {
     },
     async 'ldp.resource.updated'(ctx) {
       let { oldData, newData } = ctx.params;
-      if (ctx.meta.isMirror) return;
       oldData = await ctx.call('jsonld.expand', { input: oldData });
       newData = await ctx.call('jsonld.expand', { input: newData });
 

--- a/src/middleware/packages/ldp/bots/resources-watcher.js
+++ b/src/middleware/packages/ldp/bots/resources-watcher.js
@@ -22,21 +22,18 @@ module.exports = {
   events: {
     async 'ldp.resource.created'(ctx) {
       const { resourceUri, newData } = ctx.params;
-      if (ctx.meta.isMirror || !resourceUri) return;
       if (this.isMatching(resourceUri)) {
         this.resourceCreated(resourceUri, newData);
       }
     },
     async 'ldp.resource.updated'(ctx) {
       const { resourceUri, newData, oldData } = ctx.params;
-      if (ctx.meta.isMirror || !resourceUri) return;
       if (this.isMatching(resourceUri)) {
         this.resourceUpdated(resourceUri, newData, oldData);
       }
     },
     async 'ldp.resource.deleted'(ctx) {
       const { resourceUri, oldData } = ctx.params;
-      if (ctx.meta.isMirror || !resourceUri) return;
       if (this.isMatching(resourceUri)) {
         this.resourceDeleted(resourceUri, oldData);
       }

--- a/src/middleware/packages/ldp/mixins/document-tagger.js
+++ b/src/middleware/packages/ldp/mixins/document-tagger.js
@@ -57,12 +57,10 @@ module.exports = {
   events: {
     async 'ldp.resource.created'(ctx) {
       const { resourceUri, newData, webId } = ctx.params;
-      if (ctx.meta.isMirror || !resourceUri) return;
       this.actions.tagCreatedResource({ resourceUri, newData, webId }, { parentCtx: ctx });
     },
     async 'ldp.resource.updated'(ctx) {
       const { resourceUri } = ctx.params;
-      if (ctx.meta.isMirror || !resourceUri) return;
       this.actions.tagUpdatedResource({ resourceUri }, { parentCtx: ctx });
     }
   },

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -92,16 +92,13 @@ module.exports = {
                 return accumulator;
               }, {});
 
-              let resource = await ctx.call(
-                'ldp.resource.get',
-                {
-                  resourceUri,
-                  webId,
-                  forceSemantic: true,
-                  // We pass the following parameters only if they are explicit
-                  ...explicitParams
-                }
-              );
+              let resource = await ctx.call('ldp.resource.get', {
+                resourceUri,
+                webId,
+                forceSemantic: true,
+                // We pass the following parameters only if they are explicit
+                ...explicitParams
+              });
 
               // If we have a child container, remove the ldp:contains property and add a ldp:Resource type
               // We are copying SOLID: https://github.com/assemblee-virtuelle/semapps/issues/429#issuecomment-768210074

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -100,8 +100,7 @@ module.exports = {
                   forceSemantic: true,
                   // We pass the following parameters only if they are explicit
                   ...explicitParams
-                },
-                { meta: { isMirror: isMirror(resourceUri, this.settings.baseUrl) } }
+                }
               );
 
               // If we have a child container, remove the ldp:contains property and add a ldp:Resource type

--- a/src/middleware/packages/ldp/services/resource/actions/create.js
+++ b/src/middleware/packages/ldp/services/resource/actions/create.js
@@ -25,8 +25,6 @@ module.exports = {
     const resourceUri = resource.id || resource['@id'];
 
     const mirror = isMirror(resourceUri, this.settings.baseUrl);
-    if (mirror && !ctx.meta.forceMirror)
-      throw new MoleculerError('Mirrored resources cannot be created with LDP PUT', 403, 'FORBIDDEN');
 
     const { disassembly, jsonContext, controlledActions } = {
       ...(await ctx.call('ldp.registry.getByUri', { resourceUri })),
@@ -57,7 +55,7 @@ module.exports = {
       resource: contentType === MIME_TYPES.JSON ? resource : resource.body,
       contentType,
       webId,
-      graphName: mirror ? '<' + this.settings.mirrorGraphName + '>' : undefined
+      graphName: mirror ? this.settings.mirrorGraphName : undefined
     });
 
     const newData = await ctx.call(
@@ -77,7 +75,9 @@ module.exports = {
       webId
     };
 
-    ctx.emit('ldp.resource.created', returnValues, { meta: { webId: null, dataset: null, isMirror: mirror } });
+    if (!mirror) {
+      ctx.emit('ldp.resource.created', returnValues, { meta: { webId: null, dataset: null } });
+    }
 
     return returnValues;
   }

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -110,7 +110,7 @@ module.exports = {
         webId
       };
 
-      ctx.call('triplestore.deleteOrphanBlankNodes', { graph: mirror ? this.settings.mirrorGraphName : undefined });
+      ctx.call('triplestore.deleteOrphanBlankNodes', { graphName: mirror ? this.settings.mirrorGraphName : undefined });
 
       if (!mirror) {
         ctx.emit('ldp.resource.deleted', returnValues, { meta: { webId: null, dataset: null, isMirror: mirror } });

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -39,8 +39,6 @@ module.exports = {
       webId = webId || ctx.meta.webId || 'anon';
 
       const mirror = isMirror(resourceUri, this.settings.baseUrl);
-      if (mirror && !ctx.meta.forceMirror)
-        throw new MoleculerError('Mirrored resources cannot be deleted with LDP', 403, 'FORBIDDEN');
 
       const { disassembly } = {
         ...(await ctx.call('ldp.registry.getByUri', { resourceUri })),
@@ -112,9 +110,11 @@ module.exports = {
         webId
       };
 
-      ctx.call('triplestore.deleteOrphanBlankNodes', { graphName: mirror ? this.settings.mirrorGraphName : undefined });
+      ctx.call('triplestore.deleteOrphanBlankNodes', { graph: mirror ? this.settings.mirrorGraphName : undefined });
 
-      ctx.emit('ldp.resource.deleted', returnValues, { meta: { webId: null, dataset: null, isMirror: mirror } });
+      if (!mirror) {
+        ctx.emit('ldp.resource.deleted', returnValues, { meta: { webId: null, dataset: null, isMirror: mirror } });
+      }
 
       return returnValues;
     }

--- a/src/middleware/packages/ldp/services/resource/actions/exist.js
+++ b/src/middleware/packages/ldp/services/resource/actions/exist.js
@@ -15,7 +15,7 @@ module.exports = {
     triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
       uri: resourceUri,
       webId,
-      graph: isMirror(resourceUri, this.settings.baseUrl) ? this.settings.mirrorGraphName : undefined
+      graphName: isMirror(resourceUri, this.settings.baseUrl) ? this.settings.mirrorGraphName : undefined
     });
 
     return triplesNb > 0;

--- a/src/middleware/packages/ldp/services/resource/actions/exist.js
+++ b/src/middleware/packages/ldp/services/resource/actions/exist.js
@@ -15,7 +15,7 @@ module.exports = {
     triplesNb = await ctx.call('triplestore.countTriplesOfSubject', {
       uri: resourceUri,
       webId,
-      graphName: isMirror(resourceUri, this.settings.baseUrl) ? this.settings.mirrorGraphName : undefined
+      graph: isMirror(resourceUri, this.settings.baseUrl) ? this.settings.mirrorGraphName : undefined
     });
 
     return triplesNb > 0;

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -109,7 +109,7 @@ module.exports = {
           { meta: { $cache: false } }
         );
 
-        ctx.call('triplestore.deleteOrphanBlankNodes', { graph: this.settings.mirrorGraphName });
+        ctx.call('triplestore.deleteOrphanBlankNodes', { graphName: this.settings.mirrorGraphName });
       } else {
         let oldTriples = await this.bodyToTriples(oldData, MIME_TYPES.JSON);
         let newTriples = await this.bodyToTriples(body || resource, contentType);

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -52,10 +52,6 @@ module.exports = {
 
       const resourceUri = resource.id || resource['@id'];
 
-      const mirror = isMirror(resourceUri, this.settings.baseUrl);
-      if (mirror && !ctx.meta.forceMirror)
-        throw new MoleculerError('Mirrored resources cannot be modified with LDP PUT', 403, 'FORBIDDEN');
-
       const { disassembly, jsonContext } = {
         ...(await ctx.call('ldp.registry.getByUri', { resourceUri })),
         ...ctx.params
@@ -81,53 +77,25 @@ module.exports = {
         await this.updateDisassembly(ctx, disassembly, resource, oldData, 'PUT');
       }
 
-      let oldTriples = await this.bodyToTriples(oldData, MIME_TYPES.JSON);
-      let newTriples = await this.bodyToTriples(body || resource, contentType);
+      // If we put in the mirror graph, don't do a diff to increase performance
+      // We can avoid the diff because these data are not protected by WebACL
+      if (isMirror(resourceUri, this.settings.baseUrl)) {
+        await ctx.call('triplestore.update', {
+          query: `
+            DELETE
+            WHERE { 
+              GRAPH <${this.settings.mirrorGraphName}> {
+                <${resourceUri}> ?p1 ?o1 .
+              }
+            }
+          `
+        });
 
-      const blankNodesVarsMap = this.mapBlankNodesOnVars([...oldTriples, ...newTriples]);
-
-      // Filter out triples whose subject is not the resource itself
-      // We don't want to update or delete resources with IDs
-      // if it is a mirror, we allow other resources to be added here,
-      // this is useful when PUT is used on a patched container that contains remote members
-
-      if (!mirror) {
-        oldTriples = this.filterOtherNamedNodes(oldTriples, resourceUri);
-        newTriples = this.filterOtherNamedNodes(newTriples, resourceUri);
-      }
-
-      oldTriples = this.convertBlankNodesToVars(oldTriples, blankNodesVarsMap);
-      newTriples = this.convertBlankNodesToVars(newTriples, blankNodesVarsMap);
-
-      // Triples to add are reversed, so that blank nodes are linked to resource before being assigned data properties
-      // Triples to remove are not reversed, because we want to remove the data properties before unlinking it from the resource
-      // This is needed, otherwise we have permissions violations with the WebACL (orphan blank nodes cannot be edited, except as "system")
-      const triplesToAdd = this.getTriplesDifference(newTriples, oldTriples).reverse();
-      const triplesToRemove = this.getTriplesDifference(oldTriples, newTriples);
-
-      // If the exact same data have been posted, skip
-      if (triplesToAdd.length === 0 && triplesToRemove.length === 0) {
-        newData = oldData;
-      } else {
-        // Keep track of blank nodes to use in WHERE clause
-        const newBlankNodes = this.getTriplesDifference(newTriples, oldTriples).filter(
-          triple => triple.object.termType === 'Variable'
-        );
-        const existingBlankNodes = oldTriples.filter(triple => triple.object.termType === 'Variable');
-
-        // Generate the query
-        let query = '';
-        if (mirror) query += 'WITH <' + this.settings.mirrorGraphName + '> ';
-        if (triplesToRemove.length > 0) query += `DELETE { ${this.triplesToString(triplesToRemove)} } `;
-        if (triplesToAdd.length > 0) query += `INSERT { ${this.triplesToString(triplesToAdd)} } `;
-        query += 'WHERE { ';
-        if (mirror) query += 'GRAPH <' + this.settings.mirrorGraphName + '> {';
-        if (existingBlankNodes.length > 0) query += this.triplesToString(existingBlankNodes);
-        if (newBlankNodes.length > 0) query += this.bindNewBlankNodes(newBlankNodes);
-        if (mirror) query += '} ';
-        query += ` }`;
-
-        await ctx.call('triplestore.update', { query, webId });
+        await ctx.call('triplestore.insert', {
+          resource,
+          contentType,
+          graphName: this.settings.mirrorGraphName
+        });
 
         // Get the new data, with the same formatting as the old data
         // We skip the cache because it has not been invalidated yet
@@ -141,16 +109,69 @@ module.exports = {
           { meta: { $cache: false } }
         );
 
-        ctx.emit(
-          'ldp.resource.updated',
-          {
-            resourceUri,
-            oldData,
-            newData,
-            webId
-          },
-          { meta: { webId: null, dataset: null, isMirror: mirror } }
-        );
+        ctx.call('triplestore.deleteOrphanBlankNodes', { graph: this.settings.mirrorGraphName });
+      } else {
+        let oldTriples = await this.bodyToTriples(oldData, MIME_TYPES.JSON);
+        let newTriples = await this.bodyToTriples(body || resource, contentType);
+
+        const blankNodesVarsMap = this.mapBlankNodesOnVars([...oldTriples, ...newTriples]);
+
+        // Filter out triples whose subject is not the resource itself
+        // We don't want to update or delete resources with IDs
+        oldTriples = this.filterOtherNamedNodes(oldTriples, resourceUri);
+        newTriples = this.filterOtherNamedNodes(newTriples, resourceUri);
+
+        oldTriples = this.convertBlankNodesToVars(oldTriples, blankNodesVarsMap);
+        newTriples = this.convertBlankNodesToVars(newTriples, blankNodesVarsMap);
+
+        // Triples to add are reversed, so that blank nodes are linked to resource before being assigned data properties
+        // Triples to remove are not reversed, because we want to remove the data properties before unlinking it from the resource
+        // This is needed, otherwise we have permissions violations with the WebACL (orphan blank nodes cannot be edited, except as "system")
+        const triplesToAdd = this.getTriplesDifference(newTriples, oldTriples).reverse();
+        const triplesToRemove = this.getTriplesDifference(oldTriples, newTriples);
+
+        // If the exact same data have been posted, skip
+        if (triplesToAdd.length > 0 || triplesToRemove.length > 0) {
+          // Keep track of blank nodes to use in WHERE clause
+          const newBlankNodes = this.getTriplesDifference(newTriples, oldTriples).filter(
+            triple => triple.object.termType === 'Variable'
+          );
+          const existingBlankNodes = oldTriples.filter(triple => triple.object.termType === 'Variable');
+
+          // Generate the query
+          let query = '';
+          if (triplesToRemove.length > 0) query += `DELETE { ${this.triplesToString(triplesToRemove)} } `;
+          if (triplesToAdd.length > 0) query += `INSERT { ${this.triplesToString(triplesToAdd)} } `;
+          query += 'WHERE { ';
+          if (existingBlankNodes.length > 0) query += this.triplesToString(existingBlankNodes);
+          if (newBlankNodes.length > 0) query += this.bindNewBlankNodes(newBlankNodes);
+          query += ` }`;
+
+          await ctx.call('triplestore.update', {query, webId});
+
+          // Get the new data, with the same formatting as the old data
+          // We skip the cache because it has not been invalidated yet
+          newData = await ctx.call(
+            'ldp.resource.get',
+            {
+              resourceUri,
+              accept: MIME_TYPES.JSON,
+              webId
+            },
+            { meta: { $cache: false } }
+          );
+
+          ctx.emit(
+            'ldp.resource.updated',
+            {
+              resourceUri,
+              oldData,
+              newData,
+              webId
+            },
+            { meta: { webId: null, dataset: null } }
+          );
+        }
       }
 
       return {

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -147,7 +147,7 @@ module.exports = {
           if (newBlankNodes.length > 0) query += this.bindNewBlankNodes(newBlankNodes);
           query += ` }`;
 
-          await ctx.call('triplestore.update', {query, webId});
+          await ctx.call('triplestore.update', { query, webId });
 
           // Get the new data, with the same formatting as the old data
           // We skip the cache because it has not been invalidated yet

--- a/src/middleware/packages/ldp/services/resource/methods.js
+++ b/src/middleware/packages/ldp/services/resource/methods.js
@@ -22,12 +22,9 @@ module.exports = {
         let resource = await response.json();
         resource['http://semapps.org/ns/core#singleMirroredResource'] = new URL(resourceUri).origin;
 
-        await this.broker.call(
-          'ldp.resource.put',
-          { resource, contentType: MIME_TYPES.JSON }
-        );
+        await this.broker.call('ldp.resource.put', { resource, contentType: MIME_TYPES.JSON });
       } catch (e) {
-        this.logger.warn("Failed to update single mirrored resource " + single.s.value);
+        this.logger.warn('Failed to update single mirrored resource ' + single.s.value);
         console.error(e);
       }
     }

--- a/src/middleware/packages/ldp/services/resource/methods.js
+++ b/src/middleware/packages/ldp/services/resource/methods.js
@@ -18,18 +18,17 @@ module.exports = {
       try {
         const resourceUri = single.s.value;
 
-        let newResource = await fetch(resourceUri, { headers: { Accept: MIME_TYPES.TURTLE } });
-        newResource = await newResource.text();
-        newResource += ` <${resourceUri}> <http://semapps.org/ns/core#singleMirroredResource> <${
-          new URL(resourceUri).origin
-        }> .`;
+        const response = await fetch(resourceUri, { headers: { Accept: MIME_TYPES.JSON } });
+        let resource = await response.json();
+        resource['http://semapps.org/ns/core#singleMirroredResource'] = new URL(resourceUri).origin;
+
         await this.broker.call(
           'ldp.resource.put',
-          { resource: { id: resourceUri }, body: newResource, webId: 'system', contentType: MIME_TYPES.TURTLE },
-          { meta: { forceMirror: true } }
+          { resource, contentType: MIME_TYPES.JSON }
         );
       } catch (e) {
-        // fail silently
+        this.logger.warn("Failed to update single mirrored resource " + single.s.value);
+        console.error(e);
       }
     }
   },

--- a/src/middleware/packages/mirror/service.js
+++ b/src/middleware/packages/mirror/service.js
@@ -14,7 +14,7 @@ module.exports = {
   name: 'mirror',
   settings: {
     baseUrl: null,
-    mirrorGraphName: 'http://semapps.org/mirror',
+    graphName: 'http://semapps.org/mirror',
     servers: [],
     acceptFollowers: true,
     actor: {
@@ -202,7 +202,7 @@ module.exports = {
               for (const pref of prefixes) {
                 sparqlQuery += 'PREFIX ' + pref[1] + '\n';
               }
-              sparqlQuery += `INSERT DATA { GRAPH <${this.settings.mirrorGraphName}> { \n`;
+              sparqlQuery += `INSERT DATA { GRAPH <${this.settings.graphName}> { \n`;
               sparqlQuery += container.replace(regexPrefix, '');
               sparqlQuery += '} }';
 
@@ -215,7 +215,7 @@ module.exports = {
         // because we don't need to periodically watch them anymore
         let singles = await this.broker.call('triplestore.query', {
           query: `SELECT DISTINCT ?s WHERE { 
-          GRAPH <${this.settings.mirrorGraphName}> { 
+          GRAPH <${this.settings.graphName}> { 
           ?s <http://semapps.org/ns/core#singleMirroredResource> <${serverUrl}> } }`
         });
 
@@ -224,7 +224,7 @@ module.exports = {
             const resourceUri = single.s.value;
             await this.broker.call('triplestore.update', {
               webId: 'system',
-              query: `DELETE WHERE { GRAPH <${this.settings.mirrorGraphName}> { 
+              query: `DELETE WHERE { GRAPH <${this.settings.graphName}> { 
               <${resourceUri}> <http://semapps.org/ns/core#singleMirroredResource> ?q. } }`
             });
           } catch (e) {
@@ -476,8 +476,7 @@ module.exports = {
             newResource = await newResource.json();
             await ctx.call(
               'ldp.resource.create',
-              { resource: newResource, webId: 'system', contentType: MIME_TYPES.JSON },
-              { meta: { forceMirror: true } }
+              { resource: newResource, contentType: MIME_TYPES.JSON }
             );
             break;
           }
@@ -486,16 +485,14 @@ module.exports = {
             newResource = await newResource.json();
             await ctx.call(
               'ldp.resource.put',
-              { resource: newResource, webId: 'system', contentType: MIME_TYPES.JSON },
-              { meta: { forceMirror: true } }
+              { resource: newResource, contentType: MIME_TYPES.JSON },
             );
             break;
           }
           case ACTIVITY_TYPES.DELETE: {
             await ctx.call(
               'ldp.resource.delete',
-              { resourceUri: activity.object.object, webId: 'system' },
-              { meta: { forceMirror: true } }
+              { resourceUri: activity.object.object },
             );
             break;
           }

--- a/src/middleware/packages/mirror/service.js
+++ b/src/middleware/packages/mirror/service.js
@@ -474,26 +474,17 @@ module.exports = {
           case ACTIVITY_TYPES.CREATE: {
             let newResource = await fetch(activity.object.object, { headers: { Accept: MIME_TYPES.JSON } });
             newResource = await newResource.json();
-            await ctx.call(
-              'ldp.resource.create',
-              { resource: newResource, contentType: MIME_TYPES.JSON }
-            );
+            await ctx.call('ldp.resource.create', { resource: newResource, contentType: MIME_TYPES.JSON });
             break;
           }
           case ACTIVITY_TYPES.UPDATE: {
             let newResource = await fetch(activity.object.object, { headers: { Accept: MIME_TYPES.JSON } });
             newResource = await newResource.json();
-            await ctx.call(
-              'ldp.resource.put',
-              { resource: newResource, contentType: MIME_TYPES.JSON },
-            );
+            await ctx.call('ldp.resource.put', { resource: newResource, contentType: MIME_TYPES.JSON });
             break;
           }
           case ACTIVITY_TYPES.DELETE: {
-            await ctx.call(
-              'ldp.resource.delete',
-              { resourceUri: activity.object.object },
-            );
+            await ctx.call('ldp.resource.delete', { resourceUri: activity.object.object });
             break;
           }
         }

--- a/src/middleware/packages/triplestore/actions/insert.js
+++ b/src/middleware/packages/triplestore/actions/insert.js
@@ -50,7 +50,7 @@ module.exports = {
     for (let dataset of datasets) {
       if (datasets.length > 1) this.logger.info(`Inserting into dataset ${dataset}...`);
       await this.fetch(urlJoin(this.settings.sparqlEndpoint, dataset, 'update'), {
-        body: graph ? `INSERT DATA { GRAPH <${graphName}> { ${rdf} } }` : `INSERT DATA { ${rdf} }`,
+        body: graphName ? `INSERT DATA { GRAPH <${graphName}> { ${rdf} } }` : `INSERT DATA { ${rdf} }`,
         headers: {
           'Content-Type': 'application/sparql-update',
           'X-SemappsUser': webId,

--- a/src/middleware/packages/triplestore/actions/insert.js
+++ b/src/middleware/packages/triplestore/actions/insert.js
@@ -50,7 +50,7 @@ module.exports = {
     for (let dataset of datasets) {
       if (datasets.length > 1) this.logger.info(`Inserting into dataset ${dataset}...`);
       await this.fetch(urlJoin(this.settings.sparqlEndpoint, dataset, 'update'), {
-        body: graphName ? `INSERT DATA { GRAPH ${graphName} { ${rdf} } }` : `INSERT DATA { ${rdf} }`,
+        body: graph ? `INSERT DATA { GRAPH <${graphName}> { ${rdf} } }` : `INSERT DATA { ${rdf} }`,
         headers: {
           'Content-Type': 'application/sparql-update',
           'X-SemappsUser': webId,

--- a/src/middleware/packages/webacl/middlewares/webacl.js
+++ b/src/middleware/packages/webacl/middlewares/webacl.js
@@ -1,5 +1,5 @@
 const { throw403 } = require('@semapps/middlewares');
-const { getContainerFromUri } = require('../utils');
+const { getContainerFromUri, isMirror } = require('../utils');
 const { defaultContainerRights, defaultCollectionRights } = require('../defaultRights');
 
 const modifyActions = [
@@ -54,10 +54,11 @@ const addRightsToNewUser = async (ctx, userUri) => {
 // TODO invalidate this cache when default permissions are changed
 let containersWithDefaultAnonRead = [];
 
-const WebAclMiddleware = config => ({
+const WebAclMiddleware = ({ baseUrl, podProvider = false, graphName = 'http://semapps.org/webacl' }) => ({
   name: 'WebAclMiddleware',
   async started(broker) {
-    if (!config.podProvider) {
+    if( !baseUrl ) throw new Error('The baseUrl config is missing for the WebACL middleware');
+    if (!podProvider) {
       const containers = await broker.call('ldp.container.getAll');
       for (let containerUri of containers) {
         const authorizations = await broker.call('triplestore.query', {
@@ -67,7 +68,7 @@ const WebAclMiddleware = config => ({
           PREFIX foaf: <http://xmlns.com/foaf/0.1/>
           SELECT ?auth
           WHERE {
-            GRAPH <http://semapps.org/webacl> {
+            GRAPH <${graphName}> {
               ?auth a acl:Authorization ;
                 acl:default <${containerUri}> ;
                 acl:agentClass foaf:Agent ;
@@ -104,15 +105,16 @@ const WebAclMiddleware = config => ({
 
         const resourceUri = ctx.params.resourceUri || ctx.params.resource.id || ctx.params.resource['@id'];
 
-        if (ctx.meta.isMirror) return bypass();
-
-        // If the logged user is fetching is own POD, bypass ACL check
-        // End with a trailing slash, otherwise "bob" will have access to the pod of "bobby" !
-        if (config.podProvider && resourceUri.startsWith(webId + '/')) {
+        // Bypass if mirrored resource as WebACL are not activated in mirror graph
+        if (isMirror(resourceUri, baseUrl)) {
           return bypass();
         }
 
-        // if mirrored resource, bypass
+        // If the logged user is fetching is own POD, bypass ACL check
+        // End with a trailing slash, otherwise "bob" will have access to the pod of "bobby" !
+        if (podProvider && resourceUri.startsWith(webId + '/')) {
+          return bypass();
+        }
 
         const containerUri = getContainerFromUri(resourceUri);
         if (containersWithDefaultAnonRead.includes(containerUri)) {
@@ -141,7 +143,8 @@ const WebAclMiddleware = config => ({
          */
         switch (action.name) {
           case 'ldp.resource.create':
-            if (ctx.meta.forceMirror) return next(ctx);
+            // Do not add ACLs if this is a mirrored resource as WebACL are not activated on the mirror graph
+            if (isMirror(ctx.params.resource['@id'] || ctx.params.resource.id, baseUrl)) return next(ctx);
             // We must add the permissions before inserting the resource
             await addRightsToNewResource(ctx, ctx.params.resource['@id'] || ctx.params.resource.id, webId);
             break;

--- a/src/middleware/packages/webacl/middlewares/webacl.js
+++ b/src/middleware/packages/webacl/middlewares/webacl.js
@@ -57,7 +57,7 @@ let containersWithDefaultAnonRead = [];
 const WebAclMiddleware = ({ baseUrl, podProvider = false, graphName = 'http://semapps.org/webacl' }) => ({
   name: 'WebAclMiddleware',
   async started(broker) {
-    if( !baseUrl ) throw new Error('The baseUrl config is missing for the WebACL middleware');
+    if (!baseUrl) throw new Error('The baseUrl config is missing for the WebACL middleware');
     if (!podProvider) {
       const containers = await broker.call('ldp.container.getAll');
       for (let containerUri of containers) {

--- a/src/middleware/packages/webacl/service.js
+++ b/src/middleware/packages/webacl/service.js
@@ -7,7 +7,7 @@ module.exports = {
   name: 'webacl',
   settings: {
     baseUrl: null,
-    graphName: '<http://semapps.org/webacl>',
+    graphName: 'http://semapps.org/webacl',
     podProvider: false,
     superAdmins: []
   },
@@ -45,7 +45,7 @@ module.exports = {
       let hasWebAcl = false;
       try {
         await this.broker.call('triplestore.query', {
-          query: `ASK WHERE { GRAPH ${this.settings.graphName} { ?s ?p ?o } }`,
+          query: `ASK WHERE { GRAPH <${this.settings.graphName}> { ?s ?p ?o } }`,
           webId: 'anon'
         });
       } catch (e) {

--- a/src/middleware/packages/webacl/services/group/actions/addMember.js
+++ b/src/middleware/packages/webacl/services/group/actions/addMember.js
@@ -51,7 +51,7 @@ module.exports = {
 
       await ctx.call('triplestore.update', {
         query: `PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-        INSERT DATA { GRAPH ${this.settings.graphName}
+        INSERT DATA { GRAPH <${this.settings.graphName}>
           { <${groupUri}> vcard:hasMember <${memberUri}> } }`,
         webId: 'system'
       });

--- a/src/middleware/packages/webacl/services/group/actions/create.js
+++ b/src/middleware/packages/webacl/services/group/actions/create.js
@@ -62,7 +62,7 @@ module.exports = {
       await ctx.call('triplestore.update', {
         query: `
           PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-          INSERT DATA { GRAPH ${this.settings.graphName}
+          INSERT DATA { GRAPH <${this.settings.graphName}>
           { <${groupUri}> a vcard:Group } }`,
         webId: 'system'
       });

--- a/src/middleware/packages/webacl/services/group/actions/delete.js
+++ b/src/middleware/packages/webacl/services/group/actions/delete.js
@@ -44,7 +44,7 @@ module.exports = {
 
       // Deleting the group
       await ctx.call('triplestore.update', {
-        query: `DELETE WHERE { GRAPH ${this.settings.graphName} 
+        query: `DELETE WHERE { GRAPH <${this.settings.graphName}> 
                 { <${groupUri}> ?p ?o. } }`,
         webId: 'system'
       });

--- a/src/middleware/packages/webacl/services/group/actions/exist.js
+++ b/src/middleware/packages/webacl/services/group/actions/exist.js
@@ -19,7 +19,7 @@ module.exports = {
         query: `
           PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
           ASK
-          WHERE { GRAPH ${this.settings.graphName} {
+          WHERE { GRAPH <${this.settings.graphName}> {
             <${groupUri}> a vcard:Group .
           } }
         `,

--- a/src/middleware/packages/webacl/services/group/actions/getGroups.js
+++ b/src/middleware/packages/webacl/services/group/actions/getGroups.js
@@ -20,7 +20,7 @@ module.exports = {
             PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
             PREFIX acl: <http://www.w3.org/ns/auth/acl#>
             PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            SELECT ?g WHERE { GRAPH ${this.settings.graphName}
+            SELECT ?g WHERE { GRAPH <${this.settings.graphName}>
             { ?g a vcard:Group.
               ?auth a acl:Authorization;
                 acl:mode acl:Read;
@@ -35,7 +35,7 @@ module.exports = {
       } else {
         groups = await ctx.call('triplestore.query', {
           query: `PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-            SELECT ?g WHERE { GRAPH ${this.settings.graphName}
+            SELECT ?g WHERE { GRAPH <${this.settings.graphName}>
             { ?g a vcard:Group } }`,
           webId: 'system'
         });

--- a/src/middleware/packages/webacl/services/group/actions/getMembers.js
+++ b/src/middleware/packages/webacl/services/group/actions/getMembers.js
@@ -41,7 +41,7 @@ module.exports = {
 
       let members = await ctx.call('triplestore.query', {
         query: `PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-          SELECT ?m WHERE { GRAPH ${this.settings.graphName}
+          SELECT ?m WHERE { GRAPH <${this.settings.graphName}>
           { <${groupUri}> vcard:hasMember ?m } }`,
         webId: 'system'
       });

--- a/src/middleware/packages/webacl/services/group/actions/isMember.js
+++ b/src/middleware/packages/webacl/services/group/actions/isMember.js
@@ -42,7 +42,7 @@ module.exports = {
       return await ctx.call('triplestore.query', {
         query: `PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
           ASK
-          WHERE { GRAPH ${this.settings.graphName} {
+          WHERE { GRAPH <${this.settings.graphName}> {
             <${groupUri}> vcard:hasMember <${memberId}> .
           } }
           `,

--- a/src/middleware/packages/webacl/services/group/actions/removeMember.js
+++ b/src/middleware/packages/webacl/services/group/actions/removeMember.js
@@ -51,7 +51,7 @@ module.exports = {
 
       await ctx.call('triplestore.update', {
         query: `PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-        DELETE DATA { GRAPH ${this.settings.graphName}
+        DELETE DATA { GRAPH <${this.settings.graphName}>
           { <${groupUri}> vcard:hasMember <${memberUri}> } }`,
         webId: 'system'
       });

--- a/src/middleware/packages/webacl/services/resource/actions/deleteAllRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/deleteAllRights.js
@@ -11,7 +11,7 @@ module.exports = {
 
       await ctx.call('triplestore.update', {
         query: `PREFIX acl: <http://www.w3.org/ns/auth/acl#>
-        WITH ${this.settings.graphName}
+        WITH <${this.settings.graphName}>
         DELETE { ?auth ?p2 ?o }
         WHERE  { ?auth ?p <${resourceUri}>.
           FILTER (?p IN (acl:accessTo, acl:default ) )

--- a/src/middleware/packages/webacl/services/resource/actions/removeRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/removeRights.js
@@ -36,7 +36,7 @@ module.exports = {
         query: `
           PREFIX acl: <http://www.w3.org/ns/auth/acl#>
           DELETE DATA {
-            GRAPH ${this.settings.graphName} {
+            GRAPH <${this.settings.graphName}> {
               ${processedRights.map(right => `<${right.auth}> <${right.p}> <${right.o}> .`).join('\n')}
             }
           }

--- a/src/middleware/packages/webacl/services/resource/actions/setRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/setRights.js
@@ -101,7 +101,7 @@ module.exports = {
 
       // we do the 2 calls in one, so it is in the same transaction, and will rollback in case of failure.
       await ctx.call('triplestore.update', {
-        query: `INSERT DATA { GRAPH ${this.settings.graphName} { ${addRequest} } }; DELETE DATA { GRAPH ${this.settings.graphName} { ${deleteRequest} } }`,
+        query: `INSERT DATA { GRAPH <${this.settings.graphName}> { ${addRequest} } }; DELETE DATA { GRAPH <${this.settings.graphName}> { ${deleteRequest} } }`,
         webId: 'system'
       });
 

--- a/src/middleware/packages/webacl/utils.js
+++ b/src/middleware/packages/webacl/utils.js
@@ -276,6 +276,10 @@ const processRights = (rights, aclUri) => {
   return list;
 };
 
+const isMirror = (resourceUri, baseUrl) => {
+  return !urlJoin(resourceUri, '/').startsWith(baseUrl);
+};
+
 module.exports = {
   getSlugFromUri,
   getContainerFromUri,
@@ -302,5 +306,6 @@ module.exports = {
   FULL_AGENT_URI,
   FULL_AGENT_GROUP,
   FULL_FOAF_AGENT,
-  FULL_ACL_ANYAGENT
+  FULL_ACL_ANYAGENT,
+  isMirror
 };

--- a/src/middleware/packages/webacl/utils.js
+++ b/src/middleware/packages/webacl/utils.js
@@ -26,7 +26,7 @@ const USER_GROUPS_QUERY = (member, ACLGraphName) => {
   return `SELECT ?group
   WHERE {
 	{ ?group vcard:hasMember <${member}> . }
-	UNION { GRAPH ${ACLGraphName} { ?group vcard:hasMember <${member}> . } }
+	UNION { GRAPH <${ACLGraphName}> { ?group vcard:hasMember <${member}> . } }
   UNION
    {
     ?group ?anyLink <${member}> .
@@ -55,7 +55,7 @@ const getUserGroups = async (ctx, user, graphName) => {
 };
 
 const AUTHORIZATION_NODE_QUERY = (mode, accesToOrDefault, resource, graphName) => `SELECT ?auth ?p ?o
-WHERE { GRAPH ${graphName} {
+WHERE { GRAPH <${graphName}> {
   ?auth a acl:Authorization ;
     acl:mode acl:${mode};
     acl:${accesToOrDefault} <${resource}>;
@@ -148,7 +148,7 @@ async function aclGroupExists(groupUri, ctx, graphName) {
     query: `
       PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
       ASK
-      WHERE { GRAPH ${graphName} {
+      WHERE { GRAPH <${graphName}> {
         <${groupUri}> a vcard:Group .
       } }
     `,
@@ -224,14 +224,14 @@ async function removeAgentGroupOrAgentFromAuthorizations(uri, isGroup, graphName
   // removing the acl:agentGroup relation to some Authorizations
   await ctx.call('triplestore.update', {
     query: `PREFIX acl: <http://www.w3.org/ns/auth/acl#>
-      DELETE WHERE { GRAPH ${graphName} { ?auth ${isGroup ? 'acl:agentGroup' : 'acl:agent'} <${uri}> }}`,
+      DELETE WHERE { GRAPH <${graphName}> { ?auth ${isGroup ? 'acl:agentGroup' : 'acl:agent'} <${uri}> }}`,
     webId: 'system'
   });
 
   // removing the Authorizations that are now empty
   await ctx.call('triplestore.update', {
     query: `PREFIX acl: <http://www.w3.org/ns/auth/acl#>
-      WITH ${graphName}
+      WITH <${graphName}>
       DELETE { ?auth ?p ?o }
       WHERE { ?auth a acl:Authorization; ?p ?o
         FILTER NOT EXISTS { ?auth acl:agent ?z }

--- a/website/docs/middleware/webacl/index.md
+++ b/website/docs/middleware/webacl/index.md
@@ -53,7 +53,11 @@ const { WebAclMiddleware } = require('@semapps/webacl');
 
 module.exports = {
   middlewares: [
-    WebAclMiddleware
+    WebAclMiddleware({
+      baseUrl: 'http://localhost:3000/', // Should be the same as the WebAclService
+      podProvider: false, // Default value
+      graphName: 'http://semapps.org/webacl' // Default value
+    })
   ]
 };
 ```
@@ -86,8 +90,12 @@ const { WebAclMiddleware, CacherMiddleware } = require('@semapps/webacl');
 
 module.exports = {
   middlewares: [
-    CacherMiddleware(...cacherConfig)
-    WebAclMiddleware,
+    CacherMiddleware(...cacherConfig),
+    WebAclMiddleware({
+      baseUrl: 'http://localhost:3000/',
+      podProvider: false, // Default value
+      graphName: 'http://semapps.org/webacl' // Default value
+    })
   ]
 };
 ```


### PR DESCRIPTION
Closes https://github.com/assemblee-virtuelle/semapps/issues/1000

Pour améliorer les performances de LDP PUT lorsqu'il s'agit de données miroir, j'ai modifié l'action `ldp.resource.put` pour qu'elle agisse différemment lorsqu'il s'agit de données miroirs. En effet, comme il n'y a pas de droits ACL (et donc pas à s'occuper de `acl:Append`), on peut simplement supprimer la resource et la réinsérer.

Je me suis pas occupé de refactorer LDP PATCH puisqu'elle n'est pas utilisée et va être supprimée prochainement.

J'ai aussi fait d'autres améliorations listées ci-dessous en commentaires.

## Breaking changes

Le WebAclMiddleware est une fonction depuis quelques temps. Pour Archipelago et d'autres instances, on le configurait encore comme ça:

```
  middlewares: [
    CacherMiddleware(cacherConfig), // Set the cacher before the WebAcl middleware
    WebAclMiddleware
  ]
```

alors qu'en réalité il fallait le configurer comme ça:

```
  middlewares: [
    CacherMiddleware(cacherConfig), // Set the cacher before the WebAcl middleware
    WebAclMiddleware()
  ]
```

Le résultat était que le middleware ne fonctionnait pas correctement, même si Moleculer n'affichait pas d'erreurs. Avec cette PR, j'impose de passer un paramètre `baseUrl`:

```
  middlewares: [
    CacherMiddleware(cacherConfig), // Set the cacher before the WebAcl middleware
    WebAclMiddleware({ baseUrl: 'http:localhost:3000/' })
  ]
```

Si vous ne le passez pas, vous aurez une erreur `The baseUrl config is missing for the WebACL middleware`
