### PR TITLE
Fix container creation permissions

### DIFF
--- a/src/middleware/packages/crypto/keys/key-container.js
+++ b/src/middleware/packages/crypto/keys/key-container.js
@@ -20,7 +20,7 @@ module.exports = {
       // If not a pod provider, the container is shared, so any user can append.
       return {
         anyUser: {
-          // `this` is not available here.
+          // Warning! ctx.service is the LdpContainerService. The WebAclMiddleware calls this function. This creates confusion.
           read: !ctx.service.settings.podProvider,
           append: !ctx.service.settings.podProvider
         }

--- a/src/middleware/packages/crypto/keys/public-key-container.js
+++ b/src/middleware/packages/crypto/keys/public-key-container.js
@@ -19,6 +19,7 @@ module.exports = {
       return {
         anyUser: {
           read: true,
+          // Warning! ctx.service is the LdpContainerService. The WebAclMiddleware calls this function. This creates confusion.
           append: !ctx.service.settings.podProvider
         }
       };

--- a/src/middleware/packages/ldp/services/container/actions/createAndAttach.js
+++ b/src/middleware/packages/ldp/services/container/actions/createAndAttach.js
@@ -23,7 +23,9 @@ module.exports = {
     if (!exists) {
       let parentContainerUri;
 
-      if (this.settings.podProvider && !webId) throw new Error(`The webId param is required in Pod provider config`);
+      if (this.settings.podProvider && (!webId || webId === 'anon' || webId === 'system'))
+        throw new Error(`The webId param is required in Pod provider config. Provided: ${webId}`);
+
       const rootContainerUri = this.settings.podProvider
         ? await ctx.call('solid-storage.getUrl', { webId })
         : urlJoin(this.settings.baseUrl, '/');
@@ -47,7 +49,7 @@ module.exports = {
         if (!parentExists) {
           // Recursively create the parent containers, without title/description/permissions
           await this.actions.createAndAttach(
-            { containerUri: parentContainerUri, options: {}, webId },
+            { containerUri: parentContainerUri, options: { permissions: {} }, webId },
             { parentCtx: ctx }
           );
         }
@@ -60,7 +62,7 @@ module.exports = {
           title,
           description,
           options,
-          webId
+          webId: this.settings.podProvider ? webId : 'system'
         },
         { parentCtx: ctx }
       );

--- a/src/middleware/packages/ldp/services/registry/actions/register.js
+++ b/src/middleware/packages/ldp/services/registry/actions/register.js
@@ -69,11 +69,9 @@ module.exports = {
       // TODO see if we can base ourselves on a general config for the POD data path
       options.fullPath = pathJoin('/:username([^/.][^/]+)', 'data', options.path);
     } else {
-      // Ensure the container has been created
       await ctx.call('ldp.container.createAndAttach', {
         containerUri: urlJoin(this.settings.baseUrl, options.path),
-        options,
-        permissions: options.permissions // Used by the WebAclMiddleware
+        options
       });
     }
 

--- a/src/middleware/packages/solid/package.json
+++ b/src/middleware/packages/solid/package.json
@@ -15,7 +15,7 @@
     "@semapps/webid": "1.0.10",
     "http-link-header": "^1.1.1",
     "moleculer": "^0.14.19",
-    "moleculer-bull": "0.2.8",
+    "moleculer-bull": "^0.2.5",
     "moleculer-db": "^0.8.16",
     "moleculer-web": "^0.10.0-beta1",
     "moment": "2.30.1",


### PR DESCRIPTION
Closes #1366

In non-Pod provider config, the LDP registry had insufficient rights to create containers, which generated errors on start. We fix this by using the `webId: system` in such cases.