### PR TITLE
New SpecialEndpointMixin

### DIFF
--- a/src/middleware/packages/ldp/index.js
+++ b/src/middleware/packages/ldp/index.js
@@ -14,6 +14,7 @@ module.exports = {
   ImageProcessorMixin: require('./mixins/image-processor'),
   DocumentTaggerMixin: require('./mixins/document-tagger'),
   DisassemblyMixin: require('./mixins/disassembly'),
+  SpecialEndpointMixin: require('./mixins/special-endpoint'),
   // Other
   defaultContainerOptions: require('./services/registry/defaultOptions'),
   LdpAdapter: require('./adapter'),

--- a/src/middleware/packages/ldp/mixins/special-endpoint.js
+++ b/src/middleware/packages/ldp/mixins/special-endpoint.js
@@ -1,0 +1,87 @@
+const urlJoin = require('url-join');
+const { namedNode, triple } = require('@rdfjs/data-model');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const { parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle } = require('@semapps/middlewares');
+
+module.exports = {
+  settings: {
+    baseUrl: null,
+    settingsDataset: null,
+    endpoint: {
+      path: null, // Should start with a dot
+      initialData: {}
+    }
+  },
+  dependencies: ['api', 'ldp'],
+  async started() {
+    if (!this.settings.baseUrl) throw new Error(`The baseUrl must be specified for service ${this.name}`);
+    if (!this.settings.settingsDataset)
+      throw new Error(`The settingsDataset must be specified for service ${this.name}`);
+
+    await this.broker.call('api.addRoute', {
+      route: {
+        path: this.settings.endpoint.path,
+        bodyParsers: false,
+        authorization: false,
+        authentication: false,
+        aliases: {
+          'GET /': [parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle, `${this.name}.endpointGet`],
+          'POST /': this.actions.endpointPost
+            ? [parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle, `${this.name}.endpointPost`]
+            : undefined
+        }
+      }
+    });
+
+    this.endpointUrl = urlJoin(this.settings.baseUrl, this.settings.endpoint.path);
+
+    const endpointExist = await this.broker.call(
+      'ldp.resource.exist',
+      { resourceUri: this.endpointUrl, webId: 'system' },
+      { meta: { dataset: this.settings.settingsDataset } }
+    );
+
+    if (!endpointExist) {
+      await this.broker.call(
+        'ldp.resource.create',
+        {
+          resource: {
+            id: this.endpointUrl,
+            ...this.settings.endpoint.initialData
+          },
+          contentType: MIME_TYPES.JSON,
+          webId: 'system'
+        },
+        { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true, skipObjectsWatcher: true } }
+      );
+    }
+  },
+  actions: {
+    async endpointAdd(ctx) {
+      const { predicate, object } = ctx.params;
+
+      await ctx.call(
+        'ldp.resource.patch',
+        {
+          resourceUri: this.endpointUrl,
+          triplesToAdd: [triple(namedNode(this.endpointUrl), predicate, object)],
+          webId: 'system'
+        },
+        { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true, skipObjectsWatcher: true } }
+      );
+    },
+    async endpointGet(ctx) {
+      ctx.meta.$responseType = ctx.meta.headers?.accept;
+
+      return await ctx.call(
+        'ldp.resource.get',
+        {
+          resourceUri: this.endpointUrl,
+          accept: ctx.meta.headers?.accept,
+          webId: 'system'
+        },
+        { meta: { dataset: this.settings.settingsDataset } }
+      );
+    }
+  }
+};

--- a/src/middleware/packages/solid/services/endpoint.js
+++ b/src/middleware/packages/solid/services/endpoint.js
@@ -1,80 +1,23 @@
-const urlJoin = require('url-join');
-const { namedNode, triple } = require('@rdfjs/data-model');
-const { MIME_TYPES } = require('@semapps/mime-types');
-const { parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle } = require('@semapps/middlewares');
+const { SpecialEndpointMixin } = require('@semapps/ldp');
 
 module.exports = {
   name: 'solid-endpoint',
+  mixins: [SpecialEndpointMixin],
   settings: {
     baseUrl: null,
-    settingsDataset: 'settings'
+    settingsDataset: null,
+    endpoint: {
+      path: '/.well-known/solid',
+      initialData: {
+        type: 'http://www.w3.org/ns/pim/space#Storage'
+      }
+    }
   },
   dependencies: ['api', 'ldp'],
   async started() {
     await this.broker.call('ldp.link-header.register', { actionName: 'solid-notifications.provider.getLink' });
-
-    await this.broker.call('api.addRoute', {
-      route: {
-        name: 'solid-endpoint',
-        path: '/.well-known/solid',
-        authorization: false,
-        authentication: false,
-        aliases: {
-          'GET /': [parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle, 'solid-endpoint.get']
-        }
-      }
-    });
-
-    this.endpointUrl = urlJoin(this.settings.baseUrl, '.well-known', 'solid');
-
-    const endpointExist = await this.broker.call(
-      'ldp.resource.exist',
-      { resourceUri: this.endpointUrl, webId: 'system' },
-      { meta: { dataset: this.settings.settingsDataset } }
-    );
-
-    if (!endpointExist) {
-      await this.broker.call(
-        'ldp.resource.create',
-        {
-          resource: {
-            id: this.endpointUrl,
-            type: 'http://www.w3.org/ns/pim/space#Storage'
-          },
-          contentType: MIME_TYPES.JSON,
-          webId: 'system'
-        },
-        { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true } }
-      );
-    }
   },
   actions: {
-    async add(ctx) {
-      const { predicate, object } = ctx.params;
-
-      await ctx.call(
-        'ldp.resource.patch',
-        {
-          resourceUri: this.endpointUrl,
-          triplesToAdd: [triple(namedNode(this.endpointUrl), predicate, object)],
-          webId: 'system'
-        },
-        { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true } }
-      );
-    },
-    async get(ctx) {
-      ctx.meta.$responseType = ctx.meta.headers?.accept;
-
-      return await ctx.call(
-        'ldp.resource.get',
-        {
-          resourceUri: this.endpointUrl,
-          accept: ctx.meta.headers?.accept,
-          webId: 'system'
-        },
-        { meta: { dataset: this.settings.settingsDataset } }
-      );
-    },
     getLink() {
       return {
         uri: this.endpointUrl,

--- a/src/middleware/packages/solid/services/notifications/channels/webhook-channel.js
+++ b/src/middleware/packages/solid/services/notifications/channels/webhook-channel.js
@@ -1,4 +1,3 @@
-const urlJoin = require('url-join');
 const fetch = require('node-fetch');
 const NotificationChannelMixin = require('./notification-channel.mixin');
 
@@ -27,24 +26,19 @@ const WebhookChannel2023Service = {
         en: 'Webhook Channel'
       },
       internal: true
+    },
+    endpoint: {
+      path: '/.notifications/WebhookChannel2023',
+      initialData: {
+        'notify:channelType': 'notify:WebhookChannel2023',
+        'notify:feature': ['notify:endAt', 'notify:rate', 'notify:startAt', 'notify:state']
+      }
     }
   },
   created() {
     if (!this.createJob) throw new Error('The QueueMixin must be configured with this service');
   },
   actions: {
-    async discover(ctx) {
-      // TODO Handle content negotiation
-      ctx.meta.$responseType = 'application/ld+json';
-      // Cache for 1 day.
-      ctx.meta.$responseHeaders = { 'Cache-Control': 'public, max-age=86400' };
-      return {
-        '@context': { notify: 'http://www.w3.org/ns/solid/notifications#' },
-        '@id': urlJoin(this.settings.baseUrl, '.notifications', 'WebhookChannel2023'),
-        'notify:channelType': 'notify:WebhookChannel2023',
-        'notify:feature': ['notify:endAt', 'notify:rate', 'notify:startAt', 'notify:state']
-      };
-    },
     async getAppChannels(ctx) {
       const { appUri, webId } = ctx.params;
       const { origin: appOrigin } = new URL(appUri);

--- a/src/middleware/packages/solid/services/notifications/channels/websocket-channel.js
+++ b/src/middleware/packages/solid/services/notifications/channels/websocket-channel.js
@@ -15,6 +15,13 @@ const WebSocketChannel2023Service = {
         en: 'WebSocket Channel'
       },
       internal: true
+    },
+    endpoint: {
+      path: '/.notifications/WebSocketChannel2023',
+      initialData: {
+        'notify:channelType': 'notify:WebSocketChannel2023',
+        'notify:feature': ['notify:endAt', 'notify:rate', 'notify:startAt', 'notify:state']
+      }
     }
   },
   async started() {
@@ -50,19 +57,6 @@ const WebSocketChannel2023Service = {
         }
       }
     });
-  },
-  actions: {
-    async discover(ctx) {
-      ctx.meta.$responseType = 'application/ld+json';
-      // Cache for 1 day.
-      ctx.meta.$responseHeaders = { 'Cache-Control': 'public, max-age=86400' };
-      return {
-        '@context': { notify: 'http://www.w3.org/ns/solid/notifications#' },
-        '@id': urlJoin(this.settings.baseUrl, '.notifications', 'WebSocketChannel2023'),
-        'notify:channelType': 'notify:WebSocketChannel2023',
-        'notify:feature': ['notify:endAt', 'notify:rate', 'notify:startAt', 'notify:state']
-      };
-    }
   },
   methods: {
     onChannelDeleted(channel) {

--- a/src/middleware/packages/solid/services/notifications/provider.js
+++ b/src/middleware/packages/solid/services/notifications/provider.js
@@ -7,6 +7,7 @@ module.exports = {
   name: 'solid-notifications.provider',
   settings: {
     baseUrl: null,
+    settingsDataset: null,
     queueServiceUrl: null,
     channels: {
       webhook: true,
@@ -15,8 +16,9 @@ module.exports = {
   },
   dependencies: ['api', 'ontologies'],
   async created() {
-    const { baseUrl, queueServiceUrl, channels } = this.settings;
+    const { baseUrl, settingsDataset, queueServiceUrl, channels } = this.settings;
     if (!baseUrl) throw new Error(`The baseUrl setting is required`);
+    if (!settingsDataset) throw new Error(`The settingsDataset setting is required`);
     if (channels.webhook && !queueServiceUrl)
       throw new Error(`The queueServiceUrl setting is required if webhooks are activated`);
 
@@ -24,7 +26,7 @@ module.exports = {
       this.broker.createService({
         name: 'solid-notifications.provider.webhook',
         mixins: [WebhookChannelService, QueueMixin(queueServiceUrl)],
-        settings: { baseUrl }
+        settings: { baseUrl, settingsDataset }
       });
     }
 
@@ -32,7 +34,7 @@ module.exports = {
       this.broker.createService({
         name: 'solid-notifications.provider.websocket',
         mixins: [WebSocketChannelService],
-        settings: { baseUrl }
+        settings: { baseUrl, settingsDataset }
       });
     }
   },


### PR DESCRIPTION
Improve the new SolidEndpointService introduced in https://github.com/assemblee-virtuelle/semapps/pull/1346 by defining a generic SpecialEndpointMixin in the `@semapps/ldp` package.

This SpecialEndpointMixin is also used by the Solid Notifications channels services, in order to handle Turtle format in the `/.notifications` endpoints as well.