### PR TITLE
Fix Mastodon compatibility

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
@@ -44,18 +44,18 @@ const InboxService = {
       }
 
       if (!ctx.meta.skipSignatureValidation) {
-        if (!ctx.meta.rawBody || !ctx.meta.headers)
-          throw new Error(`Cannot validate HTTP signature because of missing meta (rawBody or headers)`);
+        if (!ctx.meta.rawBody || !ctx.meta.originalHeaders)
+          throw new Error(`Cannot validate HTTP signature because of missing meta (rawBody or originalHeaders)`);
 
         const validDigest = await ctx.call('signature.verifyDigest', {
           body: ctx.meta.rawBody, // Stored by parseJson middleware
-          headers: ctx.meta.headers
+          headers: ctx.meta.originalHeaders
         });
 
         const { isValid: validSignature } = await ctx.call('signature.verifyHttpSignature', {
           url: collectionUri,
           method: 'POST',
-          headers: ctx.meta.headers
+          headers: ctx.meta.originalHeaders
         });
 
         if (!validDigest || !validSignature) {

--- a/src/middleware/packages/ldp/services/api/actions/get.js
+++ b/src/middleware/packages/ldp/services/api/actions/get.js
@@ -29,7 +29,10 @@ module.exports = async function get(ctx) {
           jsonContext: parseJson(ctx.meta.headers?.jsonldcontext)
         })
       );
+
       ctx.meta.$responseType = ctx.meta.$responseType || accept;
+      if (ctx.meta.$responseType === 'application/ld+json')
+        ctx.meta.$responseType = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`;
     } else if (types.includes('https://www.w3.org/ns/activitystreams#Collection')) {
       /*
        * AS COLLECTION
@@ -45,7 +48,7 @@ module.exports = async function get(ctx) {
           jsonContext: parseJson(ctx.meta.headers?.jsonldcontext)
         })
       );
-      ctx.meta.$responseType = 'application/ld+json';
+      ctx.meta.$responseType = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`;
     } else {
       /*
        * LDP RESOURCE
@@ -55,7 +58,7 @@ module.exports = async function get(ctx) {
         ...ctx.meta.headers
       };
 
-      if (ctx.meta.accepts && ctx.meta.accepts.includes('text/html') && this.settings.preferredViewForResource) {
+      if (ctx.meta.originalHeaders?.accept?.includes('text/html') && this.settings.preferredViewForResource) {
         const webId = ctx.meta.webId || 'anon';
         const resourceExist = await ctx.call('ldp.resource.exist', { resourceUri: uri, webId });
         if (resourceExist) {
@@ -95,6 +98,8 @@ module.exports = async function get(ctx) {
         }
       } else {
         ctx.meta.$responseType = ctx.meta.$responseType || accept;
+        if (ctx.meta.$responseType === 'application/ld+json')
+          ctx.meta.$responseType = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`;
       }
     }
 

--- a/src/middleware/packages/middlewares/index.js
+++ b/src/middleware/packages/middlewares/index.js
@@ -4,7 +4,9 @@ const Busboy = require('busboy');
 const streams = require('memory-streams');
 
 const parseHeader = async (req, res, next) => {
-  req.$ctx.meta.headers = req.headers || {};
+  req.$ctx.meta.headers = req.headers ? { ...req.headers } : {};
+  // Also remember original headers (needed for HTTP signatures verification and files type negociation)
+  req.$ctx.meta.originalHeaders = req.headers ? { ...req.headers } : {};
   next();
 };
 
@@ -37,8 +39,6 @@ const throw500 = msg => {
 
 const negotiateAccept = (req, res, next) => {
   if (!req.$ctx.meta.headers) req.$ctx.meta.headers = {};
-  // we keep the full list for further use
-  req.$ctx.meta.accepts = req.headers.accept;
   if (req.headers.accept === '*/*') {
     delete req.headers.accept;
   }


### PR DESCRIPTION
## Fix Content-Type on GET requests

Since Mastodon 4.2.5 and [this security fix](https://github.com/mastodon/mastodon/security/advisories/GHSA-3fjr-858r-92rw),  Mastodon instances expected all fetched content to have as Content-Type either `application/activity+json` or `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`. Otherwise a 401 Unauthorized error is sent.

This change was done [here](https://github.com/mastodon/mastodon/commit/9fee5e852669e26f970e278021302e1a203fc022#diff-1b2ab99d8073c43c90558fe012a0788736f9972feaea360eb1eaf3d25d70bc80R181-R190).

With this PR, all GET requests which return a `application/ld+json` Content-Type now include the ActivityStreams profile (eg. `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`)

## Fix signature validation

When POSTing to inbox, Mastodon instances now include the Content-Type in the HTTP signature (`... headers="(request-target) host date digest content-type"...`). The problem is that our API middlewares change the `Content-Type` to `application/ld+json` for easier handling... and so when we compare this header with the signature, it fails.

This PR now stores a `originalHeaders` meta, which is used in HTTP signature validation.

In the future, we should consider not changing the Content-Type and Accept headers, as this regularly cause issues.