### PR TITLE
Fix DisassemblyMixin missing export

### DIFF
--- a/src/middleware/packages/ldp/index.js
+++ b/src/middleware/packages/ldp/index.js
@@ -9,6 +9,7 @@ module.exports = {
   ControlledContainerMixin: require('./mixins/controlled-container'),
   ImageProcessorMixin: require('./mixins/image-processor'),
   DocumentTaggerMixin: require('./mixins/document-tagger'),
+  DisassemblyMixin: require('./mixins/disassembly'),
   LdpAdapter: require('./adapter'),
   getContainerRoute: require('./routes/getContainerRoute'),
   getResourcesRoute: require('./routes/getResourcesRoute'),


### PR DESCRIPTION
Adding : DisassemblyMixin: require('./mixins/disassembly'),
in ldppackage index.js file