### PR TITLE
Improve ObjectsWatcherMiddleware

### DIFF
--- a/src/middleware/packages/sync/middlewares/objects-watcher.js
+++ b/src/middleware/packages/sync/middlewares/objects-watcher.js
@@ -142,7 +142,8 @@ const ObjectsWatcherMiddleware = (config = {}) => {
                 webId: 'system'
               });
               if (containerExist) {
-                containerUri = ctx.params.resourceUri;
+                // We don't want to announce containers right changes
+                return await next(ctx);
               } else {
                 resourceUri = ctx.params.resourceUri;
               }


### PR DESCRIPTION
- Post to outbox even if no recipients are defined (set `postWithoutRecipients` to `true`)
- Also watch for PATCH calls
- Do not use `Announce` activity anymore
- Adapt SynchronizerService to this change