### PR TITLE
Improve collections permissions

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection.js
@@ -21,6 +21,8 @@ const CollectionService = {
     accept: MIME_TYPES.JSON,
     activateTombstones: false,
     permissions: {},
+    // These default permissions can be overridden by providing
+    // a `permissions` param when calling activitypub.collection.post
     newResourcesPermissions: webId => {
       switch (webId) {
         case 'anon':
@@ -237,6 +239,7 @@ const CollectionService = {
           PREFIX semapps: <http://semapps.org/ns/core#>
           SELECT ?ordered ?summary ?dereferenceItems ?itemsPerPage ?sortPredicate ?sortOrder
           WHERE {
+            <${collectionUri}> a <https://www.w3.org/ns/activitystreams#Collection> . # This will return [] if the user has no read permission
             BIND (EXISTS{<${collectionUri}> a <https://www.w3.org/ns/activitystreams#OrderedCollection>} AS ?ordered)
             OPTIONAL { <${collectionUri}> as:summary ?summary . }
             OPTIONAL { <${collectionUri}> semapps:dereferenceItems ?dereferenceItems . }
@@ -249,8 +252,8 @@ const CollectionService = {
         webId
       });
 
-      if (!results.length === 0) {
-        throw new MoleculerError('Collection Not found', 404, 'NOT_FOUND');
+      if (results.length === 0) {
+        throw new MoleculerError('Not found', 404, 'NOT_FOUND');
       }
 
       const options = Object.fromEntries(

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collections-registry.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collections-registry.js
@@ -32,8 +32,17 @@ const CollectionsRegistryService = {
     },
     async createAndAttachCollection(ctx) {
       const { objectUri, collection } = ctx.params;
-      const { path, attachPredicate, ordered, summary, dereferenceItems, itemsPerPage, sortPredicate, sortOrder } =
-        collection || {};
+      const {
+        path,
+        attachPredicate,
+        ordered,
+        summary,
+        dereferenceItems,
+        itemsPerPage,
+        sortPredicate,
+        sortOrder,
+        permissions
+      } = collection || {};
       const collectionUri = urlJoin(objectUri, path);
 
       const exists = await ctx.call('activitypub.collection.exist', { resourceUri: collectionUri });
@@ -54,7 +63,8 @@ const CollectionsRegistryService = {
               'semapps:sortOrder': sortOrder
             },
             contentType: MIME_TYPES.JSON,
-            webId: this.settings.podProvider ? getWebIdFromUri(objectUri) : 'system'
+            webId: this.settings.podProvider ? getWebIdFromUri(objectUri) : 'system',
+            permissions // Handled by the WebAclMiddleware, if present
           },
           {
             meta: {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/reply.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/reply.js
@@ -54,7 +54,8 @@ const ReplyService = {
             ?collection a as:Collection .
             ?object as:replies ?collection .
           }
-        `
+        `,
+        webId: 'system'
       });
     },
     async updateCollectionsOptions(ctx) {

--- a/src/middleware/packages/webacl/middlewares/webacl.js
+++ b/src/middleware/packages/webacl/middlewares/webacl.js
@@ -336,7 +336,7 @@ const WebAclMiddleware = ({ baseUrl, podProvider = false, graphName = 'http://se
 
               const permissions =
                 typeof ctx.params.permissions === 'function'
-                  ? ctx.params.permissions(ctx.params.webId)
+                  ? ctx.params.permissions(ctx.params.webId || ctx.meta.webId || 'anon')
                   : ctx.params.permissions;
 
               await ctx.call('webacl.resource.addRights', {

--- a/src/middleware/tests/jest.config.js
+++ b/src/middleware/tests/jest.config.js
@@ -1,7 +1,10 @@
-module.exports = {
+/** @type {import('jest').Config} */
+const config = {
   testEnvironment: 'node',
   transform: {
     '\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }]
   },
   transformIgnorePatterns: []
 };
+
+module.exports = config;


### PR DESCRIPTION
Allow to pass a `permissions` param on the `activitypub.collection.post` (and on the collection options), which will override the default collection permissions