### PR TITLE
Remove original 'content-encoding' header from proxy response's headers

### DIFF
--- a/src/middleware/packages/crypto/signature/proxy.js
+++ b/src/middleware/packages/crypto/signature/proxy.js
@@ -122,6 +122,7 @@ const ProxyService = {
         // Remove headers that we don't want to be transfered
         response.headers.delete('content-length');
         response.headers.delete('connection');
+        response.headers.delete('content-encoding');
 
         return {
           ok: true,


### PR DESCRIPTION
closes #1343 