### PR TITLE
pass activity to SingleMailNotificationService filter method

### DIFF
--- a/src/middleware/packages/notifications/services/single-mail/service.js
+++ b/src/middleware/packages/notifications/services/single-mail/service.js
@@ -31,7 +31,7 @@ const SingleMailNotificationsService = {
         const locale = account.preferredLocale || this.settings.defaultLocale;
         const notification = await ctx.call('activity-mapping.map', { activity, locale });
 
-        if (notification && (await this.filterNotification(notification))) {
+        if (notification && (await this.filterNotification(notification, activity))) {
           if (notification.actionLink) notification.actionLink = await this.formatLink(notification.actionLink, recipientUri);
 
           await this.queueMail(ctx, notification.key, {
@@ -52,7 +52,7 @@ const SingleMailNotificationsService = {
   methods: {
     // Optional method called for each notification
     // Return true if you want the notification to be sent by email
-    async filterNotification(notification) {
+    async filterNotification(notification, activity) {
       return true;
     },
     // Method called to format "actionLink" returned for each notification

--- a/website/docs/middleware/notifications/single-mail.md
+++ b/website/docs/middleware/notifications/single-mail.md
@@ -76,7 +76,7 @@ module.exports = {
   methods: {
     // Optional method called for each notification
     // Return true if you want the notification to be sent by email
-    async filterNotification(notification) {
+    async filterNotification(notification, activity) {
       return true;
     },
     // Method called to format the actionLink prop of each notification


### PR DESCRIPTION
This is required by https://github.com/assemblee-virtuelle/activitypods/issues/65, to filter ignored contacts.