### PR TITLE
fix: disable nx daemon due to high resource consumption

### DIFF
--- a/src/frontend/nx.json
+++ b/src/frontend/nx.json
@@ -1,9 +1,9 @@
 {
   "tasksRunnerOptions": {
-    "useDaemonProcess": false,
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
+        "useDaemonProcess": false,
         "cacheableOperations": ["build", "yalc:publish"]
       }
     }

--- a/src/middleware/nx.json
+++ b/src/middleware/nx.json
@@ -1,9 +1,9 @@
 {
   "tasksRunnerOptions": {
-    "useDaemonProcess": false,
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
+        "useDaemonProcess": false,
         "cacheableOperations": []
       }
     }


### PR DESCRIPTION
Previously, the setting was placed at the wrong place. Now the daemon should actually not start on running yarn commands in the middleware or frontend.