### PR TITLE
1003 better semantics for activitpub mirror service

### DIFF
--- a/src/middleware/packages/activitypub/services/relay.js
+++ b/src/middleware/packages/activitypub/services/relay.js
@@ -257,7 +257,7 @@ const RelayService = {
         async getFollowers() {
             return [this.relayFollowersUri, PUBLIC_URI];
         },
-        prepare_triple(expanded_activity) {
+        prepareTriple(expanded_activity) {
             let triple = expanded_activity[0]['https://www.w3.org/ns/activitystreams#object']?.[0]?.['https://www.w3.org/ns/activitystreams#object']?.[0];
             if (triple) {
                 triple.subject = triple['https://www.w3.org/ns/activitystreams#subject']?.[0]?.['@id'];
@@ -286,7 +286,7 @@ const RelayService = {
                                 return;
                             }
                         }
-                        let triple = this.prepare_triple(expanded_activity);
+                        let triple = this.prepareTriple(expanded_activity);
                         if (triple) {
                             if (isMirror(triple.subject, this.settings.baseUri)) {
                                 this.logger.warn('Attempt at offering an inverse relationship on a mirrored resource. aborting');
@@ -311,7 +311,8 @@ const RelayService = {
                         let newResource = await fetch(activity.object.object, { headers: { Accept: MIME_TYPES.JSON } });
                         newResource = await newResource.json();
                         await ctx.call('ldp.resource.create', { resource: newResource, contentType: MIME_TYPES.JSON });
-                        await ctx.call('ldp.container.attach', { containerUri: activity.object.target, resourceUri: activity.object.object }, { meta: { forceMirror: true } });
+                        if (activity.object.target)
+                            await ctx.call('ldp.container.attach', { containerUri: activity.object.target, resourceUri: activity.object.object }, { meta: { forceMirror: true } });
                         break;
                     }
                     case ACTIVITY_TYPES.UPDATE: {
@@ -327,7 +328,7 @@ const RelayService = {
                     case ACTIVITY_TYPES.ADD: {
                         const relation = activity.object.object;
                         if (relation.type != OBJECT_TYPES.RELATIONSHIP) break;
-                        let triple = this.prepare_triple(expanded_activity);
+                        let triple = this.prepareTriple(expanded_activity);
                         if (triple)
                             await ctx.call('ldp.container.attach', { containerUri: triple.subject, resourceUri: triple.object }, { meta: { forceMirror: true } });
                         break;
@@ -335,7 +336,7 @@ const RelayService = {
                     case ACTIVITY_TYPES.REMOVE: {
                         const relation = activity.object.object;
                         if (relation.type != OBJECT_TYPES.RELATIONSHIP) break;
-                        let triple = this.prepare_triple(expanded_activity);
+                        let triple = this.prepareTriple(expanded_activity);
                         if (triple)
                             await ctx.call('ldp.container.detach', { containerUri: triple.subject, resourceUri: triple.object }, { meta: { forceMirror: true } });
                         break;

--- a/src/middleware/packages/inference/service.js
+++ b/src/middleware/packages/inference/service.js
@@ -19,7 +19,6 @@ module.exports = {
         this.inverseRelations = { ...this.inverseRelations, ...result };
       }
     }
-    console.log(this.inverseRelations)
     const services = await this.broker.call('$node.services');
     if (services.map(s => s.name).filter(s => s.startsWith('activitypub.relay')).length) {
       this.hasRelayService = true;

--- a/src/middleware/packages/ldp/services/container/actions/clear.js
+++ b/src/middleware/packages/ldp/services/container/actions/clear.js
@@ -26,6 +26,8 @@ module.exports = {
       webId
     });
 
+    // TODO: emit an event that will be handled by mirror service.
+
     ctx.call('triplestore.deleteOrphanBlankNodes');
   }
 };

--- a/src/middleware/packages/ldp/services/container/actions/detach.js
+++ b/src/middleware/packages/ldp/services/container/actions/detach.js
@@ -43,7 +43,7 @@ module.exports = {
       dataset
     });
 
-    ctx.emit(
+    if (!mirror) ctx.emit(
       'ldp.container.detached',
       {
         containerUri,

--- a/src/middleware/packages/ldp/services/container/actions/patch.js
+++ b/src/middleware/packages/ldp/services/container/actions/patch.js
@@ -86,9 +86,8 @@ module.exports = {
                     }
                     turtleToSparql += `INSERT DATA { GRAPH <${this.settings.mirrorGraphName}> { \n`;
                     turtleToSparql += newResource.replace(regexPrefix, '');
-                    turtleToSparql += `<${insUri}> <http://semapps.org/ns/core#singleMirroredResource> <${
-                      new URL(insUri).origin
-                    }> .`;
+                    turtleToSparql += `<${insUri}> <http://semapps.org/ns/core#singleMirroredResource> <${new URL(insUri).origin
+                      }> .`;
                     turtleToSparql += '} }';
 
                     await ctx.call('triplestore.update', { query: turtleToSparql });
@@ -110,7 +109,7 @@ module.exports = {
               try {
                 await ctx.call('ldp.container.detach', { containerUri, resourceUri: delUri });
 
-                // if the resource is attached to any container, it must be deleted.
+                // if the resource is not attached to any container anymore, it must be deleted.
 
                 let remaining = await ctx.call('triplestore.query', {
                   query: `SELECT (COUNT (?s) as ?count) WHERE { ?s <http://www.w3.org/ns/ldp#contains> <${delUri}> }`

--- a/src/middleware/packages/ldp/services/container/actions/post.js
+++ b/src/middleware/packages/ldp/services/container/actions/post.js
@@ -115,23 +115,24 @@ module.exports = {
         // Re-throw the error so that it's displayed by the API function
         throw e;
       }
+      // console.log("emit ldp.container.attached")
+      // ctx.emit(
+      //   'ldp.container.attached',
+      //   {
+      //     containerUri,
+      //     resourceUri
+      //   },
+      //   { meta: { webId: null, dataset: null } }
+      // );
 
+      // this is usefull to propagate the attachement to mirroring servers.
+      // we prefer not to use the event ldp.container.attached and ldp.resource.created for that purpose
+      // (because the order in which they arrive to mirroring servers is unknwon and leas to race condition)
       ctx.emit(
-        'ldp.container.attached',
+        'ldp.container.posted',
         {
           containerUri,
           resourceUri
-        },
-        { meta: { webId: null, dataset: null } }
-      );
-
-      // this is usefull to propagate the attachement to mirroring servers.
-      // we prefer not to use the event ldp.container.attached for that purpose
-      // (because it would trigger too many activities in case of a long PATCH)
-      ctx.emit(
-        'ldp.container.patched',
-        {
-          containerUri
         },
         { meta: { webId: null, dataset: null } }
       );

--- a/src/middleware/packages/ldp/services/container/actions/post.js
+++ b/src/middleware/packages/ldp/services/container/actions/post.js
@@ -115,24 +115,13 @@ module.exports = {
         // Re-throw the error so that it's displayed by the API function
         throw e;
       }
-      // console.log("emit ldp.container.attached")
-      // ctx.emit(
-      //   'ldp.container.attached',
-      //   {
-      //     containerUri,
-      //     resourceUri
-      //   },
-      //   { meta: { webId: null, dataset: null } }
-      // );
 
-      // this is usefull to propagate the attachement to mirroring servers.
-      // we prefer not to use the event ldp.container.attached and ldp.resource.created for that purpose
-      // (because the order in which they arrive to mirroring servers is unknwon and leas to race condition)
       ctx.emit(
-        'ldp.container.posted',
+        'ldp.container.attached',
         {
           containerUri,
-          resourceUri
+          resourceUri,
+          fromContainerPost: true,
         },
         { meta: { webId: null, dataset: null } }
       );

--- a/src/middleware/packages/mirror/service.js
+++ b/src/middleware/packages/mirror/service.js
@@ -224,7 +224,7 @@ module.exports = {
         (await this.checkResourcePublic(containerUri)) &&
         !isMirror(containerUri, this.settings.baseUrl)
       ) {
-        this.resourceContainer(containerUri, resourceUri, true);
+        this.resourceContainerUpdated(containerUri, resourceUri, true);
       }
     },
     async 'ldp.container.detached'(ctx) {
@@ -234,7 +234,7 @@ module.exports = {
         (await this.checkResourcePublic(containerUri)) &&
         !isMirror(containerUri, this.settings.baseUrl)
       ) {
-        this.resourceContainer(containerUri, resourceUri, false);
+        this.resourceContainerUpdated(containerUri, resourceUri, false);
       }
     },
     async 'ldp.resource.deleted'(ctx) {
@@ -352,7 +352,7 @@ module.exports = {
         }
       });
     },
-    async resourceContainer(containerUri, resourceUri, attach) {
+    async resourceContainerUpdated(containerUri, resourceUri, attach) {
       const AnnounceActivity = await this.broker.call('activitypub.relay.postToFollowers', {
         activity: {
           type: ACTIVITY_TYPES.ANNOUNCE,

--- a/src/middleware/packages/mirror/service.js
+++ b/src/middleware/packages/mirror/service.js
@@ -200,7 +200,7 @@ module.exports = {
     async 'ldp.container.posted'(ctx) {
       const { resourceUri, containerUri } = ctx.params;
       if (
-        !this.containerExcludedFromMirror(resourceUri) &&
+        !this.containerExcludedFromMirror(containerUri) &&
         (await this.checkResourcePublic(resourceUri)) &&
         !isMirror(resourceUri, this.settings.baseUrl)
       ) {

--- a/src/middleware/packages/mirror/service.js
+++ b/src/middleware/packages/mirror/service.js
@@ -197,16 +197,6 @@ module.exports = {
     }
   },
   events: {
-    async 'ldp.container.posted'(ctx) {
-      const { resourceUri, containerUri } = ctx.params;
-      if (
-        !this.containerExcludedFromMirror(containerUri) &&
-        (await this.checkResourcePublic(resourceUri)) &&
-        !isMirror(resourceUri, this.settings.baseUrl)
-      ) {
-        this.resourceCreated(containerUri, resourceUri);
-      }
-    },
     async 'ldp.resource.updated'(ctx) {
       const { resourceUri, newData, oldData } = ctx.params;
       if (
@@ -218,8 +208,17 @@ module.exports = {
       }
     },
     async 'ldp.container.attached'(ctx) {
-      const { containerUri, resourceUri } = ctx.params;
-      if (
+      const { containerUri, resourceUri, fromContainerPost } = ctx.params;
+      if (fromContainerPost) {
+        // we use the attached to container event to detect the creation of a new resource
+        if (
+          !this.containerExcludedFromMirror(containerUri) &&
+          (await this.checkResourcePublic(resourceUri)) &&
+          !isMirror(resourceUri, this.settings.baseUrl)
+        ) {
+          this.resourceCreated(containerUri, resourceUri);
+        }
+      } else if (
         !this.containerExcludedFromMirror(containerUri) &&
         (await this.checkResourcePublic(containerUri)) &&
         !isMirror(containerUri, this.settings.baseUrl)


### PR DESCRIPTION
fixes #1003 

The semantic is now following the specs.
One exception: When a new Resource is POSTed to a container, we cannot send 2 Activities (CREATE and the ADD RELATIONSHIP) why? because the order in which they arrive on the mirroring server is unknown, and can change depending on when the asynchronous HTTP requests are made between the 2 Relay actors. So... I had to bend a bit the specs.
The CREATE activity contains now an additional `target` member, that tells to which container to add the resource. And only this activity is sent (the ADD RELATIONSHIP is not sent)