### PR TITLE
Fix collection menu is loading too slowly

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
@@ -155,6 +155,15 @@ async function selectAndDereferenceItems(ctx, allItemURIs, options, webId, curso
   let nextItemUri = null;
   let previousItemUri = null;
 
+  // Pagination is enabled but no page is selected, we will display the "menu" so we don't need to dereference anything
+  if (options.itemsPerPage && !cursorDirection.hasBeforeEq && !cursorDirection.hasAfterEq) {
+    return {
+      items: allItemURIs,
+      previousItemUri,
+      nextItemUri
+    };
+  }
+
   do {
     itemUri = cursorDirection.hasBeforeEq ? allItemURIs.pop() : allItemURIs.shift();
     if (itemUri) {


### PR DESCRIPTION
When we are loading only the "menu" of the inbox or outbox, resources are being dereferenced while they shouldn't, which make it very slow to load.

This code attempts to fix the problem, but maybe it could be improved. What do you think @SlyRock ?