### PR TITLE
Fix WAC groups API

### DIFF
--- a/src/middleware/packages/signature/services/proxy.js
+++ b/src/middleware/packages/signature/services/proxy.js
@@ -127,7 +127,9 @@ const ProxyService = {
         };
       } else {
         this.logger.warn(
-          `Could not fetch ${url} through proxy of ${actorUri} (Error ${response.status}: ${response.statusText})`
+          `Could not ${method || 'GET'} ${url} through proxy of ${actorUri} (Error ${response.status}: ${
+            response.statusText
+          })`
         );
         throw new MoleculerError(response.statusText, response.status);
       }

--- a/src/middleware/packages/webacl/routes/getRoutes.js
+++ b/src/middleware/packages/webacl/routes/getRoutes.js
@@ -8,7 +8,7 @@ const onError = (req, res, err) => {
   res.end(JSON.stringify({ type, code, message, data, name }));
 };
 
-const getRoutes = () => {
+const getRoutes = podProvider => {
   const middlewares = [parseHeader, parseJson, negotiateContentType, negotiateAccept];
 
   return [
@@ -49,17 +49,17 @@ const getRoutes = () => {
       onError
     },
     {
-      path: '/_groups',
+      path: podProvider ? '/_groups/:username([^/._][^/]+)' : '/_groups',
       name: 'acl-groups',
       authorization: false,
       authentication: true,
       aliases: {
-        'PATCH /:id': ['webacl.group.api_addMember'],
-        'POST /': ['webacl.group.api_create'],
+        'POST /': [parseHeader, 'webacl.group.api_create'],
         'GET /:id': ['webacl.group.api_getMembers'],
         'GET /': ['webacl.group.api_getGroups'],
         'DELETE /:id': ['webacl.group.api_delete'],
-        'POST /:id': ['webacl.group.api_removeMember']
+        'PATCH /:id': ['webacl.group.api_addMember'],
+        'PUT /:id': ['webacl.group.api_removeMember']
       },
       bodyParsers: {
         json: true

--- a/src/middleware/packages/webacl/service.js
+++ b/src/middleware/packages/webacl/service.js
@@ -59,7 +59,7 @@ module.exports = {
       }
     }
 
-    for (const route of getRoutes()) {
+    for (const route of getRoutes(this.settings.podProvider)) {
       await this.broker.call('api.addRoute', { route });
     }
 

--- a/src/middleware/packages/webacl/services/group/actions/addMember.js
+++ b/src/middleware/packages/webacl/services/group/actions/addMember.js
@@ -5,9 +5,10 @@ const { sanitizeSPARQL } = require('../../../utils');
 module.exports = {
   api: async function api(ctx) {
     if (!ctx.params.memberUri) throw new MoleculerError('needs a memberUri in your PATCH (json)', 400, 'BAD_REQUEST');
+    if (this.settings.podProvider) ctx.meta.dataset = ctx.params.username;
 
     await ctx.call('webacl.group.addMember', {
-      groupSlug: ctx.params.id,
+      groupSlug: this.settings.podProvider ? `${ctx.params.username}/${ctx.params.id}` : ctx.params.id,
       memberUri: ctx.params.memberUri
     });
 

--- a/src/middleware/packages/webacl/services/group/actions/create.js
+++ b/src/middleware/packages/webacl/services/group/actions/create.js
@@ -1,17 +1,25 @@
 const { MoleculerError } = require('moleculer').Errors;
 const createSlug = require('speakingurl');
 const urlJoin = require('url-join');
-const { aclGroupExists, sanitizeSPARQL } = require('../../../utils');
+const { getSlugFromUri } = require('@semapps/ldp');
+const { sanitizeSPARQL } = require('../../../utils');
 
 module.exports = {
   api: async function api(ctx) {
-    if (!ctx.params.slug) throw new MoleculerError('needs a slug in your POST (json)', 400, 'BAD_REQUEST');
+    if (!ctx.meta.headers?.slug) throw new MoleculerError('needs a slug in your POST (json)', 400, 'BAD_REQUEST');
+    if (this.settings.podProvider) ctx.meta.dataset = ctx.params.username;
 
-    await ctx.call('webacl.group.create', {
-      groupSlug: ctx.params.slug
+    const { groupUri } = await ctx.call('webacl.group.create', {
+      groupSlug: this.settings.podProvider ? `${ctx.params.username}/${ctx.meta.headers.slug}` : ctx.meta.headers.slug
     });
 
-    ctx.meta.$statusCode = 204;
+    ctx.meta.$responseHeaders = {
+      Location: groupUri,
+      'Content-Length': 0
+    };
+    // We need to set this also here (in addition to above) or we get a Moleculer warning
+    ctx.meta.$location = groupUri;
+    ctx.meta.$statusCode = 201;
   },
   action: {
     visibility: 'public',
@@ -28,6 +36,15 @@ module.exports = {
         groupSlug = createSlug(groupSlug, { lang: 'fr', custom: { '.': '.', '/': '/' } });
         groupUri = urlJoin(this.settings.baseUrl, '_groups', groupSlug);
       }
+
+      // if (this.settings.podProvider) {
+      //   const username = getSlugFromUri(webId);
+      //   const baseGroupUrl = urlJoin(this.settings.baseUrl, '_groups', username);
+
+      //   if (!groupUri.startsWith(`${baseGroupUrl}/`)) {
+      //     throw new Error(`Cannot create group ${groupUri} with webId ${webId}`);
+      //   }
+      // }
 
       await sanitizeSPARQL(groupUri);
 
@@ -67,8 +84,6 @@ module.exports = {
         webId: 'system'
       });
 
-      // ctx.meta.$statusCode = 200;
-      // ctx.meta.$responseType = 'application/json'
       return { groupUri };
     }
   }

--- a/src/middleware/packages/webacl/services/group/actions/create.js
+++ b/src/middleware/packages/webacl/services/group/actions/create.js
@@ -1,7 +1,6 @@
 const { MoleculerError } = require('moleculer').Errors;
 const createSlug = require('speakingurl');
 const urlJoin = require('url-join');
-const { getSlugFromUri } = require('@semapps/ldp');
 const { sanitizeSPARQL } = require('../../../utils');
 
 module.exports = {
@@ -36,15 +35,6 @@ module.exports = {
         groupSlug = createSlug(groupSlug, { lang: 'fr', custom: { '.': '.', '/': '/' } });
         groupUri = urlJoin(this.settings.baseUrl, '_groups', groupSlug);
       }
-
-      // if (this.settings.podProvider) {
-      //   const username = getSlugFromUri(webId);
-      //   const baseGroupUrl = urlJoin(this.settings.baseUrl, '_groups', username);
-
-      //   if (!groupUri.startsWith(`${baseGroupUrl}/`)) {
-      //     throw new Error(`Cannot create group ${groupUri} with webId ${webId}`);
-      //   }
-      // }
 
       await sanitizeSPARQL(groupUri);
 

--- a/src/middleware/packages/webacl/services/group/actions/delete.js
+++ b/src/middleware/packages/webacl/services/group/actions/delete.js
@@ -4,8 +4,9 @@ const { removeAgentGroupOrAgentFromAuthorizations, sanitizeSPARQL } = require('.
 
 module.exports = {
   api: async function api(ctx) {
+    if (this.settings.podProvider) ctx.meta.dataset = ctx.params.username;
     await ctx.call('webacl.group.delete', {
-      groupSlug: ctx.params.id
+      groupSlug: this.settings.podProvider ? `${ctx.params.username}/${ctx.params.id}` : ctx.params.id
     });
 
     ctx.meta.$statusCode = 204;

--- a/src/middleware/packages/webacl/services/group/actions/getGroups.js
+++ b/src/middleware/packages/webacl/services/group/actions/getGroups.js
@@ -1,5 +1,6 @@
 module.exports = {
   api: async function api(ctx) {
+    if (this.settings.podProvider) ctx.meta.dataset = ctx.params.username;
     return await ctx.call('webacl.group.getGroups', {});
   },
   action: {
@@ -20,13 +21,17 @@ module.exports = {
             PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
             PREFIX acl: <http://www.w3.org/ns/auth/acl#>
             PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            SELECT ?g WHERE { GRAPH <${this.settings.graphName}>
-            { ?g a vcard:Group.
+            SELECT ?g 
+            WHERE 
+            { GRAPH <${this.settings.graphName}>
+              { ?g a vcard:Group.
               ?auth a acl:Authorization;
                 acl:mode acl:Read;
                 acl:accessTo ?g;
                 ${agentSelector}
-            } }`,
+              } 
+            }
+          `,
           webId: 'system'
         });
 
@@ -34,9 +39,14 @@ module.exports = {
         // and also the groups with acl:AuthenticatedAgent
       } else {
         groups = await ctx.call('triplestore.query', {
-          query: `PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-            SELECT ?g WHERE { GRAPH <${this.settings.graphName}>
-            { ?g a vcard:Group } }`,
+          query: `
+            PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+            SELECT ?g 
+            WHERE { 
+              GRAPH <${this.settings.graphName}>
+              { ?g a vcard:Group } 
+            }
+          `,
           webId: 'system'
         });
       }

--- a/src/middleware/packages/webacl/services/group/actions/getMembers.js
+++ b/src/middleware/packages/webacl/services/group/actions/getMembers.js
@@ -4,8 +4,9 @@ const { sanitizeSPARQL } = require('../../../utils');
 
 module.exports = {
   api: async function api(ctx) {
+    if (this.settings.podProvider) ctx.meta.dataset = ctx.params.username;
     return await ctx.call('webacl.group.getMembers', {
-      groupSlug: ctx.params.id
+      groupSlug: this.settings.podProvider ? `${ctx.params.username}/${ctx.params.id}` : ctx.params.id
     });
   },
   action: {
@@ -40,9 +41,14 @@ module.exports = {
       }
 
       const members = await ctx.call('triplestore.query', {
-        query: `PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-          SELECT ?m WHERE { GRAPH <${this.settings.graphName}>
-          { <${groupUri}> vcard:hasMember ?m } }`,
+        query: `
+          PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+          SELECT ?m 
+          WHERE { 
+            GRAPH <${this.settings.graphName}>
+            { <${groupUri}> vcard:hasMember ?m } 
+          }
+        `,
         webId: 'system'
       });
 

--- a/src/middleware/packages/webacl/services/group/actions/removeMember.js
+++ b/src/middleware/packages/webacl/services/group/actions/removeMember.js
@@ -6,9 +6,10 @@ module.exports = {
   api: async function api(ctx) {
     if (!ctx.params.deleteUserUri)
       throw new MoleculerError('needs a deleteUserUri in your POST (json)', 400, 'BAD_REQUEST');
+    if (this.settings.podProvider) ctx.meta.dataset = ctx.params.username;
 
     await ctx.call('webacl.group.removeMember', {
-      groupSlug: ctx.params.id,
+      groupSlug: this.settings.podProvider ? `${ctx.params.username}/${ctx.params.id}` : ctx.params.id,
       memberUri: ctx.params.deleteUserUri
     });
 


### PR DESCRIPTION
Several API routes to manage WAC groups were broken, obviously they had never been used.

In Pod provider mode, the base routes now includes the username (`https://localhost:3000/_groups/alice`). This makes it easier to handle permissions. New WAC groups should be POSTed to that URL.