### PR TITLE
Refactor remote URIs detection

### DIFF
--- a/src/middleware/packages/inference/subservices/remote.js
+++ b/src/middleware/packages/inference/subservices/remote.js
@@ -1,7 +1,6 @@
 const fetch = require('node-fetch');
 const N3 = require('n3');
 const { ACTIVITY_TYPES, OBJECT_TYPES, ActivitiesHandlerMixin, matchActivity } = require('@semapps/activitypub');
-const urlJoin = require('url-join');
 
 const { DataFactory } = N3;
 const { triple, namedNode } = DataFactory;
@@ -88,11 +87,6 @@ module.exports = {
       }
     }
   },
-  methods: {
-    isRemoteUri(uri) {
-      return !urlJoin(uri, '/').startsWith(this.settings.baseUrl);
-    }
-  },
   activities: {
     offerInference: {
       async match(activity, fetcher) {
@@ -132,7 +126,7 @@ module.exports = {
         if (this.settings.acceptFromRemoteServers && recipientUri === this.relayActor.id) {
           const relationship = activity.object.object;
           if (relationship.subject && relationship.relationship && relationship.object) {
-            if (this.isRemoteUri(relationship.subject)) {
+            if (await ctx.call('ldp.remote.isRemote', { resourceUri: relationship.subject })) {
               this.logger.warn('Attempt at offering an inverse relationship on a remote resource. Aborting...');
               return;
             }

--- a/src/middleware/packages/ldp/services/container/actions/attach.js
+++ b/src/middleware/packages/ldp/services/container/actions/attach.js
@@ -14,7 +14,7 @@ module.exports = {
     const { containerUri, resourceUri } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
 
-    const isRemoteContainer = this.isRemoteUri(containerUri, ctx.meta.dataset);
+    const isRemoteContainer = await ctx.call('ldp.remote.isRemote', { resourceUri: containerUri });
 
     const resourceExists = await ctx.call('ldp.resource.exist', { resourceUri, webId });
     if (!resourceExists) {

--- a/src/middleware/packages/ldp/services/container/actions/detach.js
+++ b/src/middleware/packages/ldp/services/container/actions/detach.js
@@ -11,7 +11,7 @@ module.exports = {
     let { containerUri, resourceUri } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
 
-    const isRemoteContainer = this.isRemoteUri(containerUri, ctx.meta.dataset);
+    const isRemoteContainer = await ctx.call('ldp.remote.isRemote', { resourceUri: containerUri });
 
     if (new URL(containerUri).pathname === '/') {
       if (isRemoteContainer) return; // indeed, we never have the root container on a mirror.

--- a/src/middleware/packages/ldp/services/container/actions/exist.js
+++ b/src/middleware/packages/ldp/services/container/actions/exist.js
@@ -11,7 +11,7 @@ module.exports = {
     // Matches container with or without trailing slash
     const containerUri = ctx.params.containerUri.replace(/\/+$/, '');
 
-    const isRemoteContainer = this.isRemoteUri(containerUri, ctx.meta.dataset);
+    const isRemoteContainer = await ctx.call('ldp.remote.isRemote', { resourceUri: containerUri });
 
     return await ctx.call('triplestore.query', {
       query: `

--- a/src/middleware/packages/ldp/services/container/actions/includes.js
+++ b/src/middleware/packages/ldp/services/container/actions/includes.js
@@ -13,7 +13,7 @@ module.exports = {
     const containerUri = ctx.params.containerUri.replace(/\/+$/, '');
     const childUri = ctx.params.resourceUri.replace(/\/+$/, '');
 
-    const isRemoteContainer = this.isRemoteUri(containerUri, ctx.meta.dataset);
+    const isRemoteContainer = await ctx.call('ldp.remote.isRemote', { resourceUri: containerUri });
 
     return await ctx.call('triplestore.query', {
       query: `

--- a/src/middleware/packages/ldp/services/container/index.js
+++ b/src/middleware/packages/ldp/services/container/index.js
@@ -1,4 +1,3 @@
-const urlJoin = require('url-join');
 const attachAction = require('./actions/attach');
 const clearAction = require('./actions/clear');
 const createAction = require('./actions/create');
@@ -40,16 +39,6 @@ module.exports = {
     isEmpty: isEmptyAction,
     post: postAction,
     patch: patchAction
-  },
-  methods: {
-    isRemoteUri(uri, dataset) {
-      if (this.settings.podProvider && !dataset)
-        throw new Error(`Unable to know if ${uri} is remote. In Pod provider config, the dataset must be provided`);
-      return (
-        !urlJoin(uri, '/').startsWith(this.settings.baseUrl) ||
-        (this.settings.podProvider && !urlJoin(uri, '/').startsWith(`${urlJoin(this.settings.baseUrl, dataset)}/`))
-      );
-    }
   },
   hooks: {
     before: {

--- a/src/middleware/packages/ldp/services/remote/actions/delete.js
+++ b/src/middleware/packages/ldp/services/remote/actions/delete.js
@@ -8,7 +8,7 @@ module.exports = {
     const { resourceUri } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId;
 
-    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
+    if (!(await this.actions.isRemote({ resourceUri }, { parentCtx: ctx }))) {
       throw new Error(
         `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset})`
       );

--- a/src/middleware/packages/ldp/services/remote/actions/delete.js
+++ b/src/middleware/packages/ldp/services/remote/actions/delete.js
@@ -8,8 +8,10 @@ module.exports = {
     const { resourceUri } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId;
 
-    if (!this.isRemoteUri(resourceUri, webId)) {
-      throw new Error(`The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId})`);
+    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
+      throw new Error(
+        `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset})`
+      );
     }
 
     if (this.settings.podProvider) {

--- a/src/middleware/packages/ldp/services/remote/actions/get.js
+++ b/src/middleware/packages/ldp/services/remote/actions/get.js
@@ -29,7 +29,7 @@ module.exports = {
         ? 'networkOnly'
         : ctx.params.strategy;
 
-    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
+    if (!(await this.actions.isRemote({ resourceUri }, { parentCtx: ctx }))) {
       throw new Error(
         `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset})`
       );

--- a/src/middleware/packages/ldp/services/remote/actions/get.js
+++ b/src/middleware/packages/ldp/services/remote/actions/get.js
@@ -29,7 +29,7 @@ module.exports = {
         ? 'networkOnly'
         : ctx.params.strategy;
 
-    if (!this.isRemoteUri(resourceUri, webId)) {
+    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
       throw new Error(
         `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset})`
       );

--- a/src/middleware/packages/ldp/services/remote/actions/getNetwork.js
+++ b/src/middleware/packages/ldp/services/remote/actions/getNetwork.js
@@ -20,7 +20,7 @@ module.exports = {
     const headers = new fetch.Headers({ accept });
     if (jsonContext) headers.set('JsonLdContext', JSON.stringify(jsonContext));
 
-    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
+    if (!(await this.actions.isRemote({ resourceUri }, { parentCtx: ctx }))) {
       throw new Error(
         `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset})`
       );

--- a/src/middleware/packages/ldp/services/remote/actions/getNetwork.js
+++ b/src/middleware/packages/ldp/services/remote/actions/getNetwork.js
@@ -20,8 +20,10 @@ module.exports = {
     const headers = new fetch.Headers({ accept });
     if (jsonContext) headers.set('JsonLdContext', JSON.stringify(jsonContext));
 
-    if (!this.isRemoteUri(resourceUri, webId)) {
-      throw new Error(`The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId})`);
+    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
+      throw new Error(
+        `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset})`
+      );
     }
 
     if (webId && webId !== 'system' && webId !== 'anon' && (await this.proxyAvailable())) {

--- a/src/middleware/packages/ldp/services/remote/actions/isRemote.js
+++ b/src/middleware/packages/ldp/services/remote/actions/isRemote.js
@@ -1,12 +1,30 @@
+const urlJoin = require('url-join');
+
 module.exports = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
-    webId: { type: 'string', optional: true }
+    dataset: { type: 'string', optional: true }
   },
   async handler(ctx) {
-    const { resourceUri, webId } = ctx.params;
+    const { resourceUri } = ctx.params;
+    const dataset = ctx.params.dataset || ctx.meta.dataset;
 
-    return this.isRemoteUri(resourceUri, webId);
+    if (!urlJoin(resourceUri, '/').startsWith(this.settings.baseUrl)) {
+      // The resource is on another server
+      return true;
+    } else {
+      // If the resource is on the same Pod provider, it may be on a different Pod
+      if (this.settings.podProvider) {
+        if (!dataset)
+          throw new Error(
+            `Unable to know if ${resourceUri} is remote. In Pod provider config, the dataset must be provided`
+          );
+
+        return !urlJoin(resourceUri, '/').startsWith(`${urlJoin(this.settings.baseUrl, dataset)}/`);
+      } else {
+        return false;
+      }
+    }
   }
 };

--- a/src/middleware/packages/ldp/services/remote/actions/store.js
+++ b/src/middleware/packages/ldp/services/remote/actions/store.js
@@ -37,7 +37,7 @@ module.exports = {
       resourceUri = resource.id || resource['@id'];
     }
 
-    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
+    if (!(await this.actions.isRemote({ resourceUri }, { parentCtx: ctx }))) {
       throw new Error(
         `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset}))`
       );

--- a/src/middleware/packages/ldp/services/remote/actions/store.js
+++ b/src/middleware/packages/ldp/services/remote/actions/store.js
@@ -37,8 +37,10 @@ module.exports = {
       resourceUri = resource.id || resource['@id'];
     }
 
-    if (!this.isRemoteUri(resourceUri, webId)) {
-      throw new Error(`The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId})`);
+    if (!(await this.actions.isRemote(resourceUri, { parentCtx: ctx }))) {
+      throw new Error(
+        `The resourceUri param must be remote. Provided: ${resourceUri} (webId ${webId} / dataset ${ctx.meta.dataset}))`
+      );
     }
 
     // Adds the default context, if it is missing

--- a/src/middleware/packages/ldp/services/remote/index.js
+++ b/src/middleware/packages/ldp/services/remote/index.js
@@ -1,4 +1,3 @@
-const urlJoin = require('url-join');
 const Schedule = require('moleculer-schedule');
 const deleteAction = require('./actions/delete');
 const getAction = require('./actions/get');
@@ -30,16 +29,6 @@ module.exports = {
     } // Used by tests
   },
   methods: {
-    isRemoteUri(uri, webId) {
-      return (
-        !urlJoin(uri, '/').startsWith(this.settings.baseUrl) ||
-        (this.settings.podProvider &&
-          webId &&
-          webId !== 'anon' &&
-          webId !== 'system' &&
-          !urlJoin(uri, '/').startsWith(`${webId}/`))
-      );
-    },
     async proxyAvailable() {
       const services = await this.broker.call('$node.services');
       return services.some(s => s.name === 'signature.proxy');

--- a/src/middleware/packages/ldp/services/resource/actions/create.js
+++ b/src/middleware/packages/ldp/services/resource/actions/create.js
@@ -18,7 +18,7 @@ module.exports = {
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
     const resourceUri = resource.id || resource['@id'];
 
-    if (this.isRemoteUri(resourceUri, ctx.meta.dataset))
+    if (await ctx.call('ldp.remote.isRemote', { resourceUri }))
       throw new MoleculerError('Remote resources cannot be created', 403, 'FORBIDDEN');
 
     const { controlledActions } = {

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -9,10 +9,9 @@ module.exports = {
   },
   async handler(ctx) {
     const { resourceUri } = ctx.params;
-    let { webId } = ctx.params;
-    webId = webId || ctx.meta.webId || 'anon';
+    const webId = ctx.params.webId || ctx.meta.webId || 'anon';
 
-    if (this.isRemoteUri(resourceUri, ctx.meta.dataset)) {
+    if (await ctx.call('ldp.remote.isRemote', { resourceUri })) {
       return await ctx.call('ldp.remote.delete', { resourceUri, webId });
     }
 

--- a/src/middleware/packages/ldp/services/resource/actions/exist.js
+++ b/src/middleware/packages/ldp/services/resource/actions/exist.js
@@ -17,7 +17,7 @@ module.exports = {
     });
 
     // If this is a remote URI and the resource is not found in default graph, also look in mirror graph
-    if (!exist && this.isRemoteUri(resourceUri, ctx.meta.dataset)) {
+    if (!exist && (await ctx.call('ldp.remote.isRemote', { resourceUri }))) {
       exist = await ctx.call('triplestore.tripleExist', {
         triple: triple(namedNode(resourceUri), variable('p'), variable('s')),
         webId,

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -16,9 +16,10 @@ module.exports = {
     aclVerified: { type: 'boolean', optional: true }
   },
   cache: {
-    enabled(ctx) {
+    async enabled(ctx) {
       // Do not cache remote resources as we have no mechanism to clear this cache
-      return !await ctx.call('ldp.remote.isRemote', { resourceUri: ctx.params.resourceUri });
+      const isRemote = await ctx.call('ldp.remote.isRemote', { resourceUri: ctx.params.resourceUri });
+      return !isRemote;
     },
     keys: ['resourceUri', 'accept', 'jsonContext']
   },

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -17,8 +17,8 @@ module.exports = {
   },
   cache: {
     enabled(ctx) {
-      // Do not cache remote resources as we have no mecanism to clear this cache
-      return !this.isRemoteUri(ctx.params.resourceUri, ctx.meta.dataset);
+      // Do not cache remote resources as we have no mechanism to clear this cache
+      return !await ctx.call('ldp.remote.isRemote', { resourceUri: ctx.params.resourceUri });
     },
     keys: ['resourceUri', 'accept', 'jsonContext']
   },
@@ -26,7 +26,7 @@ module.exports = {
     const { resourceUri, aclVerified, jsonContext } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
 
-    if (this.isRemoteUri(resourceUri, ctx.meta.dataset)) {
+    if (await ctx.call('ldp.remote.isRemote', { resourceUri })) {
       return await ctx.call('ldp.remote.get', ctx.params);
     }
 

--- a/src/middleware/packages/ldp/services/resource/actions/patch.js
+++ b/src/middleware/packages/ldp/services/resource/actions/patch.js
@@ -43,7 +43,7 @@ module.exports = {
     let { resourceUri, triplesToAdd, triplesToRemove, skipInferenceCheck, webId } = ctx.params;
     webId = webId || ctx.meta.webId || 'anon';
 
-    if (this.isRemoteUri(resourceUri, ctx.meta.dataset))
+    if (await ctx.call('ldp.remote.isRemote', { resourceUri }))
       throw new MoleculerError('Remote resources cannot be patched', 403, 'FORBIDDEN');
 
     // const resourceExist = await ctx.call('ldp.resource.exist', { resourceUri, webId: 'system' });

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -27,7 +27,7 @@ module.exports = {
 
     const resourceUri = resource.id || resource['@id'];
 
-    if (this.isRemoteUri(resourceUri, ctx.meta.dataset))
+    if (await ctx.call('ldp.remote.isRemote', { resourceUri }))
       throw new MoleculerError(
         `Remote resource ${resourceUri} cannot be modified (dataset: ${ctx.meta.dataset})`,
         403,

--- a/src/middleware/packages/ldp/services/resource/methods.js
+++ b/src/middleware/packages/ldp/services/resource/methods.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const urlJoin = require('url-join');
 const rdfParser = require('rdf-parse').default;
 const streamifyString = require('streamify-string');
 const { variable } = require('@rdfjs/data-model');
@@ -128,13 +127,5 @@ module.exports = {
   },
   bindNewBlankNodes(triples) {
     return triples.map(triple => `BIND (BNODE() AS ?${triple.object.value}) .`).join('\n');
-  },
-  isRemoteUri(uri, dataset) {
-    if (this.settings.podProvider && !dataset)
-      throw new Error(`Unable to know if ${uri} is remote. In Pod provider config, the dataset must be provided`);
-    return (
-      !urlJoin(uri, '/').startsWith(this.settings.baseUrl) ||
-      (this.settings.podProvider && !urlJoin(uri, '/').startsWith(`${urlJoin(this.settings.baseUrl, dataset)}/`))
-    );
   }
 };

--- a/src/middleware/packages/webacl/middlewares/webacl.js
+++ b/src/middleware/packages/webacl/middlewares/webacl.js
@@ -1,7 +1,7 @@
 const urlJoin = require('url-join');
 const { throw403 } = require('@semapps/middlewares');
 const { arrayOf, defaultContainerOptions } = require('@semapps/ldp');
-const { isRemoteUri, getSlugFromUri } = require('../utils');
+const { getSlugFromUri } = require('../utils');
 
 const modifyActions = [
   'ldp.resource.create',
@@ -123,7 +123,7 @@ const WebAclMiddleware = ({ baseUrl, podProvider = false, graphName = 'http://se
 
         const resourceUri = ctx.params.resourceUri || ctx.params.resource.id || ctx.params.resource['@id'];
 
-        if (isRemoteUri(resourceUri, ctx.meta.dataset, { baseUrl, podProvider })) {
+        if (await ctx.call('ldp.remote.isRemote', { resourceUri })) {
           // Bypass if mirrored resource as WebACL are not activated in mirror graph
           if ((await ctx.call('ldp.remote.getGraph', { resourceUri })) === 'http://semapps.org/mirror') {
             return bypass();
@@ -169,7 +169,7 @@ const WebAclMiddleware = ({ baseUrl, podProvider = false, graphName = 'http://se
             const resourceUri = ctx.params.resource['@id'] || ctx.params.resource.id;
             // Do not add ACLs if this is a mirrored resource as WebACL are not activated on the mirror graph
             if (
-              isRemoteUri(resourceUri, ctx.meta.dataset, { baseUrl, podProvider }) &&
+              (await ctx.call('ldp.remote.isRemote', { resourceUri })) &&
               (await ctx.call('ldp.remote.getGraph', { resourceUri })) === 'http://semapps.org/mirror'
             )
               return next(ctx);

--- a/src/middleware/packages/webacl/utils.js
+++ b/src/middleware/packages/webacl/utils.js
@@ -300,15 +300,6 @@ const processRights = (rights, aclUri) => {
   return list;
 };
 
-const isRemoteUri = (uri, dataset, { baseUrl, podProvider }) => {
-  if (podProvider && !dataset)
-    throw new Error(`Unable to know if ${uri} is remote. In Pod provider config, the dataset must be provided`);
-  return (
-    !urlJoin(uri, '/').startsWith(baseUrl) ||
-    (podProvider && !urlJoin(uri, '/').startsWith(`${urlJoin(baseUrl, dataset)}/`))
-  );
-};
-
 module.exports = {
   getSlugFromUri,
   hasType,
@@ -336,6 +327,5 @@ module.exports = {
   FULL_AGENT_URI,
   FULL_AGENT_GROUP,
   FULL_FOAF_AGENT,
-  FULL_ACL_ANYAGENT,
-  isRemoteUri
+  FULL_ACL_ANYAGENT
 };


### PR DESCRIPTION
A `isRemoteURI` function was used in various packages. But it wasn't using the same method in the LdpResourceService and the LdpRemoteService, which generated errors from the LdpRemoteService about resources not being remote (while in fact they were).

So I refactored the `ldp.remote.isRemote` action to use a `dataset` prop instead of `webId` (which is more consistent, since we care about where the data may be, not who owns the storage) and I call this action from every other SemApps services.

This way we will have a single source of truth about weither a resource is remote or not !