### PR TITLE
Fix activitypub.collection.get

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
@@ -190,7 +190,6 @@ async function selectAndDereferenceItems(ctx, allItemURIs, options, webId, curso
     nextItemUri = allItemURIs.shift();
   }
 
-  // Return the items without their individual context
   return {
     items: selectedItems,
     previousItemUri,


### PR DESCRIPTION
- Don't check WAC permissions if the items are not dereferenced (this is not necessary and decreases a lot the performances)
- Return the options only once (before this fix, it returned `semapps:dereferenceItems` + `dereferenceItems`)