### PR TITLE
fix: capabilities not sent from outbox (broken invite link feature)

### DIFF
--- a/src/middleware/packages/activitypub/services/activitypub/subservices/outbox.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/outbox.js
@@ -96,9 +96,9 @@ const OutboxService = {
           webId: actorUri
         });
 
-        // -- Persist Capability --
-        // There might be a capability attached which should not be persisted
-        // because other's could otherwise read it from the (public) outbox.
+        // -- Persist Activity --
+        // There might be a capability attached which cannot be persisted, if it has a non-resolvable id.
+        // So we won't persist it and re-attach it afterwards.
         let { capability, ...activityToPersist } = activity;
 
         activityUri = await ctx.call('activitypub.activity.post', {


### PR DESCRIPTION
The capabilities sent to the outbox are not persisted in the outbox anymore.

Additionally, because they *were* persisted but did not have a resolvable URI, the triplestore could not store the capabilities completely either so that the sent acitivities' capabilities were invalid.