### PR TITLE
If we post to the inbox of a deleted user, send a 404 or 410 error.

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
@@ -45,6 +45,13 @@ const InboxService = {
         throw new E.UnAuthorizedError('INVALID_ACTOR', 'Activity actor is not the same as the posting actor');
       }
 
+      // confirm that the account is not a tombstone
+      const account = await ctx.call('auth.account.findByUsername', { username: activity.username });
+      if (account && account.deletedAt) {
+        const error = new Error(`The account has been deleted`);
+        error.code = 410;
+        throw error;
+      }
       // We want the next operations to be done by the system
       // TODO check if we can avoid this, as this is a bad practice
       ctx.meta.webId = 'system';

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
@@ -45,12 +45,13 @@ const InboxService = {
         throw new E.UnAuthorizedError('INVALID_ACTOR', 'Activity actor is not the same as the posting actor');
       }
 
-      // confirm that the account is not a tombstone
+      // Verify that the account exists and has not been deleted
       const account = await ctx.call('auth.account.findByUsername', { username: activity.username });
-      if (account && account.deletedAt) {
-        const error = new Error(`The account has been deleted`);
-        error.code = 410;
-        throw error;
+      if (!account) {
+        throw new E.NotFoundError();
+      }
+      if (account.deletedAt) {
+        throw new E.GoneError();
       }
       // We want the next operations to be done by the system
       // TODO check if we can avoid this, as this is a bad practice

--- a/src/middleware/packages/triplestore/actions/query.js
+++ b/src/middleware/packages/triplestore/actions/query.js
@@ -27,11 +27,8 @@ module.exports = {
     const dataset = ctx.params.dataset || ctx.meta.dataset || this.settings.mainDataset;
 
     if (!dataset) throw new Error(`No dataset defined for triplestore query: ${query}`);
-    if (!(await ctx.call('triplestore.dataset.exist', { dataset }))) {
-      const error = new Error(`The dataset ${dataset} doesn't exist`);
-      error.code = 404;
-      throw error;
-    }
+    if (!(await ctx.call('triplestore.dataset.exist', { dataset })))
+      throw new Error(`The dataset ${dataset} doesn't exist`);
 
     if (typeof query === 'object') query = this.generateSparqlQuery(query);
 

--- a/src/middleware/packages/triplestore/actions/query.js
+++ b/src/middleware/packages/triplestore/actions/query.js
@@ -27,8 +27,11 @@ module.exports = {
     const dataset = ctx.params.dataset || ctx.meta.dataset || this.settings.mainDataset;
 
     if (!dataset) throw new Error(`No dataset defined for triplestore query: ${query}`);
-    if (!(await ctx.call('triplestore.dataset.exist', { dataset })))
-      throw new Error(`The dataset ${dataset} doesn't exist`);
+    if (!(await ctx.call('triplestore.dataset.exist', { dataset }))) {
+      const error = new Error(`The dataset ${dataset} doesn't exist`);
+      error.code = 404;
+      throw error;
+    }
 
     if (typeof query === 'object') query = this.generateSparqlQuery(query);
 

--- a/src/middleware/tests/activitypub/inbox.test.js
+++ b/src/middleware/tests/activitypub/inbox.test.js
@@ -179,21 +179,4 @@ describe('Permissions are correctly set on inbox', () => {
       });
     });
   });
-
-  test('Check the inbox response for a deleted actor', async () => {
-    const account = await broker2.call('auth.account.findByUsername', { username: "simonlouvet" });
-    console.log(account);
-
-    await broker2.call('auth.account.setTombstone', { webId: simon.id });
-
-    const account2 = await broker2.call('auth.account.findByUsername', { username: "simonlouvet" });
-    console.log(account2);
-
-
-    await expect(broker2.call('activitypub.collection.get', {
-      resourceUri: simon.inbox,
-      page: 1,
-      webId: 'anon'
-    })).rejects.toThrow('Not found');
-  });
 });


### PR DESCRIPTION
This PR addresses the issue https://github.com/activitypods/activitypods/issues/348

Few questions I had:
1. Currently I am only checking if a deletedAt field exists in an account to return 410, should I also check if that date is more than one year old and return 404 accordingly?
2. The issue said that this logic should not throw, but I implemented the changes using throws. Please let me know if this works.