### PR TITLE
Allow minimal LDP container representation

### DIFF
--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -1,6 +1,6 @@
 const { MIME_TYPES } = require('@semapps/mime-types');
 const { MoleculerError } = require('moleculer').Errors;
-const { buildBlankNodesQuery, buildFiltersQuery, isContainer, cleanUndefined, arrayOf } = require('../../../utils');
+const { buildFiltersQuery, isContainer, cleanUndefined, arrayOf } = require('../../../utils');
 
 module.exports = {
   visibility: 'public',
@@ -9,13 +9,14 @@ module.exports = {
     webId: { type: 'string', optional: true },
     accept: { type: 'string', optional: true },
     filters: { type: 'object', optional: true },
+    doNotIncludeResources: { type: 'boolean', default: false },
     jsonContext: { type: 'multi', rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }], optional: true }
   },
   cache: {
-    keys: ['containerUri', 'accept', 'filters', 'jsonContext', 'webId', '#webId']
+    keys: ['containerUri', 'accept', 'filters', 'doNotIncludeResources', 'jsonContext', 'webId', '#webId']
   },
   async handler(ctx) {
-    const { containerUri, filters, jsonContext } = ctx.params;
+    const { containerUri, filters, doNotIncludeResources, jsonContext } = ctx.params;
     let { webId } = ctx.params;
     webId = webId || ctx.meta.webId || 'anon';
 
@@ -23,127 +24,101 @@ module.exports = {
       ...(await ctx.call('ldp.registry.getByUri', { containerUri })),
       ...ctx.params
     };
-    const filtersQuery = buildFiltersQuery(filters);
 
-    // Handle JSON-LD differently, because the framing (https://w3c.github.io/json-ld-framing/)
-    // does not work correctly and resources are not embedded at the right place.
-    // This has bad impact on performances, unless the cache is activated
-    if (accept === MIME_TYPES.JSON) {
-      let result = await ctx.call('triplestore.query', {
+    if (accept !== MIME_TYPES.JSON)
+      throw new Error(`LDP containers can only be returned with JSON-LD format at the moment.`);
+
+    let containerResults = await ctx.call('triplestore.query', {
+      query: `
+        ${await ctx.call('ontologies.getRdfPrefixes')}
+        CONSTRUCT  {
+          <${containerUri}> ?p ?o .
+        }
+        WHERE {
+          <${containerUri}> ?p ?o .
+          MINUS { <${containerUri}> ldp:contains ?o } .
+        }
+      `,
+      accept,
+      webId: 'system'
+    });
+
+    if (Object.keys(containerResults).length === 1 && containerResults['@context']) {
+      throw new MoleculerError(
+        `Container not found ${containerUri} (webId ${webId} / dataset ${ctx.meta.dataset})`,
+        404,
+        'NOT_FOUND'
+      );
+    }
+
+    if (!doNotIncludeResources) {
+      const filtersQuery = buildFiltersQuery(filters);
+
+      const resourcesResults = await ctx.call('triplestore.query', {
         query: `
           ${await ctx.call('ontologies.getRdfPrefixes')}
-          CONSTRUCT  {
-            <${containerUri}>
-              a ?containerType ;
-              <http://www.w3.org/ns/ldp#contains> ?s1 ;
-              <http://purl.org/dc/terms/title> ?title ;
-              <http://purl.org/dc/terms/description> ?description .
-          }
+          SELECT ?s1
           WHERE {
-            <${containerUri}> a <http://www.w3.org/ns/ldp#Container>, ?containerType .
-            OPTIONAL { <${containerUri}> <http://purl.org/dc/terms/title> ?title . }
-            OPTIONAL { <${containerUri}> <http://purl.org/dc/terms/description> ?description . }
-            OPTIONAL {
-              <${containerUri}> <http://www.w3.org/ns/ldp#contains> ?s1 .
-              ${filtersQuery.where}
-            }
+            <${containerUri}> <http://www.w3.org/ns/ldp#contains> ?s1 .
+            ${filtersQuery.where}
           }
         `,
         accept,
         webId
       });
 
-      if (Object.keys(result).length === 1 && result['@context']) {
-        throw new MoleculerError(
-          `Container not found ${containerUri} (webId ${webId} / dataset ${ctx.meta.dataset})`,
-          404,
-          'NOT_FOUND'
-        );
-      }
+      const resourcesUris = resourcesResults?.map(node => node.s1.value);
 
       // Request each resources (in parallel)
-      const resources =
-        !result || !result.contains
-          ? []
-          : await Promise.all(
-              arrayOf(result.contains).flatMap(async resourceUri => {
-                try {
-                  // We pass the accept/jsonContext parameters only if they are explicit
-                  const resource = await ctx.call(
-                    'ldp.resource.get',
-                    cleanUndefined({
-                      resourceUri,
-                      webId,
-                      jsonContext,
-                      accept
-                    })
-                  );
-
-                  // Ensure a valid resource is returned (in some case, we may have only the context)
-                  if (resource['@id'] || resource.id) {
-                    // If we have a child container, remove the ldp:contains property and add a ldp:Resource type
-                    // We are copying SOLID: https://github.com/assemblee-virtuelle/semapps/issues/429#issuecomment-768210074
-                    if (isContainer(resource)) {
-                      delete resource['ldp:contains'];
-                      const typePredicate = resource.type ? 'type' : '@type';
-                      resource[typePredicate] = arrayOf(resource[typePredicate]);
-                      resource[typePredicate].push('ldp:Resource');
-                    }
-
-                    return resource;
-                  }
-                } catch (e) {
-                  // Ignore a resource if it is not found
-                  if (e.name !== 'MoleculerError') throw e;
-                }
-                return [];
+      containerResults['http://www.w3.org/ns/ldp#contains'] = await Promise.all(
+        arrayOf(resourcesUris).flatMap(async resourceUri => {
+          try {
+            // We pass the accept/jsonContext parameters only if they are explicit
+            const resource = await ctx.call(
+              'ldp.resource.get',
+              cleanUndefined({
+                resourceUri,
+                webId,
+                jsonContext,
+                accept
               })
             );
 
-      result = await ctx.call('jsonld.parser.compact', {
-        input: {
-          '@id': containerUri,
-          '@type': ['http://www.w3.org/ns/ldp#Container', 'http://www.w3.org/ns/ldp#BasicContainer'],
-          'http://purl.org/dc/terms/title': result.title,
-          'http://purl.org/dc/terms/description': result.description,
-          'http://www.w3.org/ns/ldp#contains': resources
-        },
-        context: jsonContext || (await ctx.call('jsonld.context.get'))
-      });
+            // Ensure a valid resource is returned (in some case, we may have only the context)
+            if (resource['@id'] || resource.id) {
+              // If we have a child container, remove the ldp:contains property and add a ldp:Resource type
+              // We are copying SOLID: https://github.com/assemblee-virtuelle/semapps/issues/429#issuecomment-768210074
+              if (isContainer(resource)) {
+                delete resource['ldp:contains'];
+                const typePredicate = resource.type ? 'type' : '@type';
+                resource[typePredicate] = arrayOf(resource[typePredicate]);
+                resource[typePredicate].push('ldp:Resource');
+              }
 
-      // If the ldp:contains is a single object, wrap it in an array for easier handling on the front side
-      const ldpContainsKey = Object.keys(result).find(key =>
-        ['http://www.w3.org/ns/ldp#contains', 'ldp:contains', 'contains'].includes(key)
-      );
-      if (ldpContainsKey && !Array.isArray(result[ldpContainsKey])) {
-        result[ldpContainsKey] = [result[ldpContainsKey]];
-      }
-
-      return result;
-    } else {
-      const blankNodesQuery = buildBlankNodesQuery(4);
-
-      return await ctx.call('triplestore.query', {
-        query: `
-          ${await ctx.call('ontologies.getRdfPrefixes')}
-          CONSTRUCT  {
-            <${containerUri}>
-              a ?containerType ;
-              ldp:contains ?s1 .
-            ${blankNodesQuery.construct}
-          }
-          WHERE {
-            <${containerUri}> a ldp:Container, ?containerType .
-            OPTIONAL {
-              <${containerUri}> ldp:contains ?s1 .
-              ${blankNodesQuery.where}
-              ${filtersQuery.where}
+              return resource;
             }
+          } catch (e) {
+            // Ignore a resource if it is not found
+            if (e.name !== 'MoleculerError') throw e;
           }
-        `,
-        accept,
-        webId
-      });
+          return [];
+        })
+      );
     }
+
+    let compactResults = await ctx.call('jsonld.parser.compact', {
+      input: containerResults,
+      context: jsonContext || (await ctx.call('jsonld.context.get'))
+    });
+
+    // If the ldp:contains is a single object, wrap it in an array for easier handling on the front side
+    const ldpContainsKey = Object.keys(compactResults).find(key =>
+      ['http://www.w3.org/ns/ldp#contains', 'ldp:contains', 'contains'].includes(key)
+    );
+    if (ldpContainsKey && !Array.isArray(compactResults[ldpContainsKey])) {
+      compactResults[ldpContainsKey] = [compactResults[ldpContainsKey]];
+    }
+
+    return compactResults;
   }
 };

--- a/src/middleware/tests/ldp/api.test.js
+++ b/src/middleware/tests/ldp/api.test.js
@@ -128,6 +128,18 @@ describe('LDP handling through API', () => {
     });
   });
 
+  // See https://www.w3.org/TR/ldp/#prefer-parameters
+  test('Get container with minimal representation', async () => {
+    const { json, headers } = await fetchServer(containerUri, {
+      headers: new fetch.Headers({
+        Prefer: 'return=representation; include="http://www.w3.org/ns/ldp#PreferMinimalContainer"'
+      })
+    });
+
+    expect(json['ldp:contains']).toBeUndefined();
+    expect(headers.get('Preference-Applied')).toBe('return=representation');
+  });
+
   test('Replace resource', async () => {
     await fetchServer(resourceUri, {
       method: 'PUT',

--- a/src/middleware/tests/ldp/container.test.js
+++ b/src/middleware/tests/ldp/container.test.js
@@ -194,10 +194,10 @@ describe('LDP container tests', () => {
       '@type': ['ldp:Container', 'ldp:BasicContainer'],
       'ldp:contains': [
         {
-          'pair:label': 'My project 2'
+          'pair:label': 'My project'
         },
         {
-          'pair:label': 'My project'
+          'pair:label': 'My project 2'
         }
       ]
     });
@@ -220,6 +220,16 @@ describe('LDP container tests', () => {
         }
       ]
     });
+  });
+
+  test('Get container without resources', async () => {
+    const container = await broker.call('ldp.container.get', {
+      containerUri: `${CONFIG.HOME_URL}resources`,
+      accept: MIME_TYPES.JSON,
+      doNotIncludeResources: true
+    });
+
+    expect(container['ldp:contained']).toBeUndefined();
   });
 
   test('Detach a resource from a container', async () => {

--- a/website/docs/middleware/ldp/container.md
+++ b/website/docs/middleware/ldp/container.md
@@ -95,13 +95,14 @@ Get the LDP container with all its resources (which are dereferenced)
 
 ##### Parameters
 
-| Property       | Type                | Default             | Description                                        |
-| -------------- | ------------------- | ------------------- | -------------------------------------------------- |
-| `containerUri` | `String`            | **required**        | URI of container                                   |
-| `accept`       | `String`            | **required**        | Type to return                                     |
-| `filters`      | `Object`            |                     | Key/value with predicates and value                |
-| `jsonContext`  | `Object`or `String` |                     | JSON-LD context to use when compacting the results |
-| `webId`        | `String`            | Logged user's webId | User doing the action                              |
+| Property                | Type                | Default             | Description                                        |
+| ----------------------- | ------------------- | ------------------- | -------------------------------------------------- |
+| `containerUri`          | `String`            | **required**        | URI of container                                   |
+| `accept`                | `String`            | **required**        | Type to return                                     |
+| `filters`               | `Object`            |                     | Key/value with predicates and value                |
+| `doNotIncludeResources` | `Boolean`           | false               | If true, does not return the contained resources   |
+| `jsonContext`           | `Object`or `String` |                     | JSON-LD context to use when compacting the results |
+| `webId`                 | `String`            | Logged user's webId | User doing the action                              |
 
 You can also pass parameters defined in the [container options](index.md#container-options).
 


### PR DESCRIPTION
Closes #1168

- Allow to return a LDP container without its resources (see [this spec](https://www.w3.org/TR/ldp/#prefer-parameters))
- Allow LDP containers to have other predicates (this is necessary to add [DataRegistration](https://github.com/activitypods/activitypods/pull/378) in ActivityPods)
- Throw error when getting with Turtle format (this is not working anyway, and will be fixed soon)
- Add related tests and documentation