### PR TITLE
Chore: deactivate nx daemon revert ts build checks

### DIFF
--- a/src/frontend/nx.json
+++ b/src/frontend/nx.json
@@ -1,5 +1,6 @@
 {
   "tasksRunnerOptions": {
+    "useDaemonProcess": false,
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {

--- a/src/frontend/packages/activitypub-components/package.json
+++ b/src/frontend/packages/activitypub-components/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/frontend/packages/auth-provider/package.json
+++ b/src/frontend/packages/auth-provider/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/frontend/packages/date-components/package.json
+++ b/src/frontend/packages/date-components/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'",
     "typecheck": "tsc --noEmit"
   },

--- a/src/frontend/packages/field-components/package.json
+++ b/src/frontend/packages/field-components/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/frontend/packages/geo-components/package.json
+++ b/src/frontend/packages/geo-components/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/frontend/packages/input-components/package.json
+++ b/src/frontend/packages/input-components/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/frontend/packages/interop-components/package.json
+++ b/src/frontend/packages/interop-components/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/frontend/packages/list-components/package.json
+++ b/src/frontend/packages/list-components/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "tsc && parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/frontend/packages/markdown-components/package.json
+++ b/src/frontend/packages/markdown-components/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'",
     "typecheck": "tsc --noEmit"
   },

--- a/src/frontend/packages/semantic-data-provider/package.json
+++ b/src/frontend/packages/semantic-data-provider/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && parcel build && yalc publish --push --changed",
+    "build": "parcel build && yalc publish --push --changed",
     "watch": "nodemon --watch src --exec 'yarn build'"
   },
   "dependencies": {

--- a/src/middleware/nx.json
+++ b/src/middleware/nx.json
@@ -1,5 +1,6 @@
 {
   "tasksRunnerOptions": {
+    "useDaemonProcess": false,
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {


### PR DESCRIPTION
The nx daemon process was consuming loads of resources. Deactivating it, seems to have no significatnt downsides.

The `tsc --noEmit` was taking more build time without significant improvements, see main description of https://github.com/assemblee-virtuelle/semapps/pull/1194.