### PR TITLE
Feature: OrphanFilesDeletion mixin

### DIFF
--- a/src/middleware/packages/ldp/index.js
+++ b/src/middleware/packages/ldp/index.js
@@ -18,6 +18,7 @@ module.exports = {
   DisassemblyMixin: require('./mixins/disassembly'),
   SingleResourceContainerMixin: require('./mixins/single-resource-container'),
   SpecialEndpointMixin: require('./mixins/special-endpoint'),
+  OrphanFilesDeletionMixin: require('./mixins/orphan-files-deletion'),
   // Other
   defaultContainerOptions: require('./services/registry/defaultOptions'),
   LdpAdapter: require('./adapter'),

--- a/src/middleware/packages/ldp/mixins/orphan-files-deletion.js
+++ b/src/middleware/packages/ldp/mixins/orphan-files-deletion.js
@@ -1,0 +1,62 @@
+const { CronJob } = require('cron');
+const urlJoin = require('url-join');
+
+module.exports = {
+  settings: {
+    orphanFilesDeletion: {
+      baseUrl: undefined,
+      cronJob: {
+        time: '0 0 4 * * *', // Every night at 4am
+        timeZone: 'Europe/Paris'
+      }
+    }
+  },
+  dependencies: ['triplestore', 'ldp.resource'],
+  actions: {
+    async checkOrphanFiles(ctx) {
+      try {
+        this.logger.info('OrphanFilesDeletion - Check...');
+
+        const containerUri = urlJoin(this.settings.orphanFilesDeletion.baseUrl, this.settings.path);
+        const orphanFiles = await ctx.call('triplestore.query', {
+          query: `
+            SELECT ?file
+            WHERE {
+              <${containerUri}> <http://www.w3.org/ns/ldp#contains> ?file .
+              FILTER NOT EXISTS {
+                ?s ?p ?file .
+                FILTER(?s != <${containerUri}>)
+              }
+            }
+          `,
+          webId: 'system'
+        });
+
+        this.logger.info(`OrphanFilesDeletion - Found ${orphanFiles.length} orphan files`);
+
+        for (let orphanFile of orphanFiles) {
+          await ctx.call('ldp.resource.delete', {
+            resourceUri: orphanFile.file.value,
+            webId: 'system'
+          });
+
+          this.logger.info(`OrphanFilesDeletion - ${orphanFile.file.value} deleted`);
+        }
+      } catch (error) {
+        this.logger.error(`OrphanFilesDeletion - Error: ${error.message}`);
+      }
+    }
+  },
+  created() {
+    this.actions.checkOrphanFiles();
+    const { cronJob } = this.settings.orphanFilesDeletion || {};
+    const { time, timeZone } = cronJob || {};
+
+    if (cronJob) {
+      this.cronJob = new CronJob(time, this.actions.checkOrphanFiles, null, true, timeZone);
+    }
+  },
+  stopped() {
+    this.cronJob?.stop();
+  }
+};

--- a/src/middleware/packages/ldp/package.json
+++ b/src/middleware/packages/ldp/package.json
@@ -11,6 +11,7 @@
     "@semapps/ontologies": "1.1.2",
     "@semapps/triplestore": "1.1.2",
     "bytes": "^3.1.2",
+    "cron": "^4.1.4",
     "dashify": "^2.0.0",
     "http-link-header": "^1.1.1",
     "mime-types": "^2.1.35",

--- a/website/docs/middleware/ldp/orphan-files-deletion.md
+++ b/website/docs/middleware/ldp/orphan-files-deletion.md
@@ -1,0 +1,39 @@
+---
+title: OrphanFilesDeletionMixin
+---
+
+Deletes files from database and from disk when they are not used anymore.
+By default, check is done when the service is launched, at every night. Cronjob can be disabled.
+
+## Usage
+
+```js
+const { ControlledContainerMixin, OrphanFilesDeletionMixin } = require('@semapps/ldp');
+
+module.exports = {
+  name: 'file',
+  mixins: [ControlledContainerMixin, OrphanFilesDeletionMixin],
+  settings: {
+    path: '/files',
+    acceptedTypes: ['semapps:File'],
+    orphanFilesDeletion: {
+      baseUrl: '<middlewareBaseUrl>',
+      cronJob: {
+        // Optional, can be set to false
+        time: '0 0 4 * * *', // Every night at 4am
+        timeZone: 'Europe/Paris'
+      }
+    },
+    activateTombstones: false
+  }
+};
+```
+
+### Settings
+
+All settings relative to this mixin should be set in a `orphanFilesDeletion` key.
+
+| Property  | Type     | Default                                             | Description                                                                          |
+| --------- | -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `baseUrl` | `String` | -                                                   | Middleware base url                                                                  |
+| `cronJob` | `Object` | { time: "0 0 4 \* \* \*", timeZone: "Europe/Paris"} | Optional cronJob settings { time, timeZone }. Can be set to false to disable cronjob |

--- a/website/docs/middleware/ldp/orphan-files-deletion.md
+++ b/website/docs/middleware/ldp/orphan-files-deletion.md
@@ -3,7 +3,7 @@ title: OrphanFilesDeletionMixin
 ---
 
 Deletes files from database and from disk when they are not used anymore.
-By default, check is done when the service is launched, at every night. Cronjob can be disabled.
+By default, check is done when the service is launched, plus every night at 4am. Cronjob can be disabled.
 
 ## Usage
 
@@ -17,7 +17,6 @@ module.exports = {
     path: '/files',
     acceptedTypes: ['semapps:File'],
     orphanFilesDeletion: {
-      baseUrl: '<middlewareBaseUrl>',
       cronJob: {
         // Optional, can be set to false
         time: '0 0 4 * * *', // Every night at 4am
@@ -35,5 +34,4 @@ All settings relative to this mixin should be set in a `orphanFilesDeletion` key
 
 | Property  | Type     | Default                                             | Description                                                                          |
 | --------- | -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `baseUrl` | `String` | -                                                   | Middleware base url                                                                  |
 | `cronJob` | `Object` | { time: "0 0 4 \* \* \*", timeZone: "Europe/Paris"} | Optional cronJob settings { time, timeZone }. Can be set to false to disable cronjob |


### PR DESCRIPTION
Hello,

Following #1384 , #1386 and as exposed in #1147, I propose a new mixin for deleting orphan uploaded files.

By default, check is done when the service is launched, at every night. Cronjob can be disabled.

Usage in a new Moleculer Service for a files container: 
```javascript
const { ControlledContainerMixin, OrphanFilesDeletionMixin } = require("@semapps/ldp");

module.exports = {
  name: 'file',
  mixins: [ControlledContainerMixin, OrphanFilesDeletionMixin],
  settings: {
    path: '/files',
    acceptedTypes: ['semapps:File'],
    orphanFilesDeletion: {
      baseUrl: "<middlewareBaseUrl>",
      cronJob: { // Optional, can be set to false
         time: "0 0 4 * * *", // Every night at 4am
         timeZone: "Europe/Paris",
      }
    },
    activateTombstones: false,
  }
}
```