### PR TITLE
Anonymize SSO users webId

### DIFF
--- a/src/middleware/packages/auth/mixins/auth.sso.js
+++ b/src/middleware/packages/auth/mixins/auth.sso.js
@@ -1,4 +1,5 @@
 const session = require('express-session');
+const { v4: uuidv4 } = require('uuid');
 const AuthMixin = require('./auth');
 const saveRedirectUrl = require('../middlewares/saveRedirectUrl');
 const redirectToFront = require('../middlewares/redirectToFront');
@@ -43,7 +44,7 @@ const AuthSSOMixin = {
         accountData = await ctx.call('auth.account.create', {
           uuid: profileData.uuid,
           email: profileData.email,
-          username: profileData.username
+          username: profileData.username || uuidv4(),
         });
         webId = await ctx.call('webid.create', this.pickWebIdData({ nick: accountData.username, ...profileData }));
         newUser = true;

--- a/src/middleware/packages/auth/package.json
+++ b/src/middleware/packages/auth/package.json
@@ -20,7 +20,8 @@
     "passport-cas2": "0.0.12",
     "passport-local": "^1.0.0",
     "pug": "^3.0.2",
-    "url-join": "^4.0.1"
+    "url-join": "^4.0.1",
+    "uuid": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/middleware/yarn.lock
+++ b/src/middleware/yarn.lock
@@ -10268,6 +10268,11 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 valid-data-url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/valid-data-url/-/valid-data-url-2.0.0.tgz#2220fa9f8d4e761ebd3f3bb02770f1212b810537"


### PR DESCRIPTION
**Tension :** 

Le problème se pose sur Archipelago. Lorsqu'un utilisateur s'inscrit via SSO (par exemple via LesCommuns), seules les données suivantes sont transmises (email, prénom, nom). Lors du processus d'inscription, une ressource lui est créée (entité Person), avec un webId dont l'identifiant est généré à partir de l'email de l'utilisateur (potentiellement suffixée).

Plusieurs problèmes se posent avec cette approche : 
- Un premier souci de sécurité : On peut ainsi inférer l'email de l'utilisateur à partir de son identifiant (en rajoutant des domaines génériques de type @gmail.com, @outlook.com, etc.)
- Un second souci de sécurité : Il se peut que l'utilisateur s'inscrive avec un email contenant des données personnelles, par exemple son nom de famille en entier, et qu'il veuille utiliser l'outil en masquant son identité complète.
- Un souci "esthétique" : L'email peut ne pas correspondre du tout avec la personne, par exemple des personnes peuvent s'inscrire avec des emails de type "contact@domaine.com", auquel cas les identifiants générés seront contact, contact1, contact2, etc. perdant ainsi toute légitimité sémantique.

**Solutions possibles :** 
- Je propose une première solution dans cette PR permettant de générer un uuid pour les SSO ne fournissant pas de username (comme LesCommuns par exemple). Cela permet de corriger le problème pour le cas d'utilisation que j'ai remarqué, mais peut-être pas pour tous.
- Une proposition plus ambitieuse, mais que je n'ai pas implémentée ici par manque de connaissance sur l'ensemble du projet Semapps et ses ramifications, serait de supprimer ces lignes : https://github.com/assemblee-virtuelle/semapps/blob/master/src/middleware/packages/auth/services/account.js#L29-L42 pour empêcher totalement la création d'un user (SSO ou non) si aucun username n'est donné (et de ne plus se fier sur son email)
- Si la modification proposée ici dans Semapps impliquerait trop de conséquences dans divers projets, il est aussi possible de faire la modification dans Archipelago seulement (en rajoutant un attribut username avec un uuid généré ici : https://github.com/assemblee-virtuelle/archipelago/blob/master/middleware/services/auth.service.js#L14-L18)

Qu'en pensez-vous ?