### PR TITLE
Add descriptions for internal resources types

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/activity.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/activity.js
@@ -25,6 +25,13 @@ const ActivityService = {
       patch: 'activitypub.activity.forbidden',
       put: 'activitypub.activity.forbidden',
       delete: 'activitypub.activity.forbidden'
+    },
+    description: {
+      labelMap: {
+        en: 'Activities',
+        fr: 'Activités'
+      },
+      internal: true
     }
   },
   dependencies: ['ldp.container'],

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection.js
@@ -45,7 +45,14 @@ const CollectionService = {
           };
       }
     },
-    excludeFromMirror: true
+    excludeFromMirror: true,
+    description: {
+      labelMap: {
+        en: 'Collections',
+        fr: 'Collections'
+      },
+      internal: true
+    }
   },
   dependencies: ['triplestore', 'ldp.resource'],
   actions: {

--- a/src/middleware/packages/auth/services/capabilities.js
+++ b/src/middleware/packages/auth/services/capabilities.js
@@ -15,7 +15,13 @@ const CapabilitiesService = {
     excludeFromMirror: true,
     activateTombstones: false,
     permissions: {},
-    newResourcesPermissions: {}
+    newResourcesPermissions: {},
+    description: {
+      labelMap: {
+        en: 'Capabilities'
+      },
+      internal: true
+    }
   },
   hooks: {
     before: {

--- a/src/middleware/packages/crypto/keys/key-container.js
+++ b/src/middleware/packages/crypto/keys/key-container.js
@@ -45,7 +45,13 @@ module.exports = {
       patch: 'keys.container.forbidden',
       delete: 'keys.delete'
     },
-    podProvider: false
+    description: {
+      labelMap: {
+        en: 'Private Keys',
+        fr: 'Clés privées'
+      },
+      internal: true
+    }
   },
   actions: {
     async forbidden(ctx) {

--- a/src/middleware/packages/crypto/keys/public-key-container.js
+++ b/src/middleware/packages/crypto/keys/public-key-container.js
@@ -44,7 +44,13 @@ module.exports = {
       put: 'keys.public-container.forbidden',
       patch: 'keys.public-container.forbidden'
     },
-    podProvider: false
+    description: {
+      labelMap: {
+        en: 'Public Keys',
+        fr: 'Clés publiques'
+      },
+      internal: true
+    }
   },
 
   actions: {

--- a/src/middleware/packages/ldp/utils.js
+++ b/src/middleware/packages/ldp/utils.js
@@ -40,27 +40,32 @@ const buildBlankNodesQuery = depth => {
   return { construct, where };
 };
 
+const isURL = value => (typeof value === 'string' || value instanceof String) && value.startsWith('http');
+
+/** If the value starts with `http` or `urn:` */
+const isURI = value =>
+  (typeof value === 'string' || value instanceof String) && (value.startsWith('http') || value.startsWith('urn:'));
+
 const buildFiltersQuery = filters => {
   let where = '';
   if (filters) {
     Object.keys(filters).forEach((predicate, i) => {
       if (filters[predicate]) {
         where += `
-          FILTER EXISTS { ?s1 ${predicate.startsWith('http') ? `<${predicate}>` : predicate} ${
-            filters[predicate].startsWith('http') ? `<${filters[predicate]}>` : `"${filters[predicate]}"`
-          } } .
+          FILTER EXISTS { 
+            ?s1 ${isURI(predicate) ? `<${predicate}>` : predicate} ${
+              isURI(filters[predicate]) ? `<${filters[predicate]}>` : `"${filters[predicate]}"`
+            } } .
         `;
       } else {
         where += `
-          FILTER NOT EXISTS { ?s1 ${predicate.startsWith('http') ? `<${predicate}>` : predicate} ?unwanted${i} } .
+          FILTER NOT EXISTS { ?s1 ${isURI(predicate) ? `<${predicate}>` : predicate} ?unwanted${i} } .
         `;
       }
     });
   }
   return { where };
 };
-
-const isURL = value => (typeof value === 'string' || value instanceof String) && value.startsWith('http');
 
 const isObject = value => typeof value === 'object' && !Array.isArray(value) && value !== null;
 
@@ -170,6 +175,7 @@ module.exports = {
   buildBlankNodesQuery,
   buildFiltersQuery,
   isURL,
+  isURI,
   isObject,
   getSlugFromUri,
   getContainerFromUri,

--- a/src/middleware/packages/solid/services/notifications/channels/webhook-channel.js
+++ b/src/middleware/packages/solid/services/notifications/channels/webhook-channel.js
@@ -18,8 +18,13 @@ const WebhookChannel2023Service = {
   settings: {
     channelType: 'WebhookChannel2023',
     sendOrReceive: 'send',
-
-    baseUrl: null
+    baseUrl: null,
+    description: {
+      labelMap: {
+        en: 'Webhook Channel'
+      },
+      internal: true
+    }
   },
   created() {
     if (!this.createJob) throw new Error('The QueueMixin must be configured with this service');
@@ -46,7 +51,6 @@ const WebhookChannel2023Service = {
       }
     }
   },
-
   methods: {
     onEvent(channel, activity) {
       this.createJob('webhookPost', channel.sendTo, { channel, activity }, queueOptions);

--- a/src/middleware/packages/solid/services/notifications/channels/websocket-channel.js
+++ b/src/middleware/packages/solid/services/notifications/channels/websocket-channel.js
@@ -9,10 +9,14 @@ const WebSocketChannel2023Service = {
   settings: {
     channelType: 'WebSocketChannel2023',
     sendOrReceive: 'receive',
-
-    baseUrl: null
+    baseUrl: null,
+    description: {
+      labelMap: {
+        en: 'WebSocket Channel'
+      },
+      internal: true
+    }
   },
-
   async started() {
     this.socketConnections = [];
 
@@ -60,7 +64,6 @@ const WebSocketChannel2023Service = {
       };
     }
   },
-
   methods: {
     onChannelDeleted(channel) {
       // Close open connections (is removed from array on close event).

--- a/src/middleware/packages/solid/services/type-index/type-indexes.js
+++ b/src/middleware/packages/solid/services/type-index/type-indexes.js
@@ -120,6 +120,7 @@ module.exports = {
           const podUrl = await ctx.call('pod.getUrl', { webId });
           const containerUri = urlJoin(podUrl, container.path);
           for (const type of arrayOf(container.acceptedTypes)) {
+            this.logger.info(`Registering ${containerUri} with type ${type}...`);
             await ctx.call('type-registrations.register', { type, containerUri, webId });
             if (container.description) {
               await ctx.call('type-registrations.attachDescription', {

--- a/src/middleware/packages/solid/services/type-index/type-registrations.js
+++ b/src/middleware/packages/solid/services/type-index/type-registrations.js
@@ -108,10 +108,11 @@ module.exports = {
         labelMap: { type: 'object', optional: true },
         labelPredicate: { type: 'string', optional: true },
         openEndpoint: { type: 'string', optional: true },
-        icon: { type: 'string', optional: true }
+        icon: { type: 'string', optional: true },
+        internal: { type: 'boolean', optional: true }
       },
       async handler(ctx) {
-        const { type, webId, labelMap, labelPredicate, openEndpoint, icon } = ctx.params;
+        const { type, webId, labelMap, labelPredicate, openEndpoint, icon, internal } = ctx.params;
 
         const [registration] = await this.actions.getByType({ type, webId }, { parentCtx: ctx });
         if (!registration) throw new Error(`No registration found with type ${type}`);
@@ -138,7 +139,8 @@ module.exports = {
             'skos:prefLabel': label,
             'apods:labelPredicate': labelPredicate,
             'apods:openEndpoint': openEndpoint,
-            'apods:icon': icon
+            'apods:icon': icon,
+            'apods:internal': internal || false
           },
           contentType: MIME_TYPES.JSON,
           webId

--- a/src/middleware/packages/webid/service.js
+++ b/src/middleware/packages/webid/service.js
@@ -6,13 +6,24 @@ const { ControlledContainerMixin, DereferenceMixin } = require('@semapps/ldp');
 /** @type {import('moleculer').ServiceSchema} */
 const WebIdService = {
   name: 'webid',
+  mixins: [ControlledContainerMixin, DereferenceMixin],
   settings: {
-    path: '/foaf/person',
     baseUrl: null,
+    podProvider: false,
+    // ControlledContainerMixin
+    path: '/foaf/person',
     acceptedTypes: ['http://xmlns.com/foaf/0.1/Person'],
     defaultAccept: 'text/turtle',
-    podProvider: false,
     podsContainer: false,
+    description: {
+      labelMap: {
+        en: 'Actor',
+        fr: 'Acteur'
+      },
+      labelPredicate: 'foaf:nick',
+      internal: true
+    },
+    // DereferenceMixin
     dereferencePlan: [
       {
         property: 'publicKey'
@@ -21,7 +32,6 @@ const WebIdService = {
     ]
   },
   dependencies: ['ldp.resource', 'ontologies'],
-  mixins: [ControlledContainerMixin, DereferenceMixin],
   async created() {
     if (!this.settings.baseUrl) throw new Error('The baseUrl setting is required for webId service.');
   },


### PR DESCRIPTION
Allow to pass a `internal` boolean to the description of controlled containers.

It will be registered in the TypeRegistration as `apods:internal`.

Also:
- Add a description for all internal resources types
- Fix container filters to consider string starting with `urn:` as URIs