### PR TITLE
CoreService: update default PAIR ontology from 2020-winter to 2021-summer

### DIFF
--- a/src/middleware/packages/core/config/ontologies.json
+++ b/src/middleware/packages/core/config/ontologies.json
@@ -61,7 +61,7 @@
   },
   {
     "prefix": "pair",
-    "owl": "http://virtual-assembly.org/ontologies/pair-2020-winter/ontology.ttl",
+    "owl": "http://virtual-assembly.org/ontologies/pair-2021-summer/ontology.ttl",
     "url": "http://virtual-assembly.org/ontologies/pair#"
   },
   {


### PR DESCRIPTION
close #1082 
Le fichier src/middleware/packages/core/config/ontologies.json contenait encore l'ancienne version de l'ontologie : http://virtual-assembly.org/ontologies/pair-2020-winter/ontology.ttl, au lieu de la nouvelle http://virtual-assembly.org/ontologies/pair-2021-summer/ontology.ttl, ce qui pouvait notemment créer des problèmes de relations inverses, non déclarées dans l'ontologie.
