### PR TITLE
Fix DereferenceMixin

### DIFF
--- a/src/middleware/packages/ldp/index.js
+++ b/src/middleware/packages/ldp/index.js
@@ -10,7 +10,7 @@ module.exports = {
   LdpResourceService: require('./services/resource'),
   // Mixins
   ControlledContainerMixin: require('./mixins/controlled-container'),
-  ControlledContainerDereferenceMixin: require('./mixins/controlled-container-dereference'),
+  DereferenceMixin: require('./mixins/dereference'),
   ImageProcessorMixin: require('./mixins/image-processor'),
   DocumentTaggerMixin: require('./mixins/document-tagger'),
   DisassemblyMixin: require('./mixins/disassembly'),

--- a/src/middleware/packages/ldp/mixins/dereference.js
+++ b/src/middleware/packages/ldp/mixins/dereference.js
@@ -119,18 +119,18 @@ module.exports = {
 
       const dereferenced = await this.dereference(ctx, result, this.settings.dereferencePlan);
       // Apply framing, if jsonContext if present, since dereferenced properties might not yet be framed correctly.
-      const { jsonContext } = ctx.params;
+      const { resourceUri, jsonContext } = ctx.params;
       if (jsonContext) {
         return await ctx.call('jsonld.parser.frame', {
           input: result,
           frame: {
-            '@context': jsonContext
+            '@context': jsonContext,
+            '@id': resourceUri
           }
         });
+      } else {
+        return dereferenced;
       }
-
-      // console.log('dereference called and dereferenced to', dereferenced);
-      return dereferenced;
     }
   },
   hooks: {

--- a/src/middleware/packages/webid/service.js
+++ b/src/middleware/packages/webid/service.js
@@ -1,7 +1,7 @@
 const urlJoin = require('url-join');
 const { MIME_TYPES } = require('@semapps/mime-types');
 const { foaf, schema } = require('@semapps/ontologies');
-const { ControlledContainerMixin, ControlledContainerDereferenceMixin } = require('@semapps/ldp');
+const { ControlledContainerMixin, DereferenceMixin } = require('@semapps/ldp');
 
 /** @type {import('moleculer').ServiceSchema} */
 const WebIdService = {
@@ -21,7 +21,7 @@ const WebIdService = {
     ]
   },
   dependencies: ['ldp.resource', 'ontologies'],
-  mixins: [ControlledContainerMixin, ControlledContainerDereferenceMixin],
+  mixins: [ControlledContainerMixin, DereferenceMixin],
   async created() {
     if (!this.settings.baseUrl) throw new Error('The baseUrl setting is required for webId service.');
   },

--- a/website/docs/middleware/ldp/controlled-container-dereference.md
+++ b/website/docs/middleware/ldp/controlled-container-dereference.md
@@ -1,5 +1,5 @@
 ---
-title: ControlledContainerDereferenceMixin
+title: DereferenceMixin
 ---
 
 ## Usage


### PR DESCRIPTION
The `@id` must be specified when framing after the dereference operations, otherwise we may get a `@graph` property.

I also renamed ControlledContainerDereferenceMixin to DereferenceMixin for simplicity's sake (similar to DisassemblyMixin).