### PR TITLE
chore: BREAKING use `waitForResource` util function

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
@@ -23,24 +23,6 @@ const ObjectService = {
         accept: MIME_TYPES.JSON
       });
     },
-    async awaitCreateComplete(ctx) {
-      const { objectUri, predicates, delayMs = 1000, maxTries = 30 } = ctx.params;
-      return await waitForResource(
-        delayMs,
-        predicates,
-        maxTries,
-        async () =>
-          (object = await ctx.call(
-            'ldp.resource.get',
-            {
-              resourceUri: objectUri,
-              accept: MIME_TYPES.JSON,
-              webId: 'system'
-            },
-            { meta: { $cache: false } }
-          ))
-      );
-    },
     async process(ctx) {
       let { activity, actorUri } = ctx.params;
       let activityType = activity.type || activity['@type'];

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
@@ -1,6 +1,5 @@
 const { MIME_TYPES } = require('@semapps/mime-types');
 const { OBJECT_TYPES, ACTIVITY_TYPES } = require('../../../constants');
-const { waitForResource } = require('../../../utils');
 
 const ObjectService = {
   name: 'activitypub.object',
@@ -52,8 +51,9 @@ const ObjectService = {
 
           if (!container)
             throw new Error(
-              `Cannot create resource of type "${activity.object.type ||
-                activity.object['@type']}", no matching containers were found!`
+              `Cannot create resource of type "${
+                activity.object.type || activity.object['@type']
+              }", no matching containers were found!`
             );
 
           const containerUri = await ctx.call('ldp.registry.getUri', { path: container.path, webId: actorUri });

--- a/src/middleware/packages/activitypub/utilTypes.d.ts
+++ b/src/middleware/packages/activitypub/utilTypes.d.ts
@@ -1,0 +1,6 @@
+export declare async function waitForResource<T>(
+  ms: number,
+  fieldNames?: keyof T | string | (string | keyof T)[],
+  maxTries: number,
+  callback: () => T
+): T;

--- a/src/middleware/packages/activitypub/utils.js
+++ b/src/middleware/packages/activitypub/utils.js
@@ -64,6 +64,39 @@ const getContainerFromUri = str => str.match(new RegExp(`(.*)/.*`))[1];
 
 const delay = t => new Promise(resolve => setTimeout(resolve, t));
 
+const arrayOf = value => {
+  // If the field is null-ish, we suppose there are no values.
+  if (!value) {
+    return [];
+  }
+  // Return as is.
+  if (Array.isArray(value)) {
+    return value;
+  }
+  // Single value is made an array.
+  return [value];
+};
+
+/**
+ * Call a callback and expect the result object to have all properties in `fieldNames`.
+ * If not, try again after `delayMs` until `maxTries` is reached.
+ * If `fieldNames` is `undefined`, the return value of `callback` is expected to not be
+ * `undefined`.
+ *
+ * @type {import("./utilTypes").waitForResource}
+ **/
+const waitForResource = async (delayMs, fieldNames, maxTries, callback) => {
+  for (let i = 0; i < maxTries; i += 1) {
+    const result = await callback();
+    // If a result (and the expected field, if required) is present, return.
+    if (result !== undefined && arrayOf(fieldNames).every(fieldName => Object.keys(result).includes(fieldName))) {
+      return result;
+    }
+    await delay(delayMs);
+  }
+  throw new Error('Waiting for resource failed. No results after ' + maxTries + ' tries');
+};
+
 module.exports = {
   objectCurrentToId,
   objectIdToCurrent,
@@ -71,5 +104,7 @@ module.exports = {
   defaultToArray,
   getSlugFromUri,
   getContainerFromUri,
-  delay
+  delay,
+  arrayOf,
+  waitForResource
 };

--- a/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
@@ -12,7 +12,6 @@ module.exports = {
 
     // Optional get-action parameters
     webId: { type: 'string', optional: true },
-    dereference: { type: 'array', optional: true },
     jsonContext: {
       type: 'multi',
       rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }],
@@ -24,20 +23,17 @@ module.exports = {
   async handler(ctx) {
     const { resourceUri, predicates = [], delayMs = 1000, maxTries = 30, webId = 'system', ...rest } = ctx.params;
 
-    return await waitForResource(
-      delayMs,
-      predicates,
-      maxTries,
-      async () =>
-        (object = await ctx.call(
-          'ldp.resource.get',
-          {
-            resourceUri: resourceUri,
-            accept: MIME_TYPES.JSON,
-            ...rest
-          },
-          { meta: { $cache: false } }
-        ))
+    return await waitForResource(delayMs, predicates, maxTries, () =>
+      ctx.call(
+        'ldp.resource.get',
+        {
+          resourceUri: resourceUri,
+          accept: MIME_TYPES.JSON,
+          webId,
+          ...rest
+        },
+        { meta: { $cache: false } }
+      )
     );
   }
 };

--- a/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
@@ -1,3 +1,4 @@
+const { MIME_TYPES } = require('@semapps/mime-types');
 const { waitForResource } = require('../../../utils');
 
 /** @type {import('moleculer').ServiceActionsSchema} */
@@ -7,10 +8,21 @@ module.exports = {
     resourceUri: { type: 'string' },
     predicates: { type: 'array', optional: true },
     delayMs: { type: 'number', optional: true },
-    maxTries: { type: 'number', optional: true }
+    maxTries: { type: 'number', optional: true },
+
+    // Optional get-action parameters
+    webId: { type: 'string', optional: true },
+    dereference: { type: 'array', optional: true },
+    jsonContext: {
+      type: 'multi',
+      rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }],
+      optional: true
+    },
+    forceSemantic: { type: 'boolean', optional: true },
+    aclVerified: { type: 'boolean', optional: true }
   },
   async handler(ctx) {
-    const { resourceUri, predicates = [], delayMs = 1000, maxTries = 30 } = ctx.params;
+    const { resourceUri, predicates = [], delayMs = 1000, maxTries = 30, webId = 'system', ...rest } = ctx.params;
 
     return await waitForResource(
       delayMs,
@@ -22,7 +34,7 @@ module.exports = {
           {
             resourceUri: resourceUri,
             accept: MIME_TYPES.JSON,
-            webId: 'system'
+            ...rest
           },
           { meta: { $cache: false } }
         ))

--- a/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
@@ -1,0 +1,31 @@
+const { waitForResource } = require('../../../utils');
+
+/** @type {import('moleculer').ServiceActionsSchema} */
+module.exports = {
+  visibility: 'public',
+  params: {
+    resourceUri: { type: 'string' },
+    predicates: { type: 'array', optional: true },
+    delayMs: { type: 'number', optional: true },
+    maxTries: { type: 'number', optional: true }
+  },
+  async handler(ctx) {
+    const { resourceUri, predicates = [], delayMs = 1000, maxTries = 30 } = ctx.params;
+
+    return await waitForResource(
+      delayMs,
+      predicates,
+      maxTries,
+      async () =>
+        (object = await ctx.call(
+          'ldp.resource.get',
+          {
+            resourceUri: resourceUri,
+            accept: MIME_TYPES.JSON,
+            webId: 'system'
+          },
+          { meta: { $cache: false } }
+        ))
+    );
+  }
+};

--- a/src/middleware/packages/ldp/services/resource/index.js
+++ b/src/middleware/packages/ldp/services/resource/index.js
@@ -1,3 +1,4 @@
+const awaitCreateCompleteAction = require('./actions/awaitCreateComplete');
 const getAction = require('./actions/get');
 const createAction = require('./actions/create');
 const patchAction = require('./actions/patch');
@@ -22,6 +23,7 @@ module.exports = {
   },
   dependencies: ['triplestore', 'jsonld'],
   actions: {
+    awaitCreateComplete: awaitCreateCompleteAction,
     create: createAction,
     delete: deleteAction,
     exist: existAction,

--- a/src/middleware/packages/ldp/utilTypes.d.ts
+++ b/src/middleware/packages/ldp/utilTypes.d.ts
@@ -1,0 +1,6 @@
+export declare async function waitForResource<T>(
+  ms: number,
+  fieldNames?: keyof T | string | (string | keyof T)[],
+  maxTries: number,
+  callback: () => T
+): T;

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -11,7 +11,11 @@ const regexProtocolAndHostAndPort = new RegExp('^http(s)?:\\/\\/([\\w-\\.:]*)');
 function createFragmentURL(baseUrl, serverUrl) {
   let fragment = 'me';
   const res = serverUrl.match(regexProtocolAndHostAndPort);
-  if (res) fragment = res[2].replace('-', '_').replace('.', '_').replace(':', '_');
+  if (res)
+    fragment = res[2]
+      .replace('-', '_')
+      .replace('.', '_')
+      .replace(':', '_');
 
   return urlJoin(baseUrl, `#${fragment}`);
 }
@@ -51,8 +55,8 @@ const buildFiltersQuery = filters => {
       if (filters[predicate]) {
         where += `
           FILTER EXISTS { ?s1 ${predicate.startsWith('http') ? `<${predicate}>` : predicate} ${
-            filters[predicate].startsWith('http') ? `<${filters[predicate]}>` : `"${filters[predicate]}"`
-          } } .
+          filters[predicate].startsWith('http') ? `<${filters[predicate]}>` : `"${filters[predicate]}"`
+        } } .
         `;
       } else {
         where += `
@@ -114,6 +118,38 @@ const defaultToArray = value => (!value ? undefined : Array.isArray(value) ? val
 
 const delay = t => new Promise(resolve => setTimeout(resolve, t));
 
+const arrayOf = value => {
+  // If the field is null-ish, we suppose there are no values.
+  if (!value) {
+    return [];
+  }
+  // Return as is.
+  if (Array.isArray(value)) {
+    return value;
+  }
+  // Single value is made an array.
+  return [value];
+};
+
+/**
+ * Call a callback and expect the result object to have all properties in `fieldNames`.
+ * If not, try again after `delayMs` until `maxTries` is reached.
+ * If `fieldNames` is `undefined`, the return value of `callback` is expected to not be
+ * `undefined`.
+ * @type {import("./utilTypes").waitForResource}
+ */
+const waitForResource = async (delayMs, fieldNames, maxTries, callback) => {
+  for (let i = 0; i < maxTries; i += 1) {
+    const result = await callback();
+    // If a result (and the expected field, if required) is present, return.
+    if (result !== undefined && arrayOf(fieldNames).every(fieldName => Object.keys(result).includes(fieldName))) {
+      return result;
+    }
+    await delay(delayMs);
+  }
+  throw new Error(`Waiting for resource failed. No results after ${  maxTries  } tries`);
+};
+
 module.exports = {
   buildBlankNodesQuery,
   buildFiltersQuery,
@@ -133,5 +169,7 @@ module.exports = {
   isMirror,
   createFragmentURL,
   regexPrefix,
-  regexProtocolAndHostAndPort
+  regexProtocolAndHostAndPort,
+  waitForResource,
+  arrayOf
 };


### PR DESCRIPTION
for `activitypub.actor` and `activitypub.object` `awaitCreateComplete`

As suggested by @srosset81 in https://github.com/assemblee-virtuelle/activitypods/pull/87#discussion_r1337275692.

I made a small change compared to the original: Instead of checking, if the required fields are undefined `result[key] === undefined`, I adopted your original check using `Object.keys(result).includes`

## Breaking changes :warning: 

`activitypub.object.awaitCreateComplete` has been replaced with `ldp.resource.awaitCreateComplete`