### PR TITLE
Pass recipientURI to SingleMailNotificationsService filter 

### DIFF
--- a/src/middleware/packages/notifications/services/single-mail/service.js
+++ b/src/middleware/packages/notifications/services/single-mail/service.js
@@ -25,7 +25,7 @@ const SingleMailNotificationsService = {
       if (this.settings.delay) {
         await delay(this.settings.delay);
       }
-
+      
       for (let recipientUri of recipients) {
         const account = await ctx.call('auth.account.findByWebId', { webId: recipientUri });
         const locale = account.preferredLocale || this.settings.defaultLocale;

--- a/src/middleware/packages/notifications/services/single-mail/service.js
+++ b/src/middleware/packages/notifications/services/single-mail/service.js
@@ -25,13 +25,13 @@ const SingleMailNotificationsService = {
       if (this.settings.delay) {
         await delay(this.settings.delay);
       }
-      
+
       for (let recipientUri of recipients) {
         const account = await ctx.call('auth.account.findByWebId', { webId: recipientUri });
         const locale = account.preferredLocale || this.settings.defaultLocale;
         const notification = await ctx.call('activity-mapping.map', { activity, locale });
 
-        if (notification && (await this.filterNotification(notification, activity))) {
+        if (notification && (await this.filterNotification(notification, activity, recipientUri))) {
           if (notification.actionLink) notification.actionLink = await this.formatLink(notification.actionLink, recipientUri);
 
           await this.queueMail(ctx, notification.key, {
@@ -52,7 +52,7 @@ const SingleMailNotificationsService = {
   methods: {
     // Optional method called for each notification
     // Return true if you want the notification to be sent by email
-    async filterNotification(notification, activity) {
+    async filterNotification(notification, activity, recipientUri) {
       return true;
     },
     // Method called to format "actionLink" returned for each notification

--- a/website/docs/middleware/notifications/single-mail.md
+++ b/website/docs/middleware/notifications/single-mail.md
@@ -76,7 +76,7 @@ module.exports = {
   methods: {
     // Optional method called for each notification
     // Return true if you want the notification to be sent by email
-    async filterNotification(notification, activity) {
+    async filterNotification(notification, activity, recipientUri) {
       return true;
     },
     // Method called to format the actionLink prop of each notification


### PR DESCRIPTION
Adds the `recipientUri` parameter to `this.filterNotification(notification, activity, recipientUri)` of the `SingleMailNotificationsService`.