### PR TITLE
fix .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
-.gitignore
+*.cjs.js
+*.es.js


### PR DESCRIPTION
Using the .gitignore in that context was useless, since the prettier is only executed in the root by the git pre-commit hook (so all files being compared cannot be in the ignored patterns).
Adding the new rules was required because the prettier does not pick up .prettierignore files from subdirectories (in that case the `/frontend` one).