### PR TITLE
LdpRegistryService: use full URI for types

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
@@ -46,18 +46,20 @@ const ObjectService = {
           // If the object passed is an URI, this is an announcement and there is nothing to process
           if (typeof activity.object === 'string') break;
 
-          // In Pod provider config, we need to find the container of the specific Pod
+          const types = await ctx.call('jsonld.parser.expandTypes', {
+            types: activity.object.type || activity.object['@type'],
+            context: activity['@context']
+          });
+
+          // Get the first matching container
+          // TODO: attach to all matching containers
           const container = await ctx.call('ldp.registry.getByType', {
-            type: activity.object.type || activity.object['@type'],
+            type: types,
             dataset: this.settings.podProvider ? getSlugFromUri(actorUri) : undefined
           });
 
           if (!container)
-            throw new Error(
-              `Cannot create resource of type "${
-                activity.object.type || activity.object['@type']
-              }", no matching containers were found!`
-            );
+            throw new Error(`Cannot create resource of type "${types.join(', ')}", no matching containers were found!`);
 
           const containerUri = await ctx.call('ldp.registry.getUri', { path: container.path, webId: actorUri });
 

--- a/src/middleware/packages/ldp/services/registry/actions/getByType.js
+++ b/src/middleware/packages/ldp/services/registry/actions/getByType.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   async handler(ctx) {
     const { type, dataset } = ctx.params;
-    const types = Array.isArray(type) ? type : [type];
+    const types = await ctx.call('jsonld.parser.expandTypes', { types: type });
     const registeredContainers = await this.actions.list({ dataset }, { parentCtx: ctx });
 
     return Object.values(registeredContainers).find(container =>

--- a/src/middleware/packages/ldp/services/registry/actions/register.js
+++ b/src/middleware/packages/ldp/services/registry/actions/register.js
@@ -20,11 +20,12 @@ module.exports = {
   },
   async handler(ctx) {
     let { path, acceptedTypes, fullPath, name, podsContainer, dataset, ...options } = ctx.params;
-    acceptedTypes = arrayOf(acceptedTypes);
+
+    acceptedTypes = acceptedTypes && (await ctx.call('jsonld.parser.expandTypes', { types: acceptedTypes }));
 
     // If no path is provided, automatically find it based on the acceptedTypes
     if (!path) {
-      if (acceptedTypes.length !== 1) {
+      if (!acceptedTypes || acceptedTypes.length !== 1) {
         throw new Error(
           'If no path is set for the ControlledContainerMixin, you must set one (and only one) acceptedTypes'
         );

--- a/website/docs/middleware/jsonld/parser.md
+++ b/website/docs/middleware/jsonld/parser.md
@@ -23,3 +23,18 @@ See [the examples](https://github.com/digitalbazaar/jsonld.js#examples) to see h
 ### `toQuads`
 
 Same as `toRDF` but returns quads formatted according to the [RDF.JS data model](https://github.com/rdfjs/data-model-spec)
+
+### `expandTypes`
+
+Return the expanded types based on a given context.
+
+##### Parameters
+
+| Property  | Type                | Default         | Description          |
+| --------- | ------------------- | --------------- | -------------------- |
+| `types`   | `String` or `Array` | **required**    | Type(s) to expand    |
+| `context` | `String`            | Default context | Context to be parsed |
+
+##### Return
+
+An array of types


### PR DESCRIPTION
The LdpRegistryService now internally store the types with their full URI, eventually converting prefixes types to full URIs (with a new `jsonld.parser.expandTypes` action)