### PR TITLE
Container-specific link header

### DIFF
--- a/src/middleware/packages/ldp/mixins/controlled-container.js
+++ b/src/middleware/packages/ldp/mixins/controlled-container.js
@@ -27,6 +27,7 @@ module.exports = {
         post: `${this.name}.post`,
         list: `${this.name}.list`,
         get: `${this.name}.get`,
+        getHeaderLinks: `${this.name}.getHeaderLinks`,
         create: `${this.name}.create`,
         patch: `${this.name}.patch`,
         put: `${this.name}.put`,
@@ -71,6 +72,9 @@ module.exports = {
         ...containerParams,
         ...ctx.params
       });
+    },
+    getHeaderLinks(ctx) {
+      return [];
     },
     create(ctx) {
       return ctx.call('ldp.resource.create', ctx.params);

--- a/src/middleware/tests/ldp/headers.test.js
+++ b/src/middleware/tests/ldp/headers.test.js
@@ -1,0 +1,67 @@
+const urlJoin = require('url-join');
+const { parse: parseLinkHeader } = require('http-link-header');
+const { fetchServer } = require('../utils');
+const initialize = require('./initialize');
+const CONFIG = require('../config');
+
+jest.setTimeout(20000);
+let broker;
+
+beforeAll(async () => {
+  broker = await initialize();
+});
+afterAll(async () => {
+  if (broker) await broker.stop();
+});
+
+describe('Headers handling of LDP server', () => {
+  test('Get headers', async () => {
+    const { headers: postHeaders } = await fetchServer(urlJoin(CONFIG.HOME_URL, 'places'), {
+      method: 'POST',
+      body: {
+        '@type': 'pair:Place',
+        'pair:label': 'My place'
+      }
+    });
+
+    const resourceUri = postHeaders.get('Location');
+    const resourcePath = new URL(resourceUri).pathname;
+
+    const { headers } = await fetchServer(resourceUri, {
+      method: 'HEAD'
+    });
+
+    const parsedLinks = parseLinkHeader(headers.get('link'));
+
+    expect(parsedLinks.refs).toMatchObject([
+      {
+        uri: urlJoin(CONFIG.HOME_URL, '_acl', resourcePath),
+        rel: 'acl'
+      }
+    ]);
+  });
+
+  test('Get container-specific headers', async () => {
+    const { headers: postHeaders } = await fetchServer(urlJoin(CONFIG.HOME_URL, 'pair', 'event'), {
+      method: 'POST',
+      body: {
+        '@type': 'pair:Event',
+        'pair:label': 'My event'
+      }
+    });
+
+    const resourceUri = postHeaders.get('Location');
+    const resourcePath = new URL(resourceUri).pathname;
+
+    const { headers } = await fetchServer(resourceUri, {
+      method: 'HEAD'
+    });
+
+    const parsedLinks = parseLinkHeader(headers.get('link'));
+
+    expect(parsedLinks.refs).toMatchObject([
+      { uri: urlJoin(CONFIG.HOME_URL, '_acl', resourcePath), rel: 'acl' },
+      { uri: 'http://foo.bar', rel: 'http://foo.baz' }
+    ]);
+  });
+});

--- a/src/middleware/tests/ldp/initialize.js
+++ b/src/middleware/tests/ldp/initialize.js
@@ -1,11 +1,11 @@
 const { ServiceBroker } = require('moleculer');
 const fs = require('fs');
-const urlJoin = require('url-join');
 const { join: pathJoin } = require('path');
 const { CoreService } = require('@semapps/core');
 const { pair, petr } = require('@semapps/ontologies');
 const { WebAclMiddleware, CacherMiddleware } = require('@semapps/webacl');
 const { AuthLocalService } = require('@semapps/auth');
+const { ControlledContainerMixin } = require('@semapps/ldp');
 const path = require('path');
 const CONFIG = require('../config');
 const { clearDataset } = require('../utils');
@@ -92,6 +92,25 @@ const initialize = async () => {
       baseUrl: CONFIG.HOME_URL,
       jwtPath: path.resolve(__dirname, '../jwt'),
       accountsDataset: CONFIG.SETTINGS_DATASET
+    }
+  });
+
+  broker.createService({
+    name: 'event',
+    mixins: [ControlledContainerMixin],
+    settings: {
+      acceptedTypes: ['pair:Event'],
+      permissions
+    },
+    actions: {
+      getHeaderLinks() {
+        return [
+          {
+            uri: 'http://foo.bar',
+            rel: 'http://foo.baz'
+          }
+        ];
+      }
     }
   });
 

--- a/src/middleware/tests/package.json
+++ b/src/middleware/tests/package.json
@@ -26,6 +26,7 @@
     "dotenv-flow": "^3.1.0",
     "fs-extra": "^9.0.1",
     "ioredis": "^4.27.0",
+    "http-link-header": "^1.1.1",
     "lru-cache": "10.1.0",
     "moleculer": "^0.14.17",
     "moleculer-web": "^0.10.0-beta1",


### PR DESCRIPTION
Allow controlled containers to set specific headers, with a new `getHeaderLinks` action.

Add tests for headers on LDP resources.