### PR TITLE
Allow to use register LDP containers per dataset

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
@@ -1,4 +1,5 @@
 const { MIME_TYPES } = require('@semapps/mime-types');
+const { getSlugFromUri } = require('@semapps/ldp');
 const { OBJECT_TYPES, ACTIVITY_TYPES } = require('../../../constants');
 
 const ObjectService = {
@@ -45,8 +46,10 @@ const ObjectService = {
           // If the object passed is an URI, this is an announcement and there is nothing to process
           if (typeof activity.object === 'string') break;
 
+          // In Pod provider config, we need to find the container of the specific Pod
           const container = await ctx.call('ldp.registry.getByType', {
-            type: activity.object.type || activity.object['@type']
+            type: activity.object.type || activity.object['@type'],
+            dataset: this.settings.podProvider ? getSlugFromUri(actorUri) : undefined
           });
 
           if (!container)

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/registry.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/registry.js
@@ -250,11 +250,14 @@ const RegistryService = {
       }
     },
     async 'ldp.registry.registered'(ctx) {
-      const { container } = ctx.params;
+      const { container, dataset } = ctx.params;
 
-      // Register the container locally
-      // Avoid race conditions, if this event is called while the register action is still running
-      this.registeredContainers[container.name] = container;
+      // Don't register pod-specific containers for now (this service will be deprecated anyway)
+      if (!dataset) {
+        // Register the container locally
+        // Avoid race conditions, if this event is called while the register action is still running
+        this.registeredContainers[container.name] = container;
+      }
     }
   }
 };

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/registry.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/registry.js
@@ -21,8 +21,17 @@ const RegistryService = {
   dependencies: ['triplestore', 'ldp'],
   async started() {
     this.registeredCollections = [];
-    this.registeredContainers = await this.broker.call('ldp.registry.list');
+    this.registeredContainers = {};
     this.collectionsInCreation = [];
+
+    this.registeredContainers['*'] = await this.broker.call('ldp.registry.list');
+
+    if (this.settings.podProvider) {
+      await this.broker.waitForServices(['pod']);
+      for (let dataset of await this.broker.call('pod.list')) {
+        this.registeredContainers[dataset] = await this.broker.call('ldp.registry.list', { dataset });
+      }
+    }
   },
   actions: {
     async register(ctx) {
@@ -108,23 +117,27 @@ const RegistryService = {
     async createAndAttachMissingCollections(ctx) {
       for (const collection of this.registeredCollections) {
         this.logger.info(`Looking for containers with types: ${JSON.stringify(collection.attachToTypes)}`);
-        // Find all containers where we want to attach this collection
-        const containers = this.getContainersByType(collection.attachToTypes);
-        if (containers) {
-          // Go through each container
-          for (const container of Object.values(containers)) {
-            const containerUri = urlJoin(this.settings.baseUri, container.fullPath);
-            this.logger.info(`Looking for resources in container ${containerUri}`);
-            const resources = await ctx.call('ldp.container.getUris', { containerUri });
-            for (const resourceUri of resources) {
-              await this.actions.createAndAttachCollection(
-                {
-                  objectUri: resourceUri,
-                  collection,
-                  webId: 'system'
-                },
-                { parentCtx: ctx }
-              );
+
+        const datasets = this.settings.podProvider ? await this.broker.call('pod.list') : ['*'];
+        for (let dataset of datasets) {
+          // Find all containers where we want to attach this collection
+          const containers = this.getContainersByType(collection.attachToTypes, dataset);
+          if (containers) {
+            // Go through each container
+            for (const container of Object.values(containers)) {
+              const containerUri = urlJoin(this.settings.baseUri, container.fullPath);
+              this.logger.info(`Looking for resources in container ${containerUri}`);
+              const resources = await ctx.call('ldp.container.getUris', { containerUri });
+              for (const resourceUri of resources) {
+                await this.actions.createAndAttachCollection(
+                  {
+                    objectUri: resourceUri,
+                    collection,
+                    webId: 'system'
+                  },
+                  { parentCtx: ctx }
+                );
+              }
             }
           }
         }
@@ -159,8 +172,13 @@ const RegistryService = {
     },
     // Get the containers with resources of the given type
     // Same action as ldp.registry.getByType, but search through locally registered containers to avoid race conditions
-    getContainersByType(types) {
-      return Object.values(this.registeredContainers).filter(container =>
+    getContainersByType(types, dataset) {
+      const containers =
+        !dataset || dataset === '*'
+          ? this.registeredContainers['*']
+          : { ...this.registeredContainers['*'], ...this.registeredContainers[dataset] };
+
+      return Object.values(containers).filter(container =>
         defaultToArray(types).some(type =>
           Array.isArray(container.acceptedTypes)
             ? container.acceptedTypes.includes(type)
@@ -252,12 +270,10 @@ const RegistryService = {
     async 'ldp.registry.registered'(ctx) {
       const { container, dataset } = ctx.params;
 
-      // Don't register pod-specific containers for now (this service will be deprecated anyway)
-      if (!dataset) {
-        // Register the container locally
-        // Avoid race conditions, if this event is called while the register action is still running
-        this.registeredContainers[container.name] = container;
-      }
+      // Register the container locally
+      // Avoid race conditions, if this event is called while the register action is still running
+      if (!this.registeredContainers[dataset || '*']) this.registeredContainers[dataset || '*'] = {};
+      this.registeredContainers[dataset || '*'][container.name] = container;
     }
   }
 };

--- a/src/middleware/packages/ldp/mixins/document-tagger.js
+++ b/src/middleware/packages/ldp/mixins/document-tagger.js
@@ -44,6 +44,7 @@ module.exports = {
       if (triples.length > 0) {
         await ctx.call('triplestore.insert', {
           resource: triples.join('\n'),
+          dataset: this.settings.podProvider && !ctx.meta.dataset ? getDatasetFromUri(resourceUri) : undefined,
           webId: 'system'
         });
       }
@@ -59,6 +60,7 @@ module.exports = {
           }> "${now.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> }
           WHERE { <${resourceUri}> <${this.settings.documentPredicates.updated}> ?updated }
         `,
+        dataset: this.settings.podProvider && !ctx.meta.dataset ? getDatasetFromUri(resourceUri) : undefined,
         webId: 'system'
       });
     }
@@ -75,15 +77,6 @@ module.exports = {
     async 'ldp.resource.patched'(ctx) {
       const { resourceUri } = ctx.params;
       this.actions.tagUpdatedResource({ resourceUri }, { parentCtx: ctx });
-    }
-  },
-  hooks: {
-    before: {
-      '*'(ctx) {
-        if (this.settings.podProvider && !ctx.meta.dataset) {
-          ctx.meta.dataset = getDatasetFromUri(ctx.params.resourceUri);
-        }
-      }
     }
   }
 };

--- a/src/middleware/packages/ldp/services/registry/actions/getByType.js
+++ b/src/middleware/packages/ldp/services/registry/actions/getByType.js
@@ -1,12 +1,15 @@
 module.exports = {
   visibility: 'public',
   params: {
-    type: { type: 'multi', rules: [{ type: 'string' }, { type: 'array' }] }
+    type: { type: 'multi', rules: [{ type: 'string' }, { type: 'array' }] },
+    dataset: { type: 'string', optional: true }
   },
   async handler(ctx) {
-    const types = Array.isArray(ctx.params.type) ? ctx.params.type : [ctx.params.type];
+    const { type, dataset } = ctx.params;
+    const types = Array.isArray(type) ? type : [type];
+    const registeredContainers = await this.actions.list({ dataset }, { parentCtx: ctx });
 
-    return Object.values(this.registeredContainers).find(container =>
+    return Object.values(registeredContainers).find(container =>
       types.some(type =>
         Array.isArray(container.acceptedTypes)
           ? container.acceptedTypes.includes(type)

--- a/src/middleware/packages/ldp/services/registry/actions/getByUri.js
+++ b/src/middleware/packages/ldp/services/registry/actions/getByUri.js
@@ -2,10 +2,11 @@ module.exports = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string', optional: true },
-    resourceUri: { type: 'string', optional: true }
+    resourceUri: { type: 'string', optional: true },
+    dataset: { type: 'string', optional: true }
   },
   async handler(ctx) {
-    let { containerUri, resourceUri } = ctx.params;
+    let { containerUri, resourceUri, dataset } = ctx.params;
 
     if (!containerUri && !resourceUri) {
       throw new Error('The param containerUri or resourceUri must be provided to ldp.registry.getByUri');
@@ -18,8 +19,9 @@ module.exports = {
 
     if (containerUri) {
       const path = new URL(containerUri).pathname;
+      const registeredContainers = await this.actions.list({ dataset }, { parentCtx: ctx });
       const containerOptions =
-        Object.values(this.registeredContainers).find(container => container.pathRegex.test(path)) || {};
+        Object.values(registeredContainers).find(container => container.pathRegex.test(path)) || {};
       return { ...this.settings.defaultOptions, ...containerOptions };
     }
     return this.settings.defaultOptions;

--- a/src/middleware/packages/ldp/services/registry/actions/list.js
+++ b/src/middleware/packages/ldp/services/registry/actions/list.js
@@ -1,6 +1,14 @@
 module.exports = {
   visibility: 'public',
-  handler() {
-    return this.registeredContainers;
+  params: {
+    dataset: { type: 'string', optional: true }
+  },
+  handler(ctx) {
+    const { dataset } = ctx.params;
+    if (dataset && this.registeredContainers[dataset]) {
+      return { ...this.registeredContainers['*'], ...this.registeredContainers[dataset] };
+    } else {
+      return this.registeredContainers['*'];
+    }
   }
 };

--- a/src/middleware/packages/ldp/services/registry/actions/register.js
+++ b/src/middleware/packages/ldp/services/registry/actions/register.js
@@ -29,6 +29,7 @@ module.exports = {
           'If no path is set for the ControlledContainerMixin, you must set one (and only one) acceptedTypes'
         );
       }
+      // If the resource type is invalid, an error will be thrown here
       path = await ctx.call('ldp.container.getPath', { resourceType: acceptedTypes[0] });
       this.logger.debug(`Automatically generated the path ${path} for resource type ${acceptedTypes[0]}`);
     }

--- a/src/middleware/packages/ldp/services/registry/actions/register.js
+++ b/src/middleware/packages/ldp/services/registry/actions/register.js
@@ -15,10 +15,11 @@ module.exports = {
     excludeFromMirror: { type: 'boolean', optional: true },
     newResourcesPermissions: { type: 'multi', rules: [{ type: 'object' }, { type: 'function' }], optional: true },
     controlledActions: { type: 'object', optional: true },
-    readOnly: { type: 'boolean', optional: true }
+    readOnly: { type: 'boolean', optional: true },
+    dataset: { type: 'string', optional: true }
   },
   async handler(ctx) {
-    let { path, acceptedTypes, fullPath, name, podsContainer, ...options } = ctx.params;
+    let { path, acceptedTypes, fullPath, name, podsContainer, dataset, ...options } = ctx.params;
     acceptedTypes = arrayOf(acceptedTypes);
 
     // If no path is provided, automatically find it based on the acceptedTypes
@@ -45,13 +46,22 @@ module.exports = {
     if (podsContainer === true) {
       // Skip container creation for the root PODs container (it is not a real LDP container since no dataset have these data)
     } else if (this.settings.podProvider) {
-      // 1. Ensure the container has been created for each user
-      const accounts = await ctx.call('auth.account.find');
-      for (const account of accounts) {
+      if (dataset && dataset !== '*') {
+        const account = await ctx.call('auth.account.findByUsername', { username: dataset });
+        if (!account) throw new Error(`No pod found with username ${dataset}`);
         if (!account.podUri) throw new Error(`The podUri is not defined for account ${account.username}`);
         ctx.meta.dataset = account.username;
         const containerUri = urlJoin(account.podUri, path);
         await this.createAndAttachContainer(ctx, containerUri, path, options);
+      } else {
+        // 1. Ensure the container has been created for each user
+        const accounts = await ctx.call('auth.account.find');
+        for (const account of accounts) {
+          if (!account.podUri) throw new Error(`The podUri is not defined for account ${account.username}`);
+          ctx.meta.dataset = account.username;
+          const containerUri = urlJoin(account.podUri, path);
+          await this.createAndAttachContainer(ctx, containerUri, path, options);
+        }
       }
 
       // TODO see if we can base ourselves on a general config for the POD data path
@@ -65,14 +75,15 @@ module.exports = {
     const pathRegex = pathToRegexp(fullPath);
 
     // Save the options
-    this.registeredContainers[name] = { path, fullPath, pathRegex, name, acceptedTypes, ...options };
+    if (!this.registeredContainers[dataset || '*']) this.registeredContainers[dataset || '*'] = {};
+    this.registeredContainers[dataset || '*'][name] = { path, fullPath, pathRegex, name, acceptedTypes, ...options };
 
     ctx.emit(
       'ldp.registry.registered',
-      { container: this.registeredContainers[name] },
+      { container: this.registeredContainers[dataset || '*'][name], dataset },
       { meta: { webId: null, dataset: null } }
     );
 
-    return this.registeredContainers[name];
+    return this.registeredContainers[dataset || '*'][name];
   }
 };

--- a/src/middleware/packages/ldp/services/registry/index.js
+++ b/src/middleware/packages/ldp/services/registry/index.js
@@ -88,8 +88,9 @@ module.exports = {
       const { accountData } = ctx.params;
       // We want to add user's containers only in POD provider config
       if (this.settings.podProvider) {
+        const registeredContainers = await this.actions.list({ dataset: accountData.username }, { parentCtx: ctx });
         // Go through each registered containers
-        for (const container of Object.values(this.registeredContainers)) {
+        for (const container of Object.values(registeredContainers)) {
           const containerUri = urlJoin(accountData.podUri, container.path);
           await this.createAndAttachContainer(ctx, containerUri, container.path);
         }

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -73,11 +73,24 @@ const getParentContainerUri = uri => uri.match(new RegExp(`(.*)/.*`))[1];
 
 const getParentContainerPath = path => path.match(new RegExp(`(.*)/.*`))[1];
 
+const getPathFromUri = uri => {
+  try {
+    const urlObject = new URL(uri);
+    return urlObject.pathname;
+  } catch (e) {
+    return false;
+  }
+};
+
 // Transforms "http://localhost:3000/dataset/data" to "dataset"
 const getDatasetFromUri = uri => {
-  const path = new URL(uri).pathname;
-  const parts = path.split('/');
-  if (parts.length > 1) return parts[1];
+  const path = getPathFromUri(uri);
+  if (path) {
+    const parts = path.split('/');
+    if (parts.length > 1) return parts[1];
+  } else {
+    throw new Error(`${uri} is not a valid URL`);
+  }
 };
 
 const hasType = (resource, type) => {

--- a/src/middleware/tests/interop/remote-inference.test.js
+++ b/src/middleware/tests/interop/remote-inference.test.js
@@ -3,7 +3,7 @@ const waitForExpect = require('wait-for-expect');
 const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 
-jest.setTimeout(50000);
+jest.setTimeout(70000);
 
 let server1;
 let server2;

--- a/website/docs/middleware/ldp/index.md
+++ b/website/docs/middleware/ldp/index.md
@@ -22,9 +22,9 @@ This package allows you to setup [LDP](https://www.w3.org/TR/ldp-primer/) contai
 - [LdpResourceService](resource.md)
 - [LdpContainerService](container.md)
 - [LdpLinkHeaderService](link-header.md)
-- LdpRegistryService
-- LdpApiService
-- LdpCacheService
+- [LdpRegistryService](registry.md)
+- LdpApiService _(internal)_
+- LdpCacheService _(internal)_
 
 ## Mixins
 

--- a/website/docs/middleware/ldp/link-header.md
+++ b/website/docs/middleware/ldp/link-header.md
@@ -2,7 +2,7 @@
 title: LdpLinkHeaderService
 ---
 
-This service is automatically created by the [LdpService](index) with the key `ldp.link-header`. It allows other services to add custom [Link header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) to GET and HEAD calls on LDP resources and containers.
+This service is automatically created by the [LdpService](index.md) with the key `ldp.link-header`. It allows other services to add custom [Link header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) to GET and HEAD calls on LDP resources and containers.
 
 ## Actions
 

--- a/website/docs/middleware/ldp/registry.md
+++ b/website/docs/middleware/ldp/registry.md
@@ -1,0 +1,85 @@
+---
+title: LdpRegistryService
+---
+
+This service is automatically created by the [LdpService](index.md) with the key `ldp.registry`. It keeps a registry of LDP containers and their associated options (which may be passed through the [ControlledContainerMixin](controlled-container.md)).
+
+## Actions
+
+The following service actions are available:
+
+### `getByType`
+
+Get the first container registration matching with the `acceptedTypes`.
+
+##### Parameters
+
+| Property  | Type                | Default      | Description                                             |
+| --------- | ------------------- | ------------ | ------------------------------------------------------- |
+| `type`    | `String` or `Array` | **required** | URI of container to which the resource will be attached |
+| `dataset` | `String`            |              | If provided, will look in pod-specific containers       |
+
+##### Return
+
+A container registration
+
+### `getByUri`
+
+Get the first container registration matching with the resource or container URI.
+If a resource URI is provided, it will get the first container containing this resource.
+
+##### Parameters
+
+| Property       | Type     | Default | Description                                       |
+| -------------- | -------- | ------- | ------------------------------------------------- |
+| `containerUri` | `String` |         | URI of the container                              |
+| `resourceUri`  | `String` |         | URI of the resource                               |
+| `dataset`      | `String` |         | If provided, will look in pod-specific containers |
+
+##### Return
+
+A container registration
+
+### `getUri`
+
+Get a container URI based on the container path and webId.
+
+##### Parameters
+
+| Property | Type     | Default      | Description                      |
+| -------- | -------- | ------------ | -------------------------------- |
+| `path`   | `String` | **required** | Container path                   |
+| `webId`  | `String` |              | Required in Pod providers config |
+
+### `list`
+
+Get the list of container registrations
+
+##### Parameters
+
+| Property  | Type     | Default | Description                                      |
+| --------- | -------- | ------- | ------------------------------------------------ |
+| `dataset` | `String` |         | If provided, will return pod-specific containers |
+
+##### Return
+
+A object with the container registration name (or path) as key, and the container registration as value.
+
+### `register`
+
+Register a container.
+
+##### Parameters
+
+| Property        | Type                | Default | Description                                                                                                                            |
+| --------------- | ------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`          | `String`            |         | Path of the container. If not provided, will be generated with [`ldp.container.getPath`](container.md#getpath) and the `acceptedTypes` |
+| `name`          | `String`            |         | Name of the container, used to store it (path will be used if none are provided)                                                       |
+| `acceptedTypes` | `Array` or `String` |         | RDF classes accepted in this container                                                                                                 |
+| `dataset`       | `String`            |         | If provided, will register the container only for the given dataset                                                                    |
+
+For other available parameters, see the [container options](index.md#container-options).
+
+##### Return
+
+The container registration

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -50,6 +50,7 @@ module.exports = {
         'middleware/ldp/resource',
         'middleware/ldp/container',
         'middleware/ldp/link-header',
+        'middleware/ldp/registry',
         'middleware/ldp/controlled-container',
         'middleware/ldp/document-tagger',
         'middleware/ldp/image-processor'


### PR DESCRIPTION
- Add a `dataset` parameter to `ldp.registry.register`
- This allows to register a container for a single pod, and still be able to get it through the LdpRegistryService
- This fixes `Create` activities side-effects: objects are created in the correct container (see https://github.com/assemblee-virtuelle/activitypods/issues/153)
- Add missing documentation for the LdpRegistryService