### PR TITLE
Add ShareService to ActivityPub package

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/index.js
+++ b/src/middleware/packages/activitypub/services/activitypub/index.js
@@ -11,6 +11,7 @@ const ObjectService = require('./subservices/object');
 const OutboxService = require('./subservices/outbox');
 const CollectionsRegistryService = require('./subservices/collections-registry');
 const ReplyService = require('./subservices/reply');
+const ShareService = require('./subservices/share');
 const SideEffectsService = require('./subservices/side-effects');
 const FakeQueueMixin = require('../../mixins/fake-queue');
 
@@ -109,6 +110,14 @@ const ActivityPubService = {
 
     this.broker.createService({
       mixins: [LikeService],
+      settings: {
+        baseUri,
+        podProvider
+      }
+    });
+
+    this.broker.createService({
+      mixins: [ShareService],
       settings: {
         baseUri,
         podProvider

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/share.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/share.js
@@ -58,30 +58,29 @@ const ShareService = {
       async match(activity, fetcher) {
         const { match, dereferencedActivity } = await matchActivity(
           {
-            // looking for an announce activity targeting any object
-            type: ACTIVITY_TYPES.ANNOUNCE,
-            object: {}
+            // looking for an announce activity
+            type: ACTIVITY_TYPES.ANNOUNCE
           },
           activity,
           fetcher
         );
-        return { match, dereferencedActivity };
+        return {
+          match: match && (await this.broker.call('activitypub.activity.isPublic', { activity })),
+          dereferencedActivity
+        };
       },
       async onReceive(ctx, activity) {
-        await this.actions.addShare({ objectUri: activity.object.id, announce: activity }, { parentCtx: ctx });
+        await this.actions.addShare({ objectUri: activity.object, announce: activity }, { parentCtx: ctx });
       }
     },
     unshareObject: {
       async match(activity, fetcher) {
         const { match, dereferencedActivity } = await matchActivity(
           {
-            // looking for an undo activity targeting an announce activity targeting any object
+            // looking for an undo activity targeting an announce activity
             type: ACTIVITY_TYPES.UNDO,
             object: {
-              type: ACTIVITY_TYPES.ANNOUNCE,
-              object: {
-                object: {}
-              }
+              type: ACTIVITY_TYPES.ANNOUNCE
             }
           },
           activity,
@@ -91,7 +90,7 @@ const ShareService = {
       },
       async onReceive(ctx, activity) {
         await this.actions.removeShare(
-          { objectUri: activity.object.object.id, announce: activity.object },
+          { objectUri: activity.object?.object, announce: activity.object },
           { parentCtx: ctx }
         );
       }

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/share.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/share.js
@@ -1,0 +1,102 @@
+const ActivitiesHandlerMixin = require('../../../mixins/activities-handler');
+const { ACTIVITY_TYPES, OBJECT_TYPES } = require('../../../constants');
+const { collectionPermissionsWithAnonRead } = require('../../../utils');
+const matchActivity = require('../../../utils/matchActivity');
+
+const ShareService = {
+  name: 'activitypub.share',
+  mixins: [ActivitiesHandlerMixin],
+  settings: {
+    baseUri: null,
+    podProvider: false,
+    collectionOptions: {
+      path: '/shares',
+      attachPredicate: 'https://www.w3.org/ns/activitystreams#shares',
+      ordered: false,
+      dereferenceItems: false,
+      permissions: collectionPermissionsWithAnonRead
+    }
+  },
+  dependencies: ['activitypub.outbox', 'activitypub.collection'],
+  actions: {
+    async addShare(ctx) {
+      const { objectUri, announce } = ctx.params;
+
+      // Create the /shares collection and attach it to the object, unless it already exists
+      const collectionUri = await ctx.call('activitypub.collections-registry.createAndAttachCollection', {
+        objectUri,
+        collection: this.settings.collectionOptions,
+        webId: 'system'
+      });
+
+      // Add the announce to the shares collection
+      await ctx.call('activitypub.collection.add', { collectionUri, item: announce.id });
+    },
+    async removeShare(ctx) {
+      const { objectUri, announce } = ctx.params;
+
+      const object = await ctx.call('activitypub.object.get', { objectUri });
+
+      // If a shares collection is attached to the object, detach the announce
+      if (object?.shares) {
+        await ctx.call('activitypub.collection.remove', {
+          collectionUri: object.shares,
+          item: announce.id
+        });
+      }
+    },
+    async updateCollectionsOptions(ctx) {
+      const { dataset } = ctx.params;
+      await ctx.call('activitypub.collections-registry.updateCollectionsOptions', {
+        collection: this.settings.collectionOptions,
+        dataset
+      });
+    }
+  },
+  activities: {
+    shareObject: {
+      async match(activity, fetcher) {
+        const { match, dereferencedActivity } = await matchActivity(
+          {
+            // looking for an announce activity targeting any object
+            type: ACTIVITY_TYPES.ANNOUNCE,
+            object: {}
+          },
+          activity,
+          fetcher
+        );
+        return { match, dereferencedActivity };
+      },
+      async onReceive(ctx, activity) {
+        await this.actions.addShare({ objectUri: activity.object.id, announce: activity }, { parentCtx: ctx });
+      }
+    },
+    unshareObject: {
+      async match(activity, fetcher) {
+        const { match, dereferencedActivity } = await matchActivity(
+          {
+            // looking for an undo activity targeting an announce activity targeting any object
+            type: ACTIVITY_TYPES.UNDO,
+            object: {
+              type: ACTIVITY_TYPES.ANNOUNCE,
+              object: {
+                object: {}
+              }
+            }
+          },
+          activity,
+          fetcher
+        );
+        return { match, dereferencedActivity };
+      },
+      async onReceive(ctx, activity) {
+        await this.actions.removeShare(
+          { objectUri: activity.object.object.id, announce: activity.object },
+          { parentCtx: ctx }
+        );
+      }
+    }
+  }
+};
+
+module.exports = ShareService;

--- a/src/middleware/tests/activitypub/shares.test.js
+++ b/src/middleware/tests/activitypub/shares.test.js
@@ -1,0 +1,125 @@
+const waitForExpect = require('wait-for-expect');
+const { OBJECT_TYPES, ACTIVITY_TYPES, PUBLIC_URI } = require('@semapps/activitypub');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const initialize = require('./initialize');
+
+jest.setTimeout(50000);
+
+const NUM_USERS = 2;
+
+describe.each(['single-server', 'multi-server'])('In mode %s, exchange shares', mode => {
+  let broker;
+  const actors = [];
+  let alice;
+  let bob;
+  let aliceMessageUri;
+  let shareActivity;
+  beforeAll(async () => {
+    if (mode === 'single-server') {
+      broker = await initialize(3000, 'testData', 'settings');
+    } else {
+      broker = [];
+    }
+
+    for (let i = 1; i <= NUM_USERS; i++) {
+      if (mode === 'multi-server') {
+        broker[i] = await initialize(3000 + i, `testData${i}`, `settings${i}`, i);
+      } else {
+        broker[i] = broker;
+      }
+      const { webId } = await broker[i].call('auth.signup', require(`./data/actor${i}.json`));
+      actors[i] = await broker[i].call('activitypub.actor.awaitCreateComplete', { actorUri: webId });
+      actors[i].call = (actionName, params, options = {}) =>
+        broker[i].call(actionName, params, { ...options, meta: { ...options.meta, webId } });
+    }
+
+    alice = actors[1];
+    bob = actors[2];
+  });
+
+  afterAll(async () => {
+    if (mode === 'multi-server') {
+      for (let i = 1; i <= NUM_USERS; i++) {
+        await broker[i].stop();
+      }
+    } else {
+      await broker.stop();
+    }
+  });
+
+  test('Bob shares Alice message', async () => {
+    const createActivity = await alice.call('activitypub.outbox.post', {
+      collectionUri: alice.outbox,
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: OBJECT_TYPES.NOTE,
+      attributedTo: alice.id,
+      content: 'Hello world',
+      to: [bob.id, PUBLIC_URI]
+    });
+
+    aliceMessageUri = createActivity.object.id;
+
+    shareActivity = await bob.call('activitypub.outbox.post', {
+      collectionUri: bob.outbox,
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: ACTIVITY_TYPES.ANNOUNCE,
+      object: aliceMessageUri,
+      to: alice.id
+    });
+
+    // Ensure the /shares collection has been created
+    await waitForExpect(async () => {
+      await expect(
+        alice.call('ldp.resource.get', {
+          resourceUri: aliceMessageUri,
+          accept: MIME_TYPES.JSON
+        })
+      ).resolves.toMatchObject({
+        shares: `${aliceMessageUri}/shares`
+      });
+    });
+
+    // Ensure the annouce activity has been added to the /shares collection
+    await waitForExpect(async () => {
+      await expect(
+        alice.call('activitypub.collection.get', {
+          resourceUri: `${aliceMessageUri}/shares`,
+          accept: MIME_TYPES.JSON
+        })
+      ).resolves.toMatchObject({
+        type: 'Collection',
+        items: shareActivity.id
+      });
+    });
+  });
+
+  test('Bob undo his share', async () => {
+    await bob.call('activitypub.outbox.post', {
+      collectionUri: bob.outbox,
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: ACTIVITY_TYPES.UNDO,
+      object: shareActivity.id,
+      to: alice.id
+    });
+
+    // Ensure the annouce activity has been added to the /shares collection
+    await waitForExpect(async () => {
+      await expect(
+        alice.call('activitypub.collection.get', {
+          resourceUri: `${aliceMessageUri}/shares`,
+          accept: MIME_TYPES.JSON
+        })
+      ).resolves.not.toMatchObject({
+        // type: 'Collection',
+        items: shareActivity.id
+      });
+    });
+
+    // // Ensure Bob'activity has been removed from the /shares collection
+    //   const response = await alice.call('activitypub.collection.get', {
+    //     resourceUri: `${aliceMessageUri}/shares`,
+    //     accept: MIME_TYPES.JSON
+    //   })
+    //   expect(response.items).toBeUndefinedOrEmptyArray();
+  });
+});


### PR DESCRIPTION
Purpose of this PR : Add ShareService to ActivityPub package

- Creation of `activitypub.share` service to handle (via side-effects on the inbox) the `shares` collection of objects being shared using `Announce` activities.
    - Only adds public announces to the object `shares` collection
- Creation of a test case to validate share/unshare scenarios and assert that only public announces are added to the collection.