### PR TITLE
Improve LDP container patch

### DIFF
--- a/src/middleware/packages/ldp/services/container/actions/patch.js
+++ b/src/middleware/packages/ldp/services/container/actions/patch.js
@@ -1,6 +1,22 @@
 const { MoleculerError } = require('moleculer').Errors;
 const { isMirror } = require('../../../utils');
 
+const checkTripleValidity = (triple, containerUri) => {
+  if (triple.subject.value !== containerUri) {
+    throw new MoleculerError(
+      `The subject must be the container URI. Provided ${triple.subject.value}`,
+      400,
+      'BAD_REQUEST'
+    );
+  } else if (triple.predicate.value !== 'http://www.w3.org/ns/ldp#contains') {
+    throw new MoleculerError(
+      `The predicate must be "http://www.w3.org/ns/ldp#contains". Provided ${triple.predicate.value}`,
+      400,
+      'BAD_REQUEST'
+    );
+  }
+};
+
 module.exports = {
   visibility: 'public',
   params: {
@@ -23,6 +39,8 @@ module.exports = {
   async handler(ctx) {
     const { containerUri, triplesToAdd, triplesToRemove } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
+    const resourcesAdded = [],
+      resourcesRemoved = [];
 
     const containerExist = await ctx.call('ldp.container.exist', { containerUri, webId });
     if (!containerExist) {
@@ -34,28 +52,29 @@ module.exports = {
 
     if (triplesToAdd) {
       for (const triple of triplesToAdd) {
-        // Ensure the containerUri is the same as specified in the params
-        if (triple.subject.value === containerUri && triple.predicate.value === 'http://www.w3.org/ns/ldp#contains') {
-          const resourceUri = triple.object.value;
-          try {
-            await ctx.call('ldp.container.attach', { containerUri, resourceUri });
-          } catch (e) {
-            if (e.code === 404 && isMirror(resourceUri, this.settings.baseUrl)) {
-              // We need to import the remote resource
-              this.logger.info(`Importing ${resourceUri}...`);
-              try {
-                await ctx.call('ldp.remote.store', {
-                  resourceUri,
-                  keepInSync: true,
-                  mirrorGraph: true,
-                  webId
-                });
+        checkTripleValidity(triple, containerUri);
 
-                // Now if the import went well, we can retry the attach
-                await ctx.call('ldp.container.attach', { containerUri, resourceUri });
-              } catch (e2) {
-                this.logger.warn(`Error while importing ${resourceUri} : ${e2.message}`);
-              }
+        const resourceUri = triple.object.value;
+        try {
+          await ctx.call('ldp.container.attach', { containerUri, resourceUri, webId });
+          resourcesAdded.push(resourceUri);
+        } catch (e) {
+          if (e.code === 404 && isMirror(resourceUri, this.settings.baseUrl)) {
+            // We need to import the remote resource
+            this.logger.info(`Importing ${resourceUri}...`);
+            try {
+              await ctx.call('ldp.remote.store', {
+                resourceUri,
+                keepInSync: true,
+                mirrorGraph: true,
+                webId
+              });
+
+              // Now if the import went well, we can retry the attach
+              await ctx.call('ldp.container.attach', { containerUri, resourceUri, webId });
+              resourcesAdded.push(resourceUri);
+            } catch (e2) {
+              this.logger.warn(`Error while importing ${resourceUri} : ${e2.message}`);
             }
           }
         }
@@ -64,27 +83,29 @@ module.exports = {
 
     if (triplesToRemove) {
       for (const triple of triplesToRemove) {
-        if (triple.subject.value === containerUri && triple.predicate.value === 'http://www.w3.org/ns/ldp#contains') {
-          const resourceUri = triple.object.value;
-          try {
-            await ctx.call('ldp.container.detach', { containerUri, resourceUri });
+        checkTripleValidity(triple, containerUri);
 
-            // If the mirrored resource is not attached to any container anymore, it must be deleted.
-            const containers = await ctx.call('ldp.resource.getContainers', { resourceUri });
-            if (containers.length === 0 && isMirror(resourceUri, this.settings.baseUrl)) {
-              await ctx.call('ldp.remote.delete', { resourceUri });
-            }
-          } catch (e) {
-            // Fail silently
-            this.logger.warn(`Error when detaching ${resourceUri} from ${containerUri}: ${e.message}`);
+        const resourceUri = triple.object.value;
+        try {
+          await ctx.call('ldp.container.detach', { containerUri, resourceUri, webId });
+
+          // If the mirrored resource is not attached to any container anymore, it must be deleted.
+          const containers = await ctx.call('ldp.resource.getContainers', { resourceUri });
+          if (containers.length === 0 && isMirror(resourceUri, this.settings.baseUrl)) {
+            await ctx.call('ldp.remote.delete', { resourceUri });
           }
+
+          resourcesRemoved.push(resourceUri);
+        } catch (e) {
+          // Fail silently
+          this.logger.warn(`Error when detaching ${resourceUri} from ${containerUri}: ${e.message}`);
         }
       }
     }
 
     ctx.emit(
       'ldp.container.patched',
-      { containerUri, triplesAdded: triplesToAdd, triplesRemoved: triplesToRemove, dataset: ctx.meta.dataset },
+      { containerUri, resourcesAdded, resourcesRemoved, dataset: ctx.meta.dataset },
       { meta: { webId: null, dataset: null } }
     );
   }


### PR DESCRIPTION
- Pass provided webId to `ldp.container.attach` and `ldp.container.detach`
- Throw error if the provided triples are incorrectly formatted
- Send resources added and removed to `ldp.container.patched` event