### PR TITLE
adding string check  if sparqlwhere come from uri

### DIFF
--- a/src/frontend/packages/semantic-data-provider/src/dataProvider/utils/fetchSparqlEndpoints.js
+++ b/src/frontend/packages/semantic-data-provider/src/dataProvider/utils/fetchSparqlEndpoints.js
@@ -28,7 +28,10 @@ const fetchSparqlEndpoints = async (containers, resourceId, params, config) => {
           getBlankNodesFromDataServers(containers[serverKey], dataServers);
 
         const predicates = params.filter?._predicates || dataModel.list?.predicates;
-
+        //When the sparql request come from URI, it's a string who must must be decode.
+        if (params.filter.sparqlWhere && (typeof params.filter.sparqlWhere === 'string' || params.filter.sparqlWhere instanceof String)) {
+          params.filter.sparqlWhere = JSON.parse(decodeURIComponent(params.filter.sparqlWhere));
+        }
         const sparqlQuery = buildSparqlQuery({
           containers: containers[serverKey],
           params: { ...params, filter: { ...dataModel.list?.filter, ...params.filter } },


### PR DESCRIPTION
le query param filter doit pouvoir supporter un attribut sparqlwhere. Cela fonctionnait en appel du dataprovider getList par hook, mais pas par query params d'url.

fix : parse du query param si filter sparqlwhere