### PR TITLE
BugFixes_for_reification_in_archipelago

### DIFF
--- a/src/frontend/packages/field-components/src/AvatarWithLabelField.js
+++ b/src/frontend/packages/field-components/src/AvatarWithLabelField.js
@@ -69,8 +69,8 @@ const AvatarWithLabelField = ({
           src={computedImage || computedFallback}
           alt={computedLabel}
           fallback={computedFallback}
-          className={classes.avatar}
           {...rest}
+          className={classes.avatar}
         />
       </div>
       {externalLink ? (

--- a/src/frontend/packages/list-components/src/GridList.js
+++ b/src/frontend/packages/list-components/src/GridList.js
@@ -26,7 +26,7 @@ const GridList = ({ children, linkType, externalLinks, spacing, xs, sm, md, lg, 
             <a href={externalLink} target="_blank" rel="noopener noreferrer" onClick={stopPropagation}>
               {React.cloneElement(React.Children.only(children), {
                 record: data[id],
-                basePath,
+                basePath : children.props.basePath||basePath,
                 externalLink: true,
                 // Workaround to force ChipField to be clickable
                 onClick: handleClick
@@ -38,7 +38,7 @@ const GridList = ({ children, linkType, externalLinks, spacing, xs, sm, md, lg, 
             <Link to={linkToRecord(basePath, id, linkType)} onClick={stopPropagation}>
               {React.cloneElement(React.Children.only(children), {
                 record: data[id],
-                basePath,
+                basePath : children.props.basePath||basePath,
                 // Workaround to force ChipField to be clickable
                 onClick: handleClick
               })}
@@ -47,7 +47,7 @@ const GridList = ({ children, linkType, externalLinks, spacing, xs, sm, md, lg, 
         } else {
           child = React.cloneElement(React.Children.only(children), {
             record: data[id],
-            basePath
+            basePath : children.props.basePath||basePath
           });
         }
 

--- a/src/frontend/packages/semantic-data-provider/src/hooks/useGetExternalLink.js
+++ b/src/frontend/packages/semantic-data-provider/src/hooks/useGetExternalLink.js
@@ -28,6 +28,8 @@ const useGetExternalLink = componentExternalLinks => {
       // If the component explicitly asks not to display as external links, use an internal link
       if (computedComponentExternalLinks === false) return false;
 
+      if (!(record?.id)) return false;
+
       const serverBaseUrl = Object.keys(serversExternalLinks).find(baseUrl => record?.id.startsWith(baseUrl));
       // If no matching data servers could be found, assume we have an internal link
       if (!serverBaseUrl) return false;


### PR DESCRIPTION
Gridlist utilise listContext et force le basPAth aux children. Ces children peuvent avoir un basePath différents de la liste principale notament dans le cas ou un ArrayField qui contient des objet d'un autre type de ressource. C'est le cas pour les relations réifiées sur archipelago.

Le className de l'Avatar de AvatarWithLabelField doit être surchargé quoi qu'il arrive notamment su un composant supérieur comme RArefernce set une props className. C'est le cas pour les relations réifiées sur archipelago.

useGetExternalLink doit supporter les record sans id et renvoyer false dans ce cas. cela arrive lors que GrildList est utilisé sur dans propriété de record à desassembly par le serveur et que c'est objets n'ont pas encore d'id. C'est le cas pour les relations réifiées sur archipelago.
