### PR TITLE
OntologiesService: Persist only selected ontologies

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/index.js
+++ b/src/middleware/packages/activitypub/services/activitypub/index.js
@@ -13,7 +13,6 @@ const CollectionsRegistryService = require('./subservices/collections-registry')
 const ReplyService = require('./subservices/reply');
 const SideEffectsService = require('./subservices/side-effects');
 const FakeQueueMixin = require('../../mixins/fake-queue');
-const { ACTOR_TYPES } = require('../../constants');
 
 const ActivityPubService = {
   name: 'activitypub',
@@ -24,13 +23,7 @@ const ActivityPubService = {
     collectionsPath: '/as/collection',
     activateTombstones: true,
     selectActorData: null,
-    queueServiceUrl: null,
-    like: {
-      attachToActorTypes: null
-    },
-    follow: {
-      attachToActorTypes: null
-    }
+    queueServiceUrl: null
   },
   dependencies: ['api', 'ontologies'],
   created() {
@@ -41,9 +34,7 @@ const ActivityPubService = {
       collectionsPath,
       selectActorData,
       queueServiceUrl,
-      activateTombstones,
-      like,
-      follow
+      activateTombstones
     } = this.settings;
 
     this.broker.createService({
@@ -139,14 +130,8 @@ const ActivityPubService = {
     });
   },
   async started() {
-    await this.broker.call('ontologies.register', {
-      ...as,
-      overwrite: true
-    });
-    await this.broker.call('ontologies.register', {
-      ...sec,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', as);
+    await this.broker.call('ontologies.register', sec);
   }
 };
 

--- a/src/middleware/packages/crypto/keys/keys-service.js
+++ b/src/middleware/packages/crypto/keys/keys-service.js
@@ -67,10 +67,7 @@ const KeysService = {
   },
   async started() {
     await this.waitForServices('ontologies');
-    this.broker.call('ontologies.register', {
-      ...sec,
-      overwrite: true
-    });
+    this.broker.call('ontologies.register', sec);
 
     await this.waitForServices('keys.migration');
     this.isMigrated = await this.broker.call('keys.migration.isMigrated');

--- a/src/middleware/packages/ldp/mixins/document-tagger.js
+++ b/src/middleware/packages/ldp/mixins/document-tagger.js
@@ -10,10 +10,7 @@ module.exports = {
     }
   },
   async started() {
-    await this.broker.call('ontologies.register', {
-      ...dc,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', dc);
   },
   actions: {
     async tagCreatedResource(ctx) {

--- a/src/middleware/packages/ldp/service.js
+++ b/src/middleware/packages/ldp/service.js
@@ -87,15 +87,9 @@ module.exports = {
     }
   },
   async started() {
-    await this.broker.call('ontologies.register', {
-      ...ldp,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', ldp);
     // Used by binaries
-    await this.broker.call('ontologies.register', {
-      ...semapps,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', semapps);
   },
   actions: {
     getBaseUrl() {

--- a/src/middleware/packages/ontologies/actions/get.js
+++ b/src/middleware/packages/ontologies/actions/get.js
@@ -10,25 +10,14 @@ module.exports = {
     let { prefix, namespace, uri } = ctx.params;
     let ontology;
 
-    if (!prefix && !namespace && !uri) throw new Error('You must provide a prefix, namespace or uri parameter');
-
-    if (this.settings.persistRegistry) {
-      if (prefix) {
-        ontology = await ctx.call('ontologies.registry.getByPrefix', { prefix });
-      } else if (namespace) {
-        ontology = await ctx.call('ontologies.registry.getByNamespace', { namespace });
-      } else if (uri) {
-        const ontologies = await ctx.call('ontologies.registry.list');
-        ontology = ontologies.find(o => uri.startsWith(o.namespace));
-      }
+    if (prefix) {
+      ontology = this.ontologies[prefix] || false;
+    } else if (namespace) {
+      ontology = Object.values(this.ontologies).find(o => o.namespace === namespace);
+    } else if (uri) {
+      ontology = Object.values(this.ontologies).find(o => uri.startsWith(o.namespace));
     } else {
-      if (prefix) {
-        ontology = this.ontologies[prefix] || false;
-      } else if (namespace) {
-        ontology = Object.values(this.ontologies).find(o => o.namespace === namespace);
-      } else if (uri) {
-        ontology = Object.values(this.ontologies).find(o => uri.startsWith(o.namespace));
-      }
+      throw new Error('You must provide a prefix, namespace or uri parameter');
     }
 
     // Must return null if no results, because the cache JsonSerializer cannot handle undefined values

--- a/src/middleware/packages/ontologies/actions/list.js
+++ b/src/middleware/packages/ontologies/actions/list.js
@@ -1,11 +1,7 @@
 module.exports = {
   visibility: 'public',
   cache: true,
-  async handler(ctx) {
-    if (this.settings.persistRegistry) {
-      return await ctx.call('ontologies.registry.list');
-    } else {
-      return Object.values(this.ontologies);
-    }
+  handler() {
+    return Object.values(this.ontologies);
   }
 };

--- a/src/middleware/packages/ontologies/service.js
+++ b/src/middleware/packages/ontologies/service.js
@@ -26,8 +26,7 @@ module.exports = {
     }
   },
   async started() {
-    if (!this.settings.persistRegistry) this.ontologies = {};
-
+    this.ontologies = {};
     await this.registerAll();
   },
   actions: {
@@ -42,12 +41,13 @@ module.exports = {
   },
   methods: {
     async registerAll() {
-      if (this.settings.persistRegistry) await this.broker.waitForServices(['ontologies.registry']);
+      if (this.settings.persistRegistry) {
+        await this.broker.waitForServices(['ontologies.registry']);
+        const persistedOntologies = await this.broker.call('ontologies.registry.list');
+        this.ontologies = { ...this.ontologies, ...persistedOntologies };
+      }
       for (const ontology of this.settings.ontologies) {
-        if (!ontology || !ontology.prefix || !ontology.namespace) {
-          throw new Error(`Cannot register ontologies ! At least one ontology is incorrect.`);
-        }
-        await this.actions.register({ ...ontology, overwrite: true });
+        await this.actions.register(ontology);
       }
     }
   }

--- a/src/middleware/packages/solid/services/notifications/listener.js
+++ b/src/middleware/packages/solid/services/notifications/listener.js
@@ -22,10 +22,7 @@ module.exports = {
   async started() {
     if (!this.settings.baseUrl) throw new Error(`The baseUrl setting is required`);
 
-    await this.broker.call('ontologies.register', {
-      ...notify,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', notify);
 
     // Retrieve all active listeners
     const results = await this.actions.list({});

--- a/src/middleware/packages/solid/services/notifications/provider.js
+++ b/src/middleware/packages/solid/services/notifications/provider.js
@@ -38,10 +38,7 @@ module.exports = {
     }
   },
   async started() {
-    await this.broker.call('ontologies.register', {
-      ...notify,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', notify);
 
     await this.broker.call('ldp.link-header.register', { actionName: 'solid-notifications.provider.getLink' });
 

--- a/src/middleware/packages/solid/services/pod.js
+++ b/src/middleware/packages/solid/services/pod.js
@@ -13,10 +13,7 @@ module.exports = {
   async started() {
     if (!this.settings.baseUrl) throw new Error('The baseUrl setting of the pod service is required');
 
-    await this.broker.call('ontologies.register', {
-      ...pim,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', pim);
 
     // Register root container for the Pod (/:username/data/)
     // Do not await or we will have a circular dependency with the LdpRegistryService

--- a/src/middleware/packages/solid/services/type-index/type-indexes.js
+++ b/src/middleware/packages/solid/services/type-index/type-indexes.js
@@ -37,10 +37,7 @@ module.exports = {
     });
   },
   async started() {
-    await this.broker.call('ontologies.register', {
-      ...solid,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', solid);
   },
   actions: {
     async createAndAttachToWebId(ctx) {

--- a/src/middleware/packages/triplestore/service.js
+++ b/src/middleware/packages/triplestore/service.js
@@ -23,7 +23,7 @@ const TripleStoreService = {
     // Sub-services customization
     dataset: {}
   },
-  dependencies: ['jsonld'],
+  dependencies: ['jsonld.parser'],
   async created() {
     const { url, user, password, dataset, fusekiBase } = this.settings;
     this.subservices = {};

--- a/src/middleware/packages/void/service.js
+++ b/src/middleware/packages/void/service.js
@@ -159,10 +159,7 @@ module.exports = {
   },
   dependencies: ['ldp.registry', 'api', 'triplestore', 'ontologies', 'jsonld'],
   async started() {
-    await this.broker.call('ontologies.register', {
-      ...voidOntology,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', voidOntology);
     await this.broker.call('api.addRoute', {
       route: {
         path: '/.well-known/void', // .well-known routes must use the root path

--- a/src/middleware/packages/webacl/service.js
+++ b/src/middleware/packages/webacl/service.js
@@ -67,17 +67,8 @@ module.exports = {
       await this.broker.call('api.addRoute', { route });
     }
 
-    await this.broker.call('ontologies.register', {
-      ...acl,
-      overwrite: true
-    });
-    await this.broker.call('ontologies.register', {
-      ...vcard,
-      overwrite: true
-    });
-    await this.broker.call('ontologies.register', {
-      ...rdfs,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', acl);
+    await this.broker.call('ontologies.register', vcard);
+    await this.broker.call('ontologies.register', rdfs);
   }
 };

--- a/src/middleware/packages/webid/service.js
+++ b/src/middleware/packages/webid/service.js
@@ -26,14 +26,8 @@ const WebIdService = {
     if (!this.settings.baseUrl) throw new Error('The baseUrl setting is required for webId service.');
   },
   async started() {
-    await this.broker.call('ontologies.register', {
-      ...foaf,
-      overwrite: true
-    });
-    await this.broker.call('ontologies.register', {
-      ...schema,
-      overwrite: true
-    });
+    await this.broker.call('ontologies.register', foaf);
+    await this.broker.call('ontologies.register', schema);
   },
   actions: {
     /**

--- a/src/middleware/tests/ontologies/initialize.js
+++ b/src/middleware/tests/ontologies/initialize.js
@@ -7,7 +7,7 @@ const { TripleStoreService } = require('@semapps/triplestore');
 const CONFIG = require('../config');
 const { clearDataset } = require('../utils');
 
-module.exports = async (cacher, persistRegistry) => {
+module.exports = async cacher => {
   await clearDataset(CONFIG.SETTINGS_DATASET);
 
   const broker = new ServiceBroker({
@@ -53,7 +53,7 @@ module.exports = async (cacher, persistRegistry) => {
   broker.createService({
     mixins: [OntologiesService],
     settings: {
-      persistRegistry,
+      persistRegistry: true,
       settingsDataset: CONFIG.SETTINGS_DATASET
     }
   });

--- a/src/middleware/tests/ontologies/ontologies.test.js
+++ b/src/middleware/tests/ontologies/ontologies.test.js
@@ -11,130 +11,133 @@ jest.setTimeout(10000);
 
 const localContextUri = urlJoin(CONFIG.HOME_URL, '.well-known/context.jsonld');
 
-describe.each([true])('Register ontologies with persistRegistry %s', persistRegistry => {
-  describe.each([false, true])('and with cacher %s', cacher => {
-    let broker;
+describe.each([false, true])('Register ontologies with cacher %s', cacher => {
+  let broker;
 
-    beforeAll(async () => {
-      broker = await initialize(cacher, persistRegistry);
-    });
-    afterAll(async () => {
-      if (broker) await broker.stop();
-    });
+  beforeAll(async () => {
+    broker = await initialize(cacher);
+  });
+  afterAll(async () => {
+    if (broker) await broker.stop();
+  });
 
-    test('Register a new ontology', async () => {
-      await broker.call('ontologies.register', { ...ont1 });
+  test('Register a new ontology', async () => {
+    await broker.call('ontologies.register', { ...ont1 });
 
-      await expect(broker.call('ontologies.get', { prefix: ont1.prefix })).resolves.toMatchObject(ont1);
-      await expect(broker.call('ontologies.get', { namespace: ont1.namespace })).resolves.toMatchObject(ont1);
-      await expect(broker.call('ontologies.get', { uri: `${ont1.namespace}MyClass` })).resolves.toMatchObject(ont1);
+    await expect(broker.call('ontologies.get', { prefix: ont1.prefix })).resolves.toMatchObject(ont1);
+    await expect(broker.call('ontologies.get', { namespace: ont1.namespace })).resolves.toMatchObject(ont1);
+    await expect(broker.call('ontologies.get', { uri: `${ont1.namespace}MyClass` })).resolves.toMatchObject(ont1);
 
-      await expect(broker.call('ontologies.list')).resolves.toEqual(
-        expect.arrayContaining([expect.objectContaining(ont1)])
-      );
-    });
+    await expect(broker.call('ontologies.list')).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining(ont1)])
+    );
+  });
 
-    test('Register the same ontology', async () => {
-      await broker.call('ontologies.register', {
-        ...ont1,
-        owl: 'https://www.w3.org/ns/ontology1.ttl'
-      });
-
-      await expect(broker.call('ontologies.get', { prefix: 'ont1' })).resolves.toMatchObject({
-        ...ont1,
-        owl: 'https://www.w3.org/ns/ontology1.ttl'
-      });
-
-      await expect(broker.call('ontologies.list')).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            ...ont1,
-            owl: 'https://www.w3.org/ns/ontology1.ttl'
-          })
-        ])
-      );
-
-      await expect(broker.call('jsonld.context.get')).resolves.toEqual([ont1.jsonldContext]);
+  test('Register the same ontology', async () => {
+    await broker.call('ontologies.register', {
+      ...ont1,
+      owl: 'https://www.w3.org/ns/ontology1.ttl'
     });
 
-    test('Register a 2nd ontology', async () => {
-      await broker.call('ontologies.register', { ...ont2 });
-
-      await expect(broker.call('ontologies.get', { prefix: 'ont2' })).resolves.toMatchObject(ont2);
-
-      await expect(broker.call('ontologies.list')).resolves.toEqual(
-        expect.arrayContaining([expect.objectContaining(ont1), expect.objectContaining(ont2)])
-      );
-
-      await expect(broker.call('jsonld.context.get')).resolves.toEqual([ont1.jsonldContext, localContextUri]);
-
-      await expect(fetch(localContextUri).then(res => res.json())).resolves.toEqual({
-        '@context': {
-          ont2: 'https://www.w3.org/ns/ontology2#'
-        }
-      });
+    await expect(broker.call('ontologies.get', { prefix: 'ont1' })).resolves.toMatchObject({
+      ...ont1,
+      owl: 'https://www.w3.org/ns/ontology1.ttl'
     });
 
-    test('Register a 3nd ontology', async () => {
-      await broker.call('ontologies.register', { ...ont3 });
+    await expect(broker.call('ontologies.list')).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ...ont1,
+          owl: 'https://www.w3.org/ns/ontology1.ttl'
+        })
+      ])
+    );
 
-      await expect(broker.call('ontologies.get', { prefix: 'ont3' })).resolves.toMatchObject(ont3);
+    await expect(broker.call('jsonld.context.get')).resolves.toEqual([ont1.jsonldContext]);
+  });
 
-      await expect(broker.call('ontologies.list')).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining(ont1),
-          expect.objectContaining(ont2),
-          expect.objectContaining(ont3)
-        ])
-      );
+  test('Register a 2nd ontology', async () => {
+    await broker.call('ontologies.register', { ...ont2 });
 
-      await expect(broker.call('jsonld.context.get')).resolves.toEqual([ont1.jsonldContext, localContextUri]);
+    await expect(broker.call('ontologies.get', { prefix: 'ont2' })).resolves.toMatchObject(ont2);
 
-      // Only the ontologies 2 and 3 should be included
-      await expect(fetch(localContextUri).then(res => res.json())).resolves.toEqual({
-        '@context': {
-          ont2: 'https://www.w3.org/ns/ontology2#',
-          ont3: 'https://www.w3.org/ns/ontology3#',
-          friend: {
-            '@id': 'ont3:friend',
-            '@type': '@id',
-            '@protected': true
-          }
-        }
-      });
+    await expect(broker.call('ontologies.list')).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining(ont1), expect.objectContaining(ont2)])
+    );
+
+    await expect(broker.call('jsonld.context.get')).resolves.toEqual([ont1.jsonldContext, localContextUri]);
+
+    await expect(fetch(localContextUri).then(res => res.json())).resolves.toEqual({
+      '@context': {
+        ont2: 'https://www.w3.org/ns/ontology2#'
+      }
     });
+  });
 
-    test('Register a 4th ontology with JSON-LD conflicts', async () => {
-      await expect(broker.call('ontologies.register', { ...ont4 })).rejects.toThrow();
-    });
+  test('Register a 3nd ontology', async () => {
+    await broker.call('ontologies.register', { ...ont3 });
 
-    test('Find prefixes with prefix.cc', async () => {
-      let result = await broker.call('ontologies.findPrefix', { uri: 'http://xmlns.com/foaf/0.1/name' });
-      expect(result).toBe('foaf');
+    await expect(broker.call('ontologies.get', { prefix: 'ont3' })).resolves.toMatchObject(ont3);
 
-      result = await broker.call('ontologies.findPrefix', { uri: 'http://xmlns.com/foaf/0.1/' });
-      expect(result).toBe('foaf');
+    await expect(broker.call('ontologies.list')).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(ont1),
+        expect.objectContaining(ont2),
+        expect.objectContaining(ont3)
+      ])
+    );
 
-      result = await broker.call('ontologies.findPrefix', { uri: 'http://xmlns.com/foaf' });
-      expect(result).toBeNull();
-    });
+    await expect(broker.call('jsonld.context.get')).resolves.toEqual([ont1.jsonldContext, localContextUri]);
 
-    test('Get RDF prefixes', async () => {
-      const rdfPrefixes = await broker.call('ontologies.getRdfPrefixes');
-
-      expect(rdfPrefixes).toBe(
-        'PREFIX ont1: <https://www.w3.org/ns/ontology1#>\nPREFIX ont2: <https://www.w3.org/ns/ontology2#>\nPREFIX ont3: <https://www.w3.org/ns/ontology3#>'
-      );
-    });
-
-    test('Get prefixes', async () => {
-      const prefixes = await broker.call('ontologies.getPrefixes');
-
-      expect(prefixes).toEqual({
-        ont1: 'https://www.w3.org/ns/ontology1#',
+    // Only the ontologies 2 and 3 should be included
+    await expect(fetch(localContextUri).then(res => res.json())).resolves.toEqual({
+      '@context': {
         ont2: 'https://www.w3.org/ns/ontology2#',
-        ont3: 'https://www.w3.org/ns/ontology3#'
-      });
+        ont3: 'https://www.w3.org/ns/ontology3#',
+        friend: {
+          '@id': 'ont3:friend',
+          '@type': '@id',
+          '@protected': true
+        }
+      }
+    });
+  });
+
+  test('Register a 4th ontology with persist option', async () => {
+    await broker.call('ontologies.register', { ...ont4, persist: true });
+
+    await expect(broker.call('ontologies.get', { prefix: 'ont4' })).resolves.toMatchObject(ont4);
+  });
+
+  test('Find prefixes with prefix.cc', async () => {
+    let result = await broker.call('ontologies.findPrefix', { uri: 'http://xmlns.com/foaf/0.1/name' });
+    expect(result).toBe('foaf');
+
+    result = await broker.call('ontologies.findPrefix', { uri: 'http://xmlns.com/foaf/0.1/' });
+    expect(result).toBe('foaf');
+
+    result = await broker.call('ontologies.findPrefix', { uri: 'http://xmlns.com/foaf' });
+    expect(result).toBeNull();
+
+    await expect(broker.call('ontologies.findPrefix', { uri: 'foaf:name' })).rejects.toThrow();
+  });
+
+  test('Get RDF prefixes', async () => {
+    const rdfPrefixes = await broker.call('ontologies.getRdfPrefixes');
+
+    expect(rdfPrefixes).toBe(
+      'PREFIX ont1: <https://www.w3.org/ns/ontology1#>\nPREFIX ont2: <https://www.w3.org/ns/ontology2#>\nPREFIX ont3: <https://www.w3.org/ns/ontology3#>\nPREFIX ont4: <https://www.w3.org/ns/ontology4#>'
+    );
+  });
+
+  test('Get prefixes', async () => {
+    const prefixes = await broker.call('ontologies.getPrefixes');
+
+    expect(prefixes).toEqual({
+      ont1: 'https://www.w3.org/ns/ontology1#',
+      ont2: 'https://www.w3.org/ns/ontology2#',
+      ont3: 'https://www.w3.org/ns/ontology3#',
+      ont4: 'https://www.w3.org/ns/ontology4#'
     });
   });
 });

--- a/src/middleware/tests/ontologies/ontologies.test.js
+++ b/src/middleware/tests/ontologies/ontologies.test.js
@@ -34,15 +34,10 @@ describe.each([true])('Register ontologies with persistRegistry %s', persistRegi
       );
     });
 
-    test('Register the same ontology with overwrite = false', async () => {
-      await expect(broker.call('ontologies.register', { ...ont1, overwrite: false })).rejects.toThrow();
-    });
-
-    test('Register the same ontology with overwrite = true', async () => {
+    test('Register the same ontology', async () => {
       await broker.call('ontologies.register', {
         ...ont1,
-        owl: 'https://www.w3.org/ns/ontology1.ttl',
-        overwrite: true
+        owl: 'https://www.w3.org/ns/ontology1.ttl'
       });
 
       await expect(broker.call('ontologies.get', { prefix: 'ont1' })).resolves.toMatchObject({

--- a/src/middleware/tests/ontologies/ontologies/ont4.json
+++ b/src/middleware/tests/ontologies/ontologies/ont4.json
@@ -1,11 +1,4 @@
 {
   "prefix": "ont4",
-  "namespace": "https://www.w3.org/ns/ontology4#",
-  "jsonldContext": {
-    "ont4": "https://www.w3.org/ns/ontology4#",
-    "friend": {
-      "@id": "ont4:friend",
-      "@type": "@id"
-    }
-  }
+  "namespace": "https://www.w3.org/ns/ontology4#"
 }

--- a/src/middleware/tests/ontologies/ontologies/ont5.json
+++ b/src/middleware/tests/ontologies/ontologies/ont5.json
@@ -1,0 +1,10 @@
+{
+  "prefix": "ont5",
+  "namespace": "https://www.w3.org/ns/ontology5#",
+  "jsonldContext": {
+    "friend": {
+      "@id": "ont5:friend",
+      "@type": "@id"
+    }
+  }
+}

--- a/website/docs/middleware/ontologies.md
+++ b/website/docs/middleware/ontologies.md
@@ -52,19 +52,20 @@ module.exports = {
 
 Any services may call the [`register`](#register) action to add new ontologies. That's how most core services register the ontologies they need.
 
-By default, the ontologies registry is not persisted. It is kept in memory and so the `register` action must be called again on every restart.
+By default, ontologies are not persisted. They are kept in memory and so the `register` action must be called again on every restart.
 
-If you wish ontologies to be persisted, you must set the `persistRegistry` setting to `true`.
+If you wish ontologies to be persisted, you must set the `persistRegistry` setting to `true` and call the `register` action with `persist: true`.
 
-By default, they will be persisted in a dataset named `settings` (the same used by the `auth.account` service).
-If you wish to use another dataset name, you can change the `settingsDataset` setting.
+By default, they will be persisted in a dataset named `settings` (the same used by the `auth.account` service). If you wish to use another dataset name, you can change the `settingsDataset` setting.
+
+Note that only the `prefix` and `namespaces` properties can be persisted.
 
 ## Settings
 
 | Property          | Type      | Default    | Description                                                             |
 | ----------------- | --------- | ---------- | ----------------------------------------------------------------------- |
 | `ontologies`      | `[Array]` |            | List of (custom) ontologies to be registered                            |
-| `persistRegistry` | `Boolean` | false      | If true, registered ontologies will be persisted in a dataset           |
+| `persistRegistry` | `Boolean` | false      | If true, registered ontologies can be persisted in a dataset            |
 | `settingsDataset` | `String`  | "settings" | The dataset where to persist ontologies (if `persistRegistry` is true ) |
 
 ## Core ontologies
@@ -81,10 +82,24 @@ These ontologies can be imported individually using their prefixes, or as a whol
 | `rdf`     | http://www.w3.org/1999/02/22-rdf-syntax-ns# |
 | `rdfs`    | http://www.w3.org/2000/01/rdf-schema#       |
 | `sec`     | https://w3id.org/security#                  |
+| `skos`    | http://www.w3.org/2008/05/skos#             |
 | `semapps` | http://semapps.org/ns/core#                 |
 | `vcard`   | http://www.w3.org/2006/vcard/ns#            |
 | `void`    | http://rdfs.org/ns/void#                    |
 | `xsd`     | http://www.w3.org/2001/XMLSchema#           |
+
+## Solid-related ontologies
+
+These ontologies can be imported individually using their prefixes, or as a whole with `solidOntologies`.
+
+| Prefix    | Namespace                                 |
+| --------- | ----------------------------------------- |
+| `apods`   | http://activitypods.org/ns/core#          |
+| `interop` | http://www.w3.org/ns/solid/interop#       |
+| `notify`  | http://www.w3.org/ns/solid/notifications# |
+| `oidc`    | http://www.w3.org/ns/solid/oidc#          |
+| `pim`     | http://www.w3.org/ns/pim/space#           |
+| `solid`   | http://www.w3.org/ns/solid/terms#         |
 
 ## Actions
 
@@ -171,4 +186,4 @@ Register a new ontology.
 | `owl`                | `String`                      |              | URL of the OWL file (used by the [InferenceService](./inference.md))                                                                  |
 | `jsonldContext`      | `String`, `Array` or `Object` |              | JSON-LD context associated with the ontology. Can be an URL, a array or an object                                                     |
 | `preserveContextUri` | `Boolean`                     | false        | If true, the `jsonldContext` will not be merged in the local context file. Works only if jsonldContext is an URL or an array of URLs. |
-| `overwrite`          | `Boolean`                     | false        | If true, any existing ontology with the same prefix and URL will be overwritten                                                       |
+| `persist`            | `Boolean`                     | false        | If true, the ontology will be persisted (see above)                                                                                   |


### PR DESCRIPTION
Until now the OntologiesService had a `persistRegistry` setting which saved all registered ontologies to the settings dataset, including their JSON-LD context.

This added a lot of data that is not very useful, since most ontologies are core ontologies. This option is only for Pod providers which want to accept custom ontologies.

So I changed the API of the service with a `persist` param that can be passed to the `ontologies.register` service. Only those ontologies are persisted. And only the prefix and namespace can be persisted.