### PR TITLE
Allow to set a baseUrl with a path

### DIFF
--- a/src/middleware/packages/auth/mixins/auth.js
+++ b/src/middleware/packages/auth/mixins/auth.js
@@ -53,7 +53,9 @@ const AuthMixin = {
 
     this.passport.use(this.passportId, this.strategy);
 
-    for (const route of this.getApiRoutes()) {
+    const { pathname: basePath } = new URL(this.settings.baseUrl);
+
+    for (const route of this.getApiRoutes(basePath)) {
       await this.broker.call('api.addRoute', { route });
     }
   },

--- a/src/middleware/packages/auth/mixins/auth.sso.js
+++ b/src/middleware/packages/auth/mixins/auth.sso.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const session = require('express-session');
 const AuthMixin = require('./auth');
 const saveRedirectUrl = require('../middlewares/saveRedirectUrl');
@@ -65,11 +66,11 @@ const AuthSSOMixin = {
     }
   },
   methods: {
-    getApiRoutes() {
+    getApiRoutes(basePath) {
       const sessionMiddleware = session({ secret: this.settings.sessionSecret, maxAge: null });
       return [
         {
-          path: '/auth',
+          path: path.join(basePath, '/auth'),
           name: 'auth',
           use: [sessionMiddleware, this.passport.initialize(), this.passport.session()],
           aliases: {
@@ -77,7 +78,7 @@ const AuthSSOMixin = {
           }
         },
         {
-          path: '/auth/logout',
+          path: path.join(basePath, '/auth/logout'),
           name: 'auth-logout',
           use: [sessionMiddleware, this.passport.initialize(), this.passport.session()],
           aliases: {

--- a/src/middleware/packages/auth/services/auth.local.js
+++ b/src/middleware/packages/auth/services/auth.local.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { Strategy } = require('passport-local');
 const AuthMixin = require('../mixins/auth');
 const sendToken = require('../middlewares/sendToken');
@@ -153,9 +154,9 @@ const AuthLocalService = {
         }
       );
     },
-    getApiRoutes() {
+    getApiRoutes(basePath) {
       const loginRoute = {
-        path: '/auth/login',
+        path: path.join(basePath, '/auth/login'),
         name: 'auth-login',
         use: [this.passport.initialize()],
         aliases: {
@@ -164,7 +165,7 @@ const AuthLocalService = {
       };
 
       const logoutRoute = {
-        path: '/auth/logout',
+        path: path.join(basePath, '/auth/logout'),
         name: 'auth-logout',
         aliases: {
           'GET /': 'auth.logout'
@@ -172,7 +173,7 @@ const AuthLocalService = {
       };
 
       const signupRoute = {
-        path: '/auth/signup',
+        path: path.join(basePath, '/auth/signup'),
         name: 'auth-signup',
         aliases: {
           'POST /': 'auth.signup'
@@ -180,7 +181,7 @@ const AuthLocalService = {
       };
 
       const formRoute = {
-        path: '/auth',
+        path: path.join(basePath, '/auth'),
         name: 'auth',
         aliases: {
           'GET /': 'auth.redirectToForm'
@@ -188,14 +189,14 @@ const AuthLocalService = {
       };
 
       const resetPasswordRoute = {
-        path: '/auth/reset_password',
+        path: path.join(basePath, '/auth/reset_password'),
         name: 'auth-reset-password',
         aliases: {
           'POST /': 'auth.resetPassword'
         }
       };
       const setNewPasswordRoute = {
-        path: '/auth/new_password',
+        path: path.join(basePath, '/auth/new_password'),
         name: 'auth-new-password',
         aliases: {
           'POST /': 'auth.setNewPassword'
@@ -203,7 +204,7 @@ const AuthLocalService = {
       };
 
       const accountSettingsRoute = {
-        path: '/auth/account',
+        path: path.join(basePath, '/auth/account'),
         name: 'auth-account',
         aliases: {
           'GET /': 'auth.account.findSettingsByWebId',

--- a/src/middleware/packages/crypto/signature/proxy.js
+++ b/src/middleware/packages/crypto/signature/proxy.js
@@ -1,5 +1,5 @@
+const path = require('path');
 const urlJoin = require('url-join');
-const { MoleculerError } = require('moleculer').Errors;
 const { parseHeader, parseFile, saveDatasetMeta } = require('@semapps/middlewares');
 const fetch = require('node-fetch');
 const { Errors: E } = require('moleculer-web');
@@ -18,8 +18,10 @@ const ProxyService = {
   settings: {
     podProvider: false
   },
-  dependencies: ['api'],
+  dependencies: ['api', 'ldp'],
   async started() {
+    const basePath = await this.broker.call('ldp.getBasePath');
+
     const routeConfig = {
       name: 'proxy-endpoint',
       authorization: true,
@@ -30,9 +32,11 @@ const ProxyService = {
     };
 
     if (this.settings.podProvider) {
-      await this.broker.call('api.addRoute', { route: { path: '/:username([^/.][^/]+)/proxy', ...routeConfig } });
+      await this.broker.call('api.addRoute', {
+        route: { path: path.join(basePath, '/:username([^/.][^/]+)/proxy'), ...routeConfig }
+      });
     } else {
-      await this.broker.call('api.addRoute', { route: { path: '/proxy', ...routeConfig } });
+      await this.broker.call('api.addRoute', { route: { path: path.join(basePath, '/proxy'), ...routeConfig } });
     }
   },
   actions: {

--- a/src/middleware/packages/ldp/routes/getCatchAllRoute.js
+++ b/src/middleware/packages/ldp/routes/getCatchAllRoute.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const {
   parseUrl,
   parseHeader,
@@ -10,7 +11,7 @@ const {
   saveDatasetMeta
 } = require('@semapps/middlewares');
 
-function getCatchAllRoute(podProvider) {
+function getCatchAllRoute(basePath, podProvider) {
   const middlewares = [
     parseUrl,
     parseHeader,
@@ -25,7 +26,7 @@ function getCatchAllRoute(podProvider) {
 
   return {
     name: 'ldp',
-    path: podProvider ? '/:username([^/.][^/]+)/:slugParts*' : '/:slugParts*',
+    path: path.join(basePath, podProvider ? '/:username([^/.][^/]+)/:slugParts*' : '/:slugParts*'),
     // Disable the body parsers so that we can parse the body ourselves
     // (Moleculer-web doesn't handle non-JSON bodies, so we must do it)
     bodyParsers: false,

--- a/src/middleware/packages/ldp/service.js
+++ b/src/middleware/packages/ldp/service.js
@@ -101,6 +101,10 @@ module.exports = {
     getBaseUrl() {
       return this.settings.baseUrl;
     },
+    getBasePath() {
+      const { pathname } = new URL(this.settings.baseUrl);
+      return pathname;
+    },
     getSetting(ctx) {
       const { key } = ctx.params;
       return this.settings[key];

--- a/src/middleware/packages/ldp/services/api/index.js
+++ b/src/middleware/packages/ldp/services/api/index.js
@@ -23,7 +23,10 @@ module.exports = {
     put: putAction
   },
   async started() {
-    await this.broker.call('api.addRoute', { route: getCatchAllRoute(this.settings.podProvider) });
+    const { pathname: basePath } = new URL(this.settings.baseUrl);
+    await this.broker.call('api.addRoute', {
+      route: getCatchAllRoute(basePath, this.settings.podProvider)
+    });
   },
   methods: {
     getUriFromSlugParts(slugParts, username) {

--- a/src/middleware/packages/nodeinfo/service.js
+++ b/src/middleware/packages/nodeinfo/service.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const urlJoin = require('url-join');
 
 const NodeinfoService = {
@@ -24,11 +25,12 @@ const NodeinfoService = {
   },
   async started() {
     if (!this.settings.baseUrl) throw new Error('The baseUrl setting is missing from nodeinfo service');
+    const { pathname: basePath } = new URL(this.settings.baseUrl);
 
     await this.broker.call('api.addRoute', {
       route: {
         name: 'nodeinfo-links',
-        path: '/.well-known/nodeinfo',
+        path: '/.well-known/nodeinfo', // .well-known links must use the root path
         authorization: false,
         authentication: false,
         aliases: {
@@ -40,7 +42,7 @@ const NodeinfoService = {
     await this.broker.call('api.addRoute', {
       route: {
         name: 'nodeinfo-schema',
-        path: '/nodeinfo/2.1',
+        path: path.join(basePath, '/nodeinfo/2.1'),
         authorization: false,
         authentication: false,
         aliases: {

--- a/src/middleware/packages/notifications/services/expo-push/service.js
+++ b/src/middleware/packages/notifications/services/expo-push/service.js
@@ -1,9 +1,11 @@
+const path = require('path');
 const ExpoPushDeviceService = require('./device');
 const ExpoPushNotificationService = require('./notification');
 
 const ExpoPushService = {
   name: 'expo-push',
   settings: {
+    baseUrl: null,
     newDeviceNotification: {
       message: null,
       data: {}
@@ -21,9 +23,12 @@ const ExpoPushService = {
     this.broker.createService({ mixins: [ExpoPushNotificationService] });
   },
   async started() {
+    if (!this.settings.baseUrl) throw new Error('The baseUrl setting is missing from expo-push service');
+    const { pathname: basePath } = new URL(this.settings.baseUrl);
+
     await this.broker.call('api.addRoute', {
       route: {
-        path: '/push',
+        path: path.join(basePath, '/push'),
         name: 'push',
         bodyParsers: { json: true },
         authorization: false,

--- a/src/middleware/packages/pod/routes/getPodsRoute.js
+++ b/src/middleware/packages/pod/routes/getPodsRoute.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const {
   parseUrl,
   parseHeader,
@@ -23,7 +24,7 @@ const transformRouteParamsToSlugParts = (req, res, next) => {
   next();
 };
 
-function getPodsRoute() {
+function getPodsRoute(basePath) {
   const middlewares = [
     parseUrl,
     parseHeader,
@@ -39,7 +40,7 @@ function getPodsRoute() {
 
   return {
     name: 'pods',
-    path: '/:username([^/.][^/]+)',
+    path: path.join(basePath, '/:username([^/.][^/]+)'),
     // Disable the body parsers so that we can parse the body ourselves
     // (Moleculer-web doesn't handle non-JSON bodies, so we must do it)
     bodyParsers: false,

--- a/src/middleware/packages/pod/service.js
+++ b/src/middleware/packages/pod/service.js
@@ -26,8 +26,11 @@ module.exports = {
     });
     */
 
+    if (!this.settings.baseUrl) throw new Error('The baseUrl setting of the pod service is required');
+    const { pathname: basePath } = new URL(this.settings.baseUrl);
+
     // API routes to actors (and their collections) are added manually
-    await this.broker.call('api.addRoute', { route: getPodsRoute() });
+    await this.broker.call('api.addRoute', { route: getPodsRoute(basePath) });
 
     // Root container for the POD (/:username/data/)
     await this.broker.call('ldp.registry.register', {

--- a/src/middleware/packages/sparql-endpoint/service.js
+++ b/src/middleware/packages/sparql-endpoint/service.js
@@ -1,5 +1,5 @@
+const path = require('path');
 const urlJoin = require('url-join');
-const { Errors: E } = require('moleculer-web');
 const getRoute = require('./getRoute');
 
 const SparqlEndpointService = {
@@ -9,12 +9,16 @@ const SparqlEndpointService = {
     ignoreAcl: false,
     podProvider: false
   },
-  dependencies: ['triplestore', 'api'],
+  dependencies: ['triplestore', 'api', 'ldp'],
   async started() {
+    const basePath = await this.broker.call('ldp.getBasePath');
     if (this.settings.podProvider) {
-      await this.broker.call('api.addRoute', { route: getRoute('/:username([^/.][^/]+)/sparql'), toBottom: false });
+      await this.broker.call('api.addRoute', {
+        route: getRoute(path.join(basePath, '/:username([^/.][^/]+)/sparql')),
+        toBottom: false
+      });
     } else {
-      await this.broker.call('api.addRoute', { route: getRoute('/sparql'), toBottom: false });
+      await this.broker.call('api.addRoute', { route: getRoute(path.join(basePath, '/sparql')), toBottom: false });
     }
   },
   actions: {

--- a/src/middleware/packages/void/service.js
+++ b/src/middleware/packages/void/service.js
@@ -165,7 +165,7 @@ module.exports = {
     });
     await this.broker.call('api.addRoute', {
       route: {
-        path: '/.well-known/void',
+        path: '/.well-known/void', // .well-known routes must use the root path
         name: 'void-endpoint',
         bodyParsers: false,
         authorization: false,

--- a/src/middleware/packages/webacl/routes/getRoutes.js
+++ b/src/middleware/packages/webacl/routes/getRoutes.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { parseHeader, negotiateContentType, negotiateAccept, parseJson } = require('@semapps/middlewares');
 
 const onError = (req, res, err) => {
@@ -8,12 +9,12 @@ const onError = (req, res, err) => {
   res.end(JSON.stringify({ type, code, message, data, name }));
 };
 
-const getRoutes = podProvider => {
+const getRoutes = (basePath, podProvider) => {
   const middlewares = [parseHeader, parseJson, negotiateContentType, negotiateAccept];
 
   return [
     {
-      path: '/_acl',
+      path: path.join(basePath, '/_acl'),
       name: 'acl',
       authorization: false,
       authentication: true,
@@ -35,7 +36,7 @@ const getRoutes = podProvider => {
       onError
     },
     {
-      path: '/_rights',
+      path: path.join(basePath, '/_rights'),
       name: 'acl-rights',
       authorization: false,
       authentication: true,
@@ -49,7 +50,7 @@ const getRoutes = podProvider => {
       onError
     },
     {
-      path: podProvider ? '/_groups/:username([^/._][^/]+)' : '/_groups',
+      path: path.join(basePath, podProvider ? '/_groups/:username([^/._][^/]+)' : '/_groups'),
       name: 'acl-groups',
       authorization: false,
       authentication: true,

--- a/src/middleware/packages/webacl/service.js
+++ b/src/middleware/packages/webacl/service.js
@@ -61,7 +61,9 @@ module.exports = {
       }
     }
 
-    for (const route of getRoutes(this.settings.podProvider)) {
+    const { pathname: basePath } = new URL(this.settings.baseUrl);
+
+    for (const route of getRoutes(basePath, this.settings.podProvider)) {
       await this.broker.call('api.addRoute', { route });
     }
 

--- a/src/middleware/packages/webfinger/service.js
+++ b/src/middleware/packages/webfinger/service.js
@@ -15,7 +15,7 @@ const WebfingerService = {
 
     await this.broker.call('api.addRoute', {
       route: {
-        path: '/.well-known',
+        path: '/.well-known', // .well-known routes must use the root path
         name: 'webfinger-endpoint',
         bodyParsers: { json: true },
         aliases: {


### PR DESCRIPTION
Many SemApps services don't work if you set a `baseUrl` with a path, such as `http://localhost:3000/api`.

Unfortunately we cannot use the global `path` settings of Moleculer's ApiGateway, because `/.well-known` routes must be at the root of the domain.

So this PR parse the basePath from the baseUrl, and use it on all routes that don't start with `/.well-known`.

If you developed custom services, you should do that too.