### PR TITLE
New SolidEndpointService

### DIFF
--- a/src/middleware/packages/solid/index.js
+++ b/src/middleware/packages/solid/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   StorageService: require('./services/storage'),
+  EndpointService: require('./services/endpoint'),
   NotificationsProviderService: require('./services/notifications/provider'),
   NotificationsListenerService: require('./services/notifications/listener'),
   TypeIndexesService: require('./services/type-index/type-indexes')

--- a/src/middleware/packages/solid/services/endpoint.js
+++ b/src/middleware/packages/solid/services/endpoint.js
@@ -1,0 +1,85 @@
+const urlJoin = require('url-join');
+const { namedNode, triple } = require('@rdfjs/data-model');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const { parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle } = require('@semapps/middlewares');
+
+module.exports = {
+  name: 'solid-endpoint',
+  settings: {
+    baseUrl: null,
+    settingsDataset: 'settings'
+  },
+  dependencies: ['api', 'ldp'],
+  async started() {
+    await this.broker.call('ldp.link-header.register', { actionName: 'solid-notifications.provider.getLink' });
+
+    await this.broker.call('api.addRoute', {
+      route: {
+        name: 'solid-endpoint',
+        path: '/.well-known/solid',
+        authorization: false,
+        authentication: false,
+        aliases: {
+          'GET /': [parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle, 'solid-endpoint.get']
+        }
+      }
+    });
+
+    this.endpointUrl = urlJoin(this.settings.baseUrl, '.well-known', 'solid');
+
+    const endpointExist = await this.broker.call(
+      'ldp.resource.exist',
+      { resourceUri: this.endpointUrl, webId: 'system' },
+      { meta: { dataset: this.settings.settingsDataset } }
+    );
+
+    if (!endpointExist) {
+      await this.broker.call(
+        'ldp.resource.create',
+        {
+          resource: {
+            id: this.endpointUrl,
+            type: 'http://www.w3.org/ns/pim/space#Storage'
+          },
+          contentType: MIME_TYPES.JSON,
+          webId: 'system'
+        },
+        { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true } }
+      );
+    }
+  },
+  actions: {
+    async add(ctx) {
+      const { predicate, object } = ctx.params;
+
+      await ctx.call(
+        'ldp.resource.patch',
+        {
+          resourceUri: this.endpointUrl,
+          triplesToAdd: [triple(namedNode(this.endpointUrl), predicate, object)],
+          webId: 'system'
+        },
+        { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true } }
+      );
+    },
+    async get(ctx) {
+      ctx.meta.$responseType = ctx.meta.headers?.accept;
+
+      return await ctx.call(
+        'ldp.resource.get',
+        {
+          resourceUri: this.endpointUrl,
+          accept: ctx.meta.headers?.accept,
+          webId: 'system'
+        },
+        { meta: { dataset: this.settings.settingsDataset } }
+      );
+    },
+    getLink() {
+      return {
+        uri: this.endpointUrl,
+        rel: 'http://www.w3.org/ns/solid/terms#storageDescription'
+      };
+    }
+  }
+};

--- a/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.js
+++ b/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.js
@@ -5,6 +5,7 @@ const { parseHeader, negotiateContentType, parseJson } = require('@semapps/middl
 const { ControlledContainerMixin, getDatasetFromUri, arrayOf } = require('@semapps/ldp');
 const { ACTIVITY_TYPES } = require('@semapps/activitypub');
 const { MIME_TYPES } = require('@semapps/mime-types');
+const { namedNode } = require('@rdfjs/data-model');
 const { v4: uuidV4 } = require('uuid');
 const moment = require('moment');
 
@@ -43,7 +44,7 @@ module.exports = {
       }
     }
   },
-  dependencies: ['api'],
+  dependencies: ['api', 'solid-endpoint'],
   async created() {
     if (!this.settings.baseUrl) throw new Error('The baseUrl setting is required');
     if (this.settings.sendOrReceive !== 'receive' && this.settings.sendOrReceive !== 'send')
@@ -68,6 +69,11 @@ module.exports = {
           'POST /': [parseHeader, negotiateContentType, parseJson, `${this.name}.createChannel`]
         }
       }
+    });
+
+    await this.broker.call('solid-endpoint.add', {
+      predicate: namedNode('http://www.w3.org/ns/solid/notifications#subscription'),
+      object: namedNode(urlJoin(this.settings.baseUrl, '.notifications', channelType))
     });
 
     this.channels = [];

--- a/src/middleware/packages/solid/services/notifications/provider.js
+++ b/src/middleware/packages/solid/services/notifications/provider.js
@@ -1,4 +1,3 @@
-const urlJoin = require('url-join');
 const QueueMixin = require('moleculer-bull');
 const { notify } = require('@semapps/ontologies');
 const WebhookChannelService = require('./channels/webhook-channel');
@@ -14,7 +13,7 @@ module.exports = {
       websocket: true
     }
   },
-  dependencies: ['api', 'ldp.link-header', 'ontologies'],
+  dependencies: ['api', 'ontologies'],
   async created() {
     const { baseUrl, queueServiceUrl, channels } = this.settings;
     if (!baseUrl) throw new Error(`The baseUrl setting is required`);
@@ -39,46 +38,5 @@ module.exports = {
   },
   async started() {
     await this.broker.call('ontologies.register', notify);
-
-    await this.broker.call('ldp.link-header.register', { actionName: 'solid-notifications.provider.getLink' });
-
-    await this.broker.call('api.addRoute', {
-      route: {
-        name: 'solid',
-        path: '/.well-known/solid',
-        authorization: false,
-        authentication: false,
-        aliases: {
-          'GET /': 'solid-notifications.provider.discover'
-        }
-      }
-    });
-  },
-  actions: {
-    discover(ctx) {
-      // TODO Handle content negotiation
-      ctx.meta.$responseType = 'application/ld+json';
-      // Cache for 1 days.
-      ctx.meta.$responseHeaders = { 'Cache-Control': 'public, max-age=86400' };
-
-      const subscriptions = [];
-      if (this.settings.channels.webhook)
-        subscriptions.push(urlJoin(this.settings.baseUrl, '.notifications', 'WebSocketChannel2023'));
-      if (this.settings.channels.websocket)
-        subscriptions.push(urlJoin(this.settings.baseUrl, '.notifications', 'WebhookChannel2023'));
-
-      return {
-        '@context': { notify: 'http://www.w3.org/ns/solid/notifications#' },
-        '@id': urlJoin(this.settings.baseUrl, '.well-known', 'solid'),
-        '@type': 'http://www.w3.org/ns/pim/space#Storage',
-        'notify:subscription': subscriptions
-      };
-    },
-    getLink() {
-      return {
-        uri: urlJoin(this.settings.baseUrl, '.well-known', 'solid'),
-        rel: 'http://www.w3.org/ns/solid/terms#storageDescription'
-      };
-    }
   }
 };


### PR DESCRIPTION
- Move the management of the `/.well-known/solid` endpoint to a new service
- Allow any service to add properties to this endpoint via the `add` action
- Persist the endpoint data in the settings dataset
- Handle content negociation