### PR TITLE
Fix content negotiation (Turtle/N-Triples)

### DIFF
--- a/src/middleware/packages/activitypub/mixins/await-activity.js
+++ b/src/middleware/packages/activitypub/mixins/await-activity.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { delay } = require('../utils');
 const matchActivity = require('../utils/matchActivity');
 
@@ -20,7 +19,6 @@ const AwaitActivityMixin = {
         try {
           const resource = await ctx.call('ldp.resource.get', {
             resourceUri,
-            accept: MIME_TYPES.JSON,
             webId
           });
           return resource; // First get the resource, then return it, otherwise the try/catch will not work

--- a/src/middleware/packages/activitypub/mixins/bot.js
+++ b/src/middleware/packages/activitypub/mixins/bot.js
@@ -1,5 +1,4 @@
 const urlJoin = require('url-join');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { arrayOf } = require('@semapps/ldp');
 const { ACTOR_TYPES } = require('../constants');
 const { getSlugFromUri, getContainerFromUri } = require('../utils');
@@ -54,7 +53,6 @@ const BotMixin = {
             preferredUsername: actorSettings.username,
             name: actorSettings.name
           },
-          contentType: MIME_TYPES.JSON,
           webId: 'system'
         });
       } catch (e) {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/activity.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/activity.js
@@ -1,6 +1,5 @@
 const { Errors: E } = require('moleculer-web');
 const { ControlledContainerMixin } = require('@semapps/ldp');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const setRightsHandler = require('./activity-handlers/setRightsHandler');
 const { objectCurrentToId, objectIdToCurrent, arrayOf } = require('../../../utils');
 const { PUBLIC_URI, FULL_ACTIVITY_TYPES } = require('../../../constants');
@@ -15,7 +14,6 @@ const ActivityService = {
     // ControlledContainerMixin settings
     path: '/as/activity',
     acceptedTypes: Object.values(FULL_ACTIVITY_TYPES),
-    accept: MIME_TYPES.JSON,
     permissions: {},
     newResourcesPermissions: {},
     readOnly: true,

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/actor.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/actor.js
@@ -1,6 +1,5 @@
 const fetch = require('node-fetch');
 const { namedNode, literal, triple, variable } = require('@rdfjs/data-model');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { arrayOf } = require('@semapps/ldp');
 const { ACTOR_TYPES, AS_PREFIX } = require('../../../constants');
 const { getSlugFromUri, waitForResource } = require('../../../utils');
@@ -21,7 +20,7 @@ const ActorService = {
       if (ctx.meta.dataset && !(await ctx.call('ldp.remote.isRemote', { resourceUri: actorUri }))) {
         try {
           // Don't return immediately the promise, or we won't be able to catch errors
-          const actor = await ctx.call('ldp.resource.get', { resourceUri: actorUri, accept: MIME_TYPES.JSON, webId });
+          const actor = await ctx.call('ldp.resource.get', { resourceUri: actorUri, webId });
           return actor;
         } catch (e) {
           console.error(e);
@@ -39,7 +38,7 @@ const ActorService = {
       const actor = await this.actions.get({ actorUri, webId }, { parentCtx: ctx });
       // If the URL is not in the same domain as the actor, it is most likely not a profile
       if (actor.url && new URL(actor.url).host === new URL(actorUri).host) {
-        return await ctx.call('ldp.resource.get', { resourceUri: actor.url, accept: MIME_TYPES.JSON, webId });
+        return await ctx.call('ldp.resource.get', { resourceUri: actor.url, webId });
       }
     },
     async appendActorData(ctx) {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/api.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/api.js
@@ -97,9 +97,9 @@ const ApiService = {
       const middlewares = [
         parseUrl,
         parseHeader,
-        parseRawBody,
         negotiateContentType,
         negotiateAccept,
+        parseRawBody,
         parseJson,
         parseFile,
         saveDatasetMeta

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/api.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/api.js
@@ -4,11 +4,10 @@ const { arrayOf } = require('@semapps/ldp');
 const {
   parseUrl,
   parseHeader,
-  parseSparql,
+  parseRawBody,
   negotiateContentType,
   negotiateAccept,
   parseJson,
-  parseTurtle,
   parseFile,
   saveDatasetMeta
 } = require('@semapps/middlewares');
@@ -98,11 +97,10 @@ const ApiService = {
       const middlewares = [
         parseUrl,
         parseHeader,
+        parseRawBody,
         negotiateContentType,
         negotiateAccept,
-        parseSparql,
         parseJson,
-        parseTurtle,
         parseFile,
         saveDatasetMeta
       ];
@@ -111,7 +109,7 @@ const ApiService = {
         name: this.settings.podProvider ? 'boxes' : `boxes${actorsPath}`,
         path: actorsPath,
         // Disable the body parsers so that we can parse the body ourselves
-        // (Moleculer-web doesn't handle non-JSON bodies, so we must do it)
+        // (Moleculer-web doesn't handle non-JSON bodies, so we must do it ourselves)
         bodyParsers: false,
         authorization: false,
         authentication: true,

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { sanitizeSparqlUri } = require('@semapps/triplestore');
 const { MoleculerError } = require('moleculer').Errors;
 const { getValueFromDataType } = require('../../../../../utils');
@@ -26,7 +25,6 @@ async function getCollectionMetadata(ctx, collectionUri, webId, dataset) {
         OPTIONAL { <${collectionUri}> semapps:sortOrder ?sortOrder . }
       }
     `,
-    accept: MIME_TYPES.JSON,
     dataset,
     webId: 'system'
   });
@@ -47,7 +45,6 @@ async function verifyCursorExists(ctx, collectionUri, cursor, dataset) {
         BIND (EXISTS{ <${collectionUri}> as:items <${cursor}> } AS ?itemExists)
       }
     `,
-    accept: MIME_TYPES.JSON,
     dataset,
     webId: 'system'
   });
@@ -91,7 +88,6 @@ async function fetchCollectionItemURIs(ctx, collectionUri, options, dataset) {
           : ''
       }
     `,
-    accept: MIME_TYPES.JSON,
     dataset,
     webId: 'system'
   });

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.js
@@ -175,7 +175,6 @@ async function selectAndDereferenceItems(ctx, allItemURIs, options, webId, curso
         try {
           let item = await ctx.call('ldp.resource.get', {
             resourceUri: itemUri,
-            accept: MIME_TYPES.JSON,
             webId: ctx.meta.impersonatedUser || webId
           });
           delete item['@context']; // Don't keep the items individual context

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.js
@@ -1,6 +1,5 @@
 const { MoleculerError } = require('moleculer').Errors;
 const { ControlledContainerMixin, arrayOf, getDatasetFromUri } = require('@semapps/ldp');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { sanitizeSparqlQuery } = require('@semapps/triplestore');
 const { Errors: E } = require('moleculer-web');
 const getAction = require('./actions/get');
@@ -129,7 +128,6 @@ const CollectionService = {
             <${collectionUri}> as:items ?items .
           }
         `,
-        accept: MIME_TYPES.JSON,
         dataset: this.getCollectionDataset(collectionUri),
         webId: 'system'
       });
@@ -153,7 +151,6 @@ const CollectionService = {
             <${collectionUri}> as:items <${itemUri}> .
           }
         `,
-        accept: MIME_TYPES.JSON,
         dataset: this.getCollectionDataset(collectionUri),
         webId: 'system'
       });
@@ -263,7 +260,6 @@ const CollectionService = {
             ?actorUri ${prefix}:${collectionKey} <${collectionUri}>
           }
         `,
-        accept: MIME_TYPES.JSON,
         dataset: this.getCollectionDataset(collectionUri),
         webId: 'system'
       });

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.js
@@ -16,7 +16,6 @@ const CollectionService = {
       'https://www.w3.org/ns/activitystreams#Collection',
       'https://www.w3.org/ns/activitystreams#OrderedCollection'
     ],
-    accept: MIME_TYPES.JSON,
     activateTombstones: false,
     permissions: {},
     // These default permissions can be overridden by providing

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.js
@@ -177,8 +177,12 @@ const CollectionService = {
       if (!collectionExist)
         throw new Error(`Cannot attach to a non-existing collection: ${collectionUri} (dataset: ${ctx.meta.dataset})`);
 
-      await ctx.call('triplestore.insert', {
-        resource: sanitizeSparqlQuery`<${collectionUri}> <https://www.w3.org/ns/activitystreams#items> <${itemUri}>`,
+      await ctx.call('triplestore.update', {
+        query: sanitizeSparqlQuery`
+          INSERT DATA { 
+            <${collectionUri}> <https://www.w3.org/ns/activitystreams#items> <${itemUri}>
+          }
+        `,
         dataset: this.getCollectionDataset(collectionUri),
         webId: 'system'
       });

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collections-registry.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collections-registry.js
@@ -145,7 +145,6 @@ const CollectionsRegistryService = {
               ?objectUri <${attachPredicate}> ?collectionUri 
             }
           `,
-          accept: MIME_TYPES.JSON,
           webId: 'system',
           dataset
         });

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
@@ -73,7 +73,7 @@ const InboxService = {
           throw new Error(`Cannot validate HTTP signature because of missing meta (rawBody or originalHeaders)`);
 
         const validDigest = await ctx.call('signature.verifyDigest', {
-          body: ctx.meta.rawBody, // Stored by parseJson middleware
+          body: ctx.meta.rawBody, // Stored by parseRawBody middleware
           headers: ctx.meta.originalHeaders
         });
 

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.js
@@ -1,6 +1,5 @@
 const { Errors: E } = require('moleculer-web');
 const { MoleculerError } = require('moleculer').Errors;
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { objectIdToCurrent, collectionPermissionsWithAnonRead } = require('../../../utils');
 const { ACTOR_TYPES } = require('../../../constants');
 const AwaitActivityMixin = require('../../../mixins/await-activity');
@@ -163,7 +162,6 @@ const InboxService = {
           }
           ORDER BY ?published
         `,
-        accept: MIME_TYPES.JSON,
         webId: 'system'
       });
 

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
@@ -20,8 +20,7 @@ const ObjectService = {
       return await ctx.call('ldp.resource.get', {
         resourceUri: objectUri,
         webId: actorUri,
-        ...rest,
-        accept: MIME_TYPES.JSON
+        ...rest
       });
     },
     // If an object is passed directly, wrap it in a Create activity
@@ -90,7 +89,6 @@ const ObjectService = {
             {
               containerUri,
               resource: activity.object,
-              contentType: MIME_TYPES.JSON,
               webId: actorUri
             },
             {
@@ -114,7 +112,6 @@ const ObjectService = {
             controlledActions?.put || 'ldp.resource.put',
             {
               resource: activity.object,
-              contentType: MIME_TYPES.JSON,
               webId: actorUri
             },
             {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
@@ -1,5 +1,4 @@
 const { getType } = require('@semapps/ldp');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { OBJECT_TYPES, ACTIVITY_TYPES } = require('../../../constants');
 
 const ObjectService = {
@@ -156,7 +155,6 @@ const ObjectService = {
           'ldp.resource.get',
           {
             resourceUri: objectUri,
-            accept: MIME_TYPES.JSON,
             webId: actorUri
           },
           { meta: { $cache: false } }

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.js
@@ -183,7 +183,6 @@ const ObjectService = {
             '@type': 'http://www.w3.org/2001/XMLSchema#dateTime'
           }
         },
-        contentType: MIME_TYPES.JSON,
         webId: 'system'
       });
     }

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/side-effects.js
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/side-effects.js
@@ -1,6 +1,5 @@
 const { credentialsContext } = require('@semapps/crypto');
 const { arrayOf } = require('@semapps/ldp');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const matchActivity = require('../../../utils/matchActivity');
 
 /**
@@ -74,7 +73,6 @@ module.exports = {
           'ldp.resource.get',
           {
             resourceUri,
-            accept: MIME_TYPES.JSON,
             webId
           },
           { meta: { dataset } }

--- a/src/middleware/packages/activitypub/services/relay.js
+++ b/src/middleware/packages/activitypub/services/relay.js
@@ -1,5 +1,4 @@
 const urlJoin = require('url-join');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { ACTOR_TYPES } = require('../constants');
 const { delay } = require('../utils');
 
@@ -57,7 +56,6 @@ const RelayService = {
             preferredUsername: actorSettings.username,
             name: actorSettings.name
           },
-          contentType: MIME_TYPES.JSON,
           webId: 'system'
         });
       } catch (e) {

--- a/src/middleware/packages/auth/services/migration.js
+++ b/src/middleware/packages/auth/services/migration.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { getSlugFromUri } = require('@semapps/ldp');
 
 module.exports = {
@@ -7,7 +6,7 @@ module.exports = {
     async migrateUsersToAccounts(ctx) {
       const { usersContainer, emailPredicate, usernamePredicate } = ctx.params;
 
-      const results = await ctx.call('ldp.container.get', { containerUri: usersContainer, accept: MIME_TYPES.JSON });
+      const results = await ctx.call('ldp.container.get', { containerUri: usersContainer });
 
       for (const user of results['ldp:contains']) {
         if (user[emailPredicate]) {

--- a/src/middleware/packages/crypto/keys/keys.js
+++ b/src/middleware/packages/crypto/keys/keys.js
@@ -84,10 +84,7 @@ const KeysService = {
         const webId = ctx.params.webId || ctx.meta.webId;
 
         // Get the key container, to search by type.
-        const container = await ctx.call('keys.container.list', {
-          webId,
-          accept: MIME_TYPES.JSON
-        });
+        const container = await ctx.call('keys.container.list', { webId });
 
         // Check if key type is present.
         const matchedKeys = container['ldp:contains'].filter(
@@ -112,7 +109,7 @@ const KeysService = {
       },
       async handler(ctx) {
         const { keyType, webId } = ctx.params;
-        const webIdDoc = await ctx.call('webid.get', { resourceUri: webId, accept: MIME_TYPES.JSON, webId: 'system' });
+        const webIdDoc = await ctx.call('webid.get', { resourceUri: webId, webId: 'system' });
 
         // RSA keys are stored in `publicKey` field, everything else in `assertionMethod`
         const publicKeys =
@@ -135,7 +132,6 @@ const KeysService = {
             const publicKeyId = key.id || key['@id'];
             return await ctx.call('keys.container.get', {
               resourceUri: await this.actions.findPrivateKeyUri({ publicKeyUri: publicKeyId }, { parentCtx: ctx }),
-              accept: MIME_TYPES.JSON,
               webId
             });
           })
@@ -164,7 +160,7 @@ const KeysService = {
         // Note: Key purposes are not regarded, as they are currently not used.
         const keyObject =
           ctx.params.keyObject || keyId
-            ? await ctx.call('keys.container.get', { resourceUri: keyId, webId, accept: MIME_TYPES.JSON })
+            ? await ctx.call('keys.container.get', { resourceUri: keyId, webId })
             : (await ctx.call('keys.getOrCreateWebIdKeys', { webId, keyType }))[0];
 
         // We need the key object to have the public key's id, so it is resolvable.
@@ -208,8 +204,7 @@ const KeysService = {
         };
         const keyUri = await ctx.call('keys.container.post', {
           webId,
-          resource: keyObject,
-          contentType: MIME_TYPES.JSON
+          resource: keyObject
         });
         keyObject.id = keyUri;
 
@@ -334,9 +329,7 @@ const KeysService = {
         const keyId = ctx.params.keyId || ctx.params.keyObject?.id || ctx.params.keyObject?.['@id'];
         if (!keyId) throw new Error('Either keyId or keyObject with id must be given.');
 
-        const keyObject =
-          ctx.params.keyObject ||
-          (await ctx.call('ldp.resource.get', { resourceUri: keyId, accept: MIME_TYPES.JSON, webId }));
+        const keyObject = ctx.params.keyObject || (await ctx.call('ldp.resource.get', { resourceUri: keyId, webId }));
 
         const isRsaKey = arrayOf(keyObject.type || keyObject['@type']).includes(KEY_TYPES.RSA);
 
@@ -347,7 +340,6 @@ const KeysService = {
 
         const webIdDocument = await ctx.call('webid.get', {
           resourceUri: webId,
-          accept: MIME_TYPES.JSON,
           webId: webId
         });
         // Ensure the same public key is not attached already.
@@ -414,9 +406,7 @@ const KeysService = {
       async handler(ctx) {
         const webId = ctx.params.webId || ctx.meta.webId;
         const privateKeyUri = ctx.params.keyId || ctx.params.keyObject?.id || ctx.params.keyObject?.['@id'];
-        const keyObject =
-          ctx.params.keyObject ||
-          (await ctx.call('ldp.resource.get', { resourceUri: privateKeyUri, accept: MIME_TYPES.JSON }));
+        const keyObject = ctx.params.keyObject || (await ctx.call('ldp.resource.get', { resourceUri: privateKeyUri }));
 
         // First, get the public key part.
         const publicKeyObject = await this.actions.getPublicKeyObject({ keyObject }, { parentCtx: ctx });
@@ -424,7 +414,6 @@ const KeysService = {
         // Then, store it in the `/public-key` container.
         const publicKeyUri = await ctx.call('keys.public-container.post', {
           resource: publicKeyObject,
-          contentType: MIME_TYPES.JSON,
           webId: webId
         });
 
@@ -456,8 +445,7 @@ const KeysService = {
       async handler(ctx) {
         const resourceUri = ctx.params.resourceUri || ctx.params.keyObject?.id || ctx.params.keyObject?.['@id'];
         const webId = ctx.params.webId || ctx.meta.webId;
-        const keyObject =
-          ctx.params.keyObject || (await ctx.call('ldp.resource.get', { resourceUri, accept: MIME_TYPES.JSON, webId }));
+        const keyObject = ctx.params.keyObject || (await ctx.call('ldp.resource.get', { resourceUri, webId }));
 
         await ctx.call('keys.container.delete', { resourceUri, webId });
         // Delete corresponding public key in the `public-key` container, if present.
@@ -481,7 +469,7 @@ const KeysService = {
       },
       async handler(ctx) {
         const { webId } = ctx.params;
-        const keys = await ctx.call('keys.container.list', { webId, accept: MIME_TYPES.JSON });
+        const keys = await ctx.call('keys.container.list', { webId });
         for (const key of keys['ldp:contains']) {
           await ctx.call('keys.delete', { resourceUri: key.id, webId });
         }
@@ -551,8 +539,7 @@ const KeysService = {
       },
       async handler(ctx) {
         const keyId = ctx.params.keyId || ctx.params.keyObject?.id || ctx.params.keyObject?.['@id'];
-        const keyObject =
-          ctx.params.keyObject || (await ctx.call('ldp.resource.get', { resourceUri: keyId, accept: MIME_TYPES.JSON }));
+        const keyObject = ctx.params.keyObject || (await ctx.call('ldp.resource.get', { resourceUri: keyId }));
 
         const keyType = keyObject['@type'] || keyObject.type;
 

--- a/src/middleware/packages/crypto/keys/migration.js
+++ b/src/middleware/packages/crypto/keys/migration.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const fs = require('fs');
 const path = require('path');
 const { KEY_TYPES } = require('../constants');
@@ -161,7 +160,6 @@ module.exports = {
         };
         const keyId = await ctx.call('keys.container.post', {
           resource: keyResource,
-          contentType: MIME_TYPES.JSON,
           webId
         });
         keyResource.id = keyId;

--- a/src/middleware/packages/crypto/signature/keypair.js
+++ b/src/middleware/packages/crypto/signature/keypair.js
@@ -3,7 +3,6 @@ const path = require('path');
 const fetch = require('node-fetch');
 const { generateKeyPair } = require('crypto');
 const { namedNode, blankNode, literal, triple } = require('@rdfjs/data-model');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { KEY_TYPES } = require('../constants');
 
 /**
@@ -107,7 +106,6 @@ const SignatureService = {
 
       const actor = await ctx.call('ldp.resource.get', {
         resourceUri: actorUri,
-        accept: MIME_TYPES.JSON,
         webId: actorUri
       });
 

--- a/src/middleware/packages/crypto/signature/proxy.js
+++ b/src/middleware/packages/crypto/signature/proxy.js
@@ -56,7 +56,7 @@ const ProxyService = {
       const body =
         ctx.params.files && ctx.params.files.length > 0
           ? await stream2buffer(ctx.params.files[0].readableStream)
-          : ctx.params.body;
+          : ctx.meta.rawBody;
 
       try {
         const response = await this.actions.query(

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-api-service.js
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-api-service.js
@@ -1,8 +1,8 @@
-const { parseHeader, negotiateAccept, parseJson } = require('@semapps/middlewares');
+const { parseHeader, parseRawBody, negotiateAccept, parseJson } = require('@semapps/middlewares');
 const path = require('node:path');
 const { VC_API_PATH } = require('../constants');
 
-const middlewares = [parseHeader, parseJson, negotiateAccept];
+const middlewares = [parseHeader, parseRawBody, parseJson, negotiateAccept];
 
 /**
  *

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-api-service.js
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-api-service.js
@@ -1,8 +1,8 @@
-const { parseHeader, parseRawBody, negotiateAccept, parseJson } = require('@semapps/middlewares');
+const { parseHeader, parseRawBody, negotiateAccept, negotiateContentType, parseJson } = require('@semapps/middlewares');
 const path = require('node:path');
 const { VC_API_PATH } = require('../constants');
 
-const middlewares = [parseHeader, parseRawBody, parseJson, negotiateAccept];
+const middlewares = [parseHeader, negotiateAccept, negotiateContentType, parseRawBody, parseJson];
 
 /**
  *

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-holder-service.js
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-holder-service.js
@@ -1,5 +1,4 @@
 const { randomUUID } = require('node:crypto');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const {
   purposes: { AuthenticationProofPurpose }
 } = require('jsonld-signatures');
@@ -115,7 +114,7 @@ const VCHolderService = {
         if (!presentationParam.id && ctx.params.options.persist)
           await ctx.call(
             'crypto.vc.holder.presentation-container.put',
-            { resource: signedPresentation, contentType: MIME_TYPES.JSON, webId: 'system' },
+            { resource: signedPresentation, webId: 'system' },
             { meta: { skipEmitEvent: true } }
           );
 
@@ -130,15 +129,13 @@ const VCHolderService = {
       // Post presentation to container (will add metadata).
       const resourceUri = await this.broker.call('crypto.vc.holder.presentation-container.post', {
         resource: presentation,
-        contentType: MIME_TYPES.JSON,
         webId
       });
 
       // Get the presentation resource.
       const resource = await this.broker.call('crypto.vc.holder.presentation-container.get', {
         resourceUri,
-        webId: 'system',
-        accept: MIME_TYPES.JSON
+        webId: 'system'
       });
 
       // Set resource rights.

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-issuer-service.js
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-issuer-service.js
@@ -127,7 +127,7 @@ const VCCredentialService = {
         if (!receivedCredential.id)
           await ctx.call(
             'crypto.vc.issuer.credential-container.put',
-            { resource: signedCredential, contentType: MIME_TYPES.JSON, webId: 'system' },
+            { resource: signedCredential, webId: 'system' },
             { meta: { skipEmitEvent: true } }
           );
 
@@ -140,7 +140,6 @@ const VCCredentialService = {
     async createCredentialResource(credential, noAnonRead, webId) {
       const resourceUri = await this.broker.call('crypto.vc.issuer.credential-container.post', {
         resource: credential,
-        contentType: MIME_TYPES.JSON,
         webId
       });
 
@@ -148,8 +147,7 @@ const VCCredentialService = {
       const resource = await this.broker.call('crypto.vc.issuer.credential-container.get', {
         resourceUri,
         jsonContext: credentialsContext,
-        webId: 'system',
-        accept: MIME_TYPES.JSON
+        webId: 'system'
       });
 
       // Set resource rights.

--- a/src/middleware/packages/importer/mixins/importer.js
+++ b/src/middleware/packages/importer/mixins/importer.js
@@ -2,7 +2,6 @@ const fetch = require('node-fetch');
 const cronParser = require('cron-parser');
 const { promises: fsPromises } = require('fs');
 const { ACTIVITY_TYPES, PUBLIC_URI } = require('@semapps/activitypub');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { isDir } = require('../utils');
 
 module.exports = {
@@ -67,7 +66,6 @@ module.exports = {
             FILTER STRSTARTS(STR(?sourceUri), "${this.settings.source.apiUrl}")
           }
         `,
-        accept: MIME_TYPES.JSON,
         webId: 'system'
       });
 

--- a/src/middleware/packages/importer/mixins/importer.js
+++ b/src/middleware/packages/importer/mixins/importer.js
@@ -197,7 +197,6 @@ module.exports = {
       if (destUri) {
         const oldData = await ctx.call('ldp.resource.get', {
           resourceUri: destUri,
-          accept: MIME_TYPES.JSON,
           webId: 'system'
         });
 
@@ -225,7 +224,6 @@ module.exports = {
                 'dc:modified': resource['dc:modified'] || this.getField('updated', data),
                 'dc:creator': resource['dc:creator'] || this.settings.dest.actorUri
               },
-              contentType: MIME_TYPES.JSON,
               webId: 'system'
             });
           } catch (e) {
@@ -257,7 +255,6 @@ module.exports = {
               'dc:modified': resource['dc:modified'] || this.getField('updated', data),
               'dc:creator': resource['dc:creator'] || this.settings.dest.actorUri
             },
-            contentType: MIME_TYPES.JSON,
             webId: 'system'
           });
         } catch (e) {

--- a/src/middleware/packages/importer/mixins/wordpress.js
+++ b/src/middleware/packages/importer/mixins/wordpress.js
@@ -1,7 +1,6 @@
 const urlJoin = require('url-join');
 const fetch = require('node-fetch');
 const { getSlugFromUri, delay } = require('@semapps/ldp');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const ImporterMixin = require('./importer');
 
 module.exports = {
@@ -90,7 +89,6 @@ module.exports = {
               readableStream: response.body,
               mimetype: mediaData.mime_type
             },
-            contentType: MIME_TYPES.JSON,
             webId: 'system'
           });
         } else {

--- a/src/middleware/packages/jsonld/package.json
+++ b/src/middleware/packages/jsonld/package.json
@@ -9,6 +9,7 @@
     "jsonld-context-parser": "^2.4.0",
     "jsonld-streaming-parser": "^2.4.2",
     "lru-cache": "^6.0.0",
+    "n3": "^1.26.0",
     "streamify-string": "^1.0.1",
     "url-join": "^4.0.1"
   },

--- a/src/middleware/packages/jsonld/package.json
+++ b/src/middleware/packages/jsonld/package.json
@@ -8,8 +8,10 @@
     "jsonld": "^3.3.2",
     "jsonld-context-parser": "^2.4.0",
     "jsonld-streaming-parser": "^2.4.2",
+    "jsonld-streaming-serializer": "^1.2.0",
     "lru-cache": "^6.0.0",
     "n3": "^1.26.0",
+    "rdf-parse": "^1.7.0",
     "streamify-string": "^1.0.1",
     "url-join": "^4.0.1"
   },

--- a/src/middleware/packages/ldp/adapter.js
+++ b/src/middleware/packages/ldp/adapter.js
@@ -1,6 +1,5 @@
 const urlJoin = require('url-join');
 const { ServiceSchemaError } = require('moleculer').Errors;
-const { MIME_TYPES } = require('@semapps/mime-types');
 
 class LdpAdapter {
   constructor({ resourceService = 'ldp.resource', containerService = 'ldp.container' } = {}) {
@@ -50,8 +49,7 @@ class LdpAdapter {
     return this.broker.call(`${this.containerService}.get`, {
       containerUri: this.service.schema.settings.containerUri,
       filters: filters.query,
-      jsonContext: this.service.schema.settings.context,
-      accept: MIME_TYPES.JSON
+      jsonContext: this.service.schema.settings.context
     });
   }
 
@@ -71,8 +69,7 @@ class LdpAdapter {
     }
     return this.broker.call(`${this.resourceService}.get`, {
       resourceUri: _id,
-      jsonContext: this.service.schema.settings.context,
-      accept: MIME_TYPES.JSON
+      jsonContext: this.service.schema.settings.context
     });
   }
 
@@ -108,8 +105,7 @@ class LdpAdapter {
           '@context': this.service.schema.settings.context,
           ...resource
         },
-        slug,
-        contentType: MIME_TYPES.JSON
+        slug
       })
       .then(resourceUri => {
         this.broker.call(`${this.containerService}.attach`, {
@@ -152,8 +148,7 @@ class LdpAdapter {
           '@context': this.service.schema.settings.context,
           '@id': _id,
           ...resource
-        },
-        contentType: MIME_TYPES.JSON
+        }
       })
       .then(resourceUri => this.findById(resourceUri));
   }

--- a/src/middleware/packages/ldp/mixins/controlled-container.js
+++ b/src/middleware/packages/ldp/mixins/controlled-container.js
@@ -1,11 +1,9 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { delay, getParentContainerUri } = require('../utils');
 
 module.exports = {
   settings: {
     path: null,
     acceptedTypes: null,
-    accept: MIME_TYPES.JSON,
     permissions: null,
     newResourcesPermissions: null,
     controlledActions: {},

--- a/src/middleware/packages/ldp/mixins/dereference.js
+++ b/src/middleware/packages/ldp/mixins/dereference.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { isObject, arrayOf } = require('../utils');
 
 /**
@@ -54,8 +53,7 @@ module.exports = {
       // Get the resource.
       try {
         let result = await ctx.call('ldp.resource.get', {
-          resourceUri,
-          accept: MIME_TYPES.JSON
+          resourceUri
         });
         // Delete the context from the result
         delete result['@context'];

--- a/src/middleware/packages/ldp/mixins/disassembly.js
+++ b/src/middleware/packages/ldp/mixins/disassembly.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { arrayOf } = require('../utils');
 
 module.exports = {
@@ -13,21 +12,16 @@ module.exports = {
   hooks: {
     before: {
       async create(ctx) {
-        const { resource, contentType } = ctx.params;
-        if (contentType === MIME_TYPES.JSON) {
-          await this.createDisassembly(ctx, resource);
-        }
+        const { resource } = ctx.params;
+        await this.createDisassembly(ctx, resource);
       },
       async put(ctx) {
-        const { resource, contentType } = ctx.params;
-        if (contentType === MIME_TYPES.JSON) {
-          const oldData = await ctx.call('ldp.resource.get', {
-            resourceUri: resource.id || resource['@id'],
-            accept: MIME_TYPES.JSON,
-            webId: 'system'
-          });
-          await this.updateDisassembly(ctx, resource, oldData);
-        }
+        const { resource } = ctx.params;
+        const oldData = await ctx.call('ldp.resource.get', {
+          resourceUri: resource.id || resource['@id'],
+          webId: 'system'
+        });
+        await this.updateDisassembly(ctx, resource, oldData);
       }
     },
     after: {
@@ -54,7 +48,6 @@ module.exports = {
                 '@context': newData['@context'],
                 ...resourceWithoutId
               },
-              contentType: MIME_TYPES.JSON,
               webId: 'system'
             });
             uriAdded.push({ '@id': newResourceUri, '@type': '@id' });
@@ -92,7 +85,6 @@ module.exports = {
                 '@context': newData['@context'],
                 ...resource
               },
-              contentType: MIME_TYPES.JSON,
               webId: 'system'
             });
             uriAdded.push({ '@id': newResourceUri, '@type': '@id' });
@@ -122,7 +114,6 @@ module.exports = {
                   '@context': newData['@context'],
                   ...resource
                 },
-                contentType: MIME_TYPES.JSON,
                 webId: 'system'
               });
             } catch (error) {

--- a/src/middleware/packages/ldp/mixins/document-tagger.js
+++ b/src/middleware/packages/ldp/mixins/document-tagger.js
@@ -39,8 +39,8 @@ module.exports = {
       }
 
       if (triples.length > 0) {
-        await ctx.call('triplestore.insert', {
-          resource: triples.join('\n'),
+        await ctx.call('triplestore.update', {
+          query: `INSERT DATA { ${triples.join('\n')} }`,
           dataset: this.settings.podProvider ? dataset || getDatasetFromUri(resourceUri) : undefined,
           webId: 'system'
         });

--- a/src/middleware/packages/ldp/mixins/image-processor.js
+++ b/src/middleware/packages/ldp/mixins/image-processor.js
@@ -27,7 +27,6 @@ module.exports = {
       const metadata = await ctx.call('ldp.resource.get', {
         resourceUri,
         jsonContext: { '@vocab': 'http://semapps.org/ns/core#' },
-        accept: MIME_TYPES.JSON,
         webId: 'system'
       });
 

--- a/src/middleware/packages/ldp/mixins/single-resource-container.js
+++ b/src/middleware/packages/ldp/mixins/single-resource-container.js
@@ -1,5 +1,4 @@
 const { MoleculerError } = require('moleculer').Errors;
-const { MIME_TYPES } = require('@semapps/mime-types');
 const ControlledContainerMixin = require('./controlled-container');
 const { delay } = require('../utils');
 
@@ -30,10 +29,7 @@ module.exports = {
       let resource = this.settings.initialValue;
       if (!resource.type && !resource['@type']) resource.type = this.settings.acceptedTypes;
 
-      return await this.actions.post(
-        { containerUri, resource, contentType: MIME_TYPES.JSON, webId },
-        { parentCtx: ctx }
-      );
+      return await this.actions.post({ containerUri, resource, webId }, { parentCtx: ctx });
     },
     async getResourceUri(ctx) {
       const containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });

--- a/src/middleware/packages/ldp/mixins/special-endpoint.js
+++ b/src/middleware/packages/ldp/mixins/special-endpoint.js
@@ -1,7 +1,13 @@
 const urlJoin = require('url-join');
 const { namedNode, triple } = require('@rdfjs/data-model');
-const { MIME_TYPES } = require('@semapps/mime-types');
-const { parseUrl, parseHeader, parseRawBody, negotiateAccept, parseJson } = require('@semapps/middlewares');
+const {
+  parseUrl,
+  parseHeader,
+  parseRawBody,
+  negotiateAccept,
+  negotiateContentType,
+  parseJson
+} = require('@semapps/middlewares');
 
 module.exports = {
   settings: {
@@ -18,7 +24,7 @@ module.exports = {
     if (!this.settings.settingsDataset)
       throw new Error(`The settingsDataset must be specified for service ${this.name}`);
 
-    const middlewares = [parseUrl, parseHeader, parseRawBody, negotiateAccept, parseJson];
+    const middlewares = [parseUrl, parseHeader, negotiateAccept, negotiateContentType, parseRawBody, parseJson];
 
     let aliases = {};
     aliases['GET /'] = [...middlewares, `${this.name}.endpointGet`];
@@ -51,7 +57,6 @@ module.exports = {
             id: this.endpointUrl,
             ...this.settings.endpoint.initialData
           },
-          contentType: MIME_TYPES.JSON,
           webId: 'system'
         },
         { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true, skipObjectsWatcher: true } }
@@ -79,7 +84,6 @@ module.exports = {
         'ldp.resource.get',
         {
           resourceUri: this.endpointUrl,
-          accept: ctx.meta.headers?.accept,
           webId: 'system'
         },
         { meta: { dataset: this.settings.settingsDataset } }

--- a/src/middleware/packages/ldp/mixins/special-endpoint.js
+++ b/src/middleware/packages/ldp/mixins/special-endpoint.js
@@ -1,7 +1,7 @@
 const urlJoin = require('url-join');
 const { namedNode, triple } = require('@rdfjs/data-model');
 const { MIME_TYPES } = require('@semapps/mime-types');
-const { parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle } = require('@semapps/middlewares');
+const { parseUrl, parseHeader, parseRawBody, negotiateAccept, parseJson } = require('@semapps/middlewares');
 
 module.exports = {
   settings: {
@@ -18,7 +18,7 @@ module.exports = {
     if (!this.settings.settingsDataset)
       throw new Error(`The settingsDataset must be specified for service ${this.name}`);
 
-    const middlewares = [parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle];
+    const middlewares = [parseUrl, parseHeader, parseRawBody, negotiateAccept, parseJson];
 
     let aliases = {};
     aliases['GET /'] = [...middlewares, `${this.name}.endpointGet`];

--- a/src/middleware/packages/ldp/routes/getCatchAllRoute.js
+++ b/src/middleware/packages/ldp/routes/getCatchAllRoute.js
@@ -2,11 +2,10 @@ const path = require('path');
 const {
   parseUrl,
   parseHeader,
-  parseSparql,
+  parseRawBody,
   negotiateContentType,
   negotiateAccept,
   parseJson,
-  parseTurtle,
   parseFile,
   saveDatasetMeta
 } = require('@semapps/middlewares');
@@ -15,11 +14,10 @@ function getCatchAllRoute(basePath, podProvider) {
   const middlewares = [
     parseUrl,
     parseHeader,
+    parseRawBody,
     negotiateContentType,
     negotiateAccept,
-    parseSparql,
     parseJson,
-    parseTurtle,
     parseFile,
     saveDatasetMeta
   ];

--- a/src/middleware/packages/ldp/routes/getCatchAllRoute.js
+++ b/src/middleware/packages/ldp/routes/getCatchAllRoute.js
@@ -14,9 +14,9 @@ function getCatchAllRoute(basePath, podProvider) {
   const middlewares = [
     parseUrl,
     parseHeader,
-    parseRawBody,
     negotiateContentType,
     negotiateAccept,
+    parseRawBody,
     parseJson,
     parseFile,
     saveDatasetMeta

--- a/src/middleware/packages/ldp/routes/getPodsRoute.js
+++ b/src/middleware/packages/ldp/routes/getPodsRoute.js
@@ -27,9 +27,9 @@ function getPodsRoute(basePath) {
   const middlewares = [
     parseUrl,
     parseHeader,
-    parseRawBody,
     negotiateContentType,
     negotiateAccept,
+    parseRawBody,
     parseJson,
     parseFile,
     saveDatasetMeta,

--- a/src/middleware/packages/ldp/routes/getPodsRoute.js
+++ b/src/middleware/packages/ldp/routes/getPodsRoute.js
@@ -2,11 +2,10 @@ const path = require('path');
 const {
   parseUrl,
   parseHeader,
-  parseSparql,
+  parseRawBody,
   negotiateContentType,
   negotiateAccept,
   parseJson,
-  parseTurtle,
   parseFile,
   saveDatasetMeta
 } = require('@semapps/middlewares');
@@ -28,11 +27,10 @@ function getPodsRoute(basePath) {
   const middlewares = [
     parseUrl,
     parseHeader,
+    parseRawBody,
     negotiateContentType,
     negotiateAccept,
-    parseSparql,
     parseJson,
-    parseTurtle,
     parseFile,
     saveDatasetMeta,
     transformRouteParamsToSlugParts

--- a/src/middleware/packages/ldp/services/api/actions/patch.js
+++ b/src/middleware/packages/ldp/services/api/actions/patch.js
@@ -6,65 +6,61 @@ const ACCEPTED_OPERATIONS = ['insert', 'delete'];
 
 module.exports = async function patch(ctx) {
   try {
-    const { username, slugParts, body } = ctx.params;
+    const { username, slugParts } = ctx.params;
+
+    if (ctx.meta.headers['content-type'] !== 'application/sparql-update')
+      throw new MoleculerError(`The Content-Type header should be application/sparql-update`, 400, 'BAD_REQUEST');
 
     const uri = this.getUriFromSlugParts(slugParts, username);
     const types = await ctx.call('ldp.resource.getTypes', { resourceUri: uri });
 
-    if (ctx.meta.parser === 'sparql') {
-      let parsedQuery;
+    let parsedQuery;
 
-      try {
-        parsedQuery = parser.parse(body);
-      } catch (e) {
-        throw new MoleculerError(`Invalid SPARQL Update: ${body}`, 400, 'BAD_REQUEST');
-      }
-
-      if (parsedQuery.type !== 'update')
-        throw new MoleculerError('Invalid SPARQL. Must be an Update', 400, 'BAD_REQUEST');
-
-      const triplesByOperation = Object.fromEntries(
-        parsedQuery.updates
-          .filter(p => ACCEPTED_OPERATIONS.includes(p.updateType))
-          .map(p => [p.updateType, p[p.updateType][0].triples])
-      );
-
-      if (Object.values(triplesByOperation).length === 0) {
-        throw new MoleculerError(
-          'Invalid SPARQL operation. Must be INSERT DATA and/or DELETE DATA',
-          400,
-          'BAD_REQUEST'
-        );
-      }
-
-      const triplesToAdd = triplesByOperation.insert;
-      const triplesToRemove = triplesByOperation.delete;
-
-      if (types.includes('http://www.w3.org/ns/ldp#Container')) {
-        /*
-         * LDP CONTAINER
-         */
-
-        await ctx.call('ldp.container.patch', {
-          containerUri: uri,
-          sparqlUpdate: body
-        });
-      } else {
-        /*
-         * LDP RESOURCE
-         */
-
-        const { controlledActions } = await ctx.call('ldp.registry.getByUri', { resourceUri: uri });
-
-        await ctx.call(controlledActions.patch || 'ldp.resource.patch', {
-          resourceUri: uri,
-          triplesToAdd,
-          triplesToRemove
-        });
-      }
-    } else {
-      throw new MoleculerError(`The Content-Type header should be application/sparql-update`, 400, 'BAD_REQUEST');
+    try {
+      parsedQuery = parser.parse(ctx.meta.rawBody);
+    } catch (e) {
+      throw new MoleculerError(`Invalid SPARQL Update: ${ctx.meta.rawBody}`, 400, 'BAD_REQUEST');
     }
+
+    if (parsedQuery.type !== 'update')
+      throw new MoleculerError('Invalid SPARQL. Must be an Update', 400, 'BAD_REQUEST');
+
+    const triplesByOperation = Object.fromEntries(
+      parsedQuery.updates
+        .filter(p => ACCEPTED_OPERATIONS.includes(p.updateType))
+        .map(p => [p.updateType, p[p.updateType][0].triples])
+    );
+
+    if (Object.values(triplesByOperation).length === 0) {
+      throw new MoleculerError('Invalid SPARQL operation. Must be INSERT DATA and/or DELETE DATA', 400, 'BAD_REQUEST');
+    }
+
+    const triplesToAdd = triplesByOperation.insert;
+    const triplesToRemove = triplesByOperation.delete;
+
+    if (types.includes('http://www.w3.org/ns/ldp#Container')) {
+      /*
+       * LDP CONTAINER
+       */
+
+      await ctx.call('ldp.container.patch', {
+        containerUri: uri,
+        sparqlUpdate: ctx.meta.rawBody
+      });
+    } else {
+      /*
+       * LDP RESOURCE
+       */
+
+      const { controlledActions } = await ctx.call('ldp.registry.getByUri', { resourceUri: uri });
+
+      await ctx.call(controlledActions.patch || 'ldp.resource.patch', {
+        resourceUri: uri,
+        triplesToAdd,
+        triplesToRemove
+      });
+    }
+
     ctx.meta.$responseHeaders = {
       'Content-Length': 0
     };

--- a/src/middleware/packages/ldp/services/api/actions/post.js
+++ b/src/middleware/packages/ldp/services/api/actions/post.js
@@ -5,18 +5,28 @@ const mime = require('mime-types');
 
 module.exports = async function post(ctx) {
   try {
-    const { username, slugParts, ...resource } = ctx.params;
+    let { username, slugParts, ...resource } = ctx.params;
 
     const containerUri = this.getUriFromSlugParts(slugParts, username);
 
     let resourceUri;
     const { controlledActions } = await ctx.call('ldp.registry.getByUri', { containerUri });
     if (ctx.meta.parser !== 'file') {
+      const contentType = ctx.meta.headers['content-type'];
+
+      // If the resource is Turtle or N-Triples, first convert it to JSON-LD
+      if (contentType && contentType !== MIME_TYPES.JSON) {
+        resource = await ctx.call('jsonld.parser.fromRDF', {
+          input: ctx.meta.rawBody,
+          options: { format: contentType }
+        });
+        delete resource['@id']; // Since no URI is provided, the @id will be ./ but that will not work with ldp.container.post
+      }
+
       resourceUri = await ctx.call(controlledActions.post || 'ldp.container.post', {
         containerUri,
         slug: ctx.meta.headers.slug,
-        resource,
-        contentType: ctx.meta.headers['content-type']
+        resource
       });
     } else {
       if (ctx.params.files.length > 1) {

--- a/src/middleware/packages/ldp/services/cache/index.js
+++ b/src/middleware/packages/ldp/services/cache/index.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   name: 'ldp.cache',
   dependencies: ['ldp.container'],
@@ -8,7 +6,7 @@ module.exports = {
       const containersUris = await ctx.call('ldp.container.getAll');
       for (const containerUri of containersUris) {
         try {
-          await ctx.call('ldp.container.get', { containerUri, accept: MIME_TYPES.JSON });
+          await ctx.call('ldp.container.get', { containerUri });
           this.logger.info(`Generated cache for container ${containerUri}`);
         } catch (e) {
           this.logger.warn(`Error when generating cache for container ${containerUri}`);

--- a/src/middleware/packages/ldp/services/container/actions/create.js
+++ b/src/middleware/packages/ldp/services/container/actions/create.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -20,7 +18,6 @@ module.exports = {
         'http://purl.org/dc/terms/title': title,
         'http://purl.org/dc/terms/description': description
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 

--- a/src/middleware/packages/ldp/services/container/actions/exist.js
+++ b/src/middleware/packages/ldp/services/container/actions/exist.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -22,7 +20,6 @@ module.exports = {
           ${isRemoteContainer ? '}' : ''}
         }
       `,
-      accept: MIME_TYPES.JSON,
       webId: 'system'
     });
   }

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -71,8 +71,7 @@ module.exports = {
               cleanUndefined({
                 resourceUri,
                 webId,
-                jsonContext,
-                accept
+                jsonContext
               })
             );
 

--- a/src/middleware/packages/ldp/services/container/actions/get.js
+++ b/src/middleware/packages/ldp/services/container/actions/get.js
@@ -13,21 +13,16 @@ module.exports = {
     jsonContext: { type: 'multi', rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }], optional: true }
   },
   cache: {
-    keys: ['containerUri', 'accept', 'filters', 'doNotIncludeResources', 'jsonContext', 'webId', '#webId']
+    keys: ['containerUri', 'filters', 'doNotIncludeResources', 'jsonContext', 'webId', '#webId']
   },
   async handler(ctx) {
-    const { containerUri, filters, doNotIncludeResources, jsonContext } = ctx.params;
+    const { containerUri, accept, filters, doNotIncludeResources, jsonContext } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
 
     await ctx.call('permissions.check', { uri: containerUri, type: 'container', mode: 'acl:Read', webId });
 
-    const { accept } = {
-      ...(await ctx.call('ldp.registry.getByUri', { containerUri })),
-      ...ctx.params
-    };
-
-    if (accept !== MIME_TYPES.JSON)
-      throw new Error(`LDP containers can only be returned with JSON-LD format at the moment.`);
+    if (accept && accept !== MIME_TYPES.JSON)
+      throw new Error(`The ldp.container.get action now only support JSON-LD. Provided: ${accept}`);
 
     let containerResults = await ctx.call('triplestore.query', {
       query: `

--- a/src/middleware/packages/ldp/services/container/actions/getAll.js
+++ b/src/middleware/packages/ldp/services/container/actions/getAll.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -14,7 +12,6 @@ module.exports = {
           ?containerUri a ldp:Container .
         }
       `,
-      accept: MIME_TYPES.JSON,
       dataset: ctx.params.dataset,
       webId: 'system'
     });

--- a/src/middleware/packages/ldp/services/container/actions/getUris.js
+++ b/src/middleware/packages/ldp/services/container/actions/getUris.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -16,7 +14,6 @@ module.exports = {
           <${containerUri}> ldp:contains ?resourceUri .
         }
       `,
-      accept: MIME_TYPES.JSON,
       webId: 'system'
     });
 

--- a/src/middleware/packages/ldp/services/container/actions/post.js
+++ b/src/middleware/packages/ldp/services/container/actions/post.js
@@ -21,7 +21,8 @@ module.exports = {
       optional: true
     },
     contentType: {
-      type: 'string'
+      type: 'string',
+      optional: true
     },
     webId: {
       type: 'string',
@@ -38,6 +39,9 @@ module.exports = {
     let isContainer = false;
     let expandedResource;
 
+    if (contentType && contentType !== MIME_TYPES.JSON)
+      throw new Error(`The ldp.container.post action now only support JSON-LD. Provided: ${contentType}`);
+
     await ctx.call('permissions.check', { uri: containerUri, type: 'container', mode: 'acl:Append', webId });
 
     // Remove undefined values as this may cause problems
@@ -45,7 +49,7 @@ module.exports = {
 
     if (!file) {
       // Adds the default context, if it is missing
-      if (contentType === MIME_TYPES.JSON && !resource['@context']) {
+      if (!resource['@context']) {
         resource = {
           '@context': await ctx.call('jsonld.context.get'),
           ...resource
@@ -109,7 +113,6 @@ module.exports = {
             '@id': resourceUri,
             ...resource
           },
-          contentType,
           webId
         });
       }

--- a/src/middleware/packages/ldp/services/container/actions/post.js
+++ b/src/middleware/packages/ldp/services/container/actions/post.js
@@ -1,5 +1,6 @@
 const { MoleculerError } = require('moleculer').Errors;
 const { MIME_TYPES } = require('@semapps/mime-types');
+const { sanitizeSparqlQuery } = require('@semapps/triplestore');
 const { cleanUndefined } = require('../../../utils');
 
 module.exports = {
@@ -89,8 +90,12 @@ module.exports = {
     // We must add this first, so that the container's ACLs are taken into account
     // But this create race conditions, especially when testing, since uncreated resources are linked to containers
     // TODO Add temporary ACLs to the resource so that it can be created, then link it to the container ?
-    await ctx.call('triplestore.insert', {
-      resource: `<${containerUri}> <http://www.w3.org/ns/ldp#contains> <${resourceUri}>`,
+    await ctx.call('triplestore.update', {
+      query: sanitizeSparqlQuery`
+        INSERT DATA {
+          <${containerUri}> <http://www.w3.org/ns/ldp#contains> <${resourceUri}>
+        }
+      `,
       webId
     });
 

--- a/src/middleware/packages/ldp/services/registry/defaultOptions.js
+++ b/src/middleware/packages/ldp/services/registry/defaultOptions.js
@@ -1,5 +1,4 @@
 module.exports = {
-  accept: 'text/turtle',
   readOnly: false,
   excludeFromMirror: false,
   permissions: webId => {

--- a/src/middleware/packages/ldp/services/remote/actions/store.js
+++ b/src/middleware/packages/ldp/services/remote/actions/store.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { Errors: E } = require('moleculer-web');
 const { hasType } = require('../../../utils');
 
@@ -85,7 +84,6 @@ module.exports = {
     await ctx.call('triplestore.insert', {
       resource,
       graphName,
-      contentType: MIME_TYPES.JSON,
       webId: 'system',
       dataset
     });

--- a/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { waitForResource } = require('../../../utils');
 
 /** @type {import('moleculer').ServiceActionsSchema} */
@@ -27,7 +26,6 @@ module.exports = {
         'ldp.resource.get',
         {
           resourceUri: resourceUri,
-          accept: MIME_TYPES.JSON,
           webId,
           ...rest
         },

--- a/src/middleware/packages/ldp/services/resource/actions/create.js
+++ b/src/middleware/packages/ldp/services/resource/actions/create.js
@@ -72,7 +72,6 @@ module.exports = {
       (controlledActions && controlledActions.get) || 'ldp.resource.get',
       {
         resourceUri,
-        accept: MIME_TYPES.JSON,
         webId: 'system' // Avoid errors if the resource creator has no read rights
       },
       { meta: { $cache: false } }

--- a/src/middleware/packages/ldp/services/resource/actions/create.js
+++ b/src/middleware/packages/ldp/services/resource/actions/create.js
@@ -10,13 +10,17 @@ module.exports = {
       optional: true
     },
     contentType: {
-      type: 'string'
+      type: 'string',
+      optional: true
     }
   },
   async handler(ctx) {
-    let { resource, contentType, body } = ctx.params;
+    let { resource, contentType } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
     const resourceUri = resource.id || resource['@id'];
+
+    if (contentType && contentType !== MIME_TYPES.JSON)
+      throw new Error(`The ldp.resource.create action now only support JSON-LD. Provided: ${contentType}`);
 
     if (await ctx.call('ldp.remote.isRemote', { resourceUri }))
       throw new MoleculerError('Remote resources cannot be created', 403, 'FORBIDDEN');
@@ -32,17 +36,14 @@ module.exports = {
     }
 
     // Adds the default context, if it is missing
-    if (contentType === MIME_TYPES.JSON && !resource['@context']) {
+    if (!resource['@context']) {
       resource = {
         '@context': await ctx.call('jsonld.context.get'),
         ...resource
       };
     }
 
-    if (contentType !== MIME_TYPES.JSON && !resource.body)
-      throw new MoleculerError('The resource must contain a body member (a string)', 400, 'BAD_REQUEST');
-
-    let newTriples = await this.bodyToTriples(body || resource, contentType);
+    let newTriples = await ctx.call('jsonld.parser.toQuads', { input: resource });
     // see PUT
     newTriples = this.filterOtherNamedNodes(newTriples, resourceUri);
     // see PUT

--- a/src/middleware/packages/ldp/services/resource/actions/delete.js
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const { MIME_TYPES } = require('@semapps/mime-types');
 
 module.exports = {
   visibility: 'public',
@@ -23,7 +22,6 @@ module.exports = {
       'ldp.resource.get',
       {
         resourceUri,
-        accept: MIME_TYPES.JSON,
         webId
       },
       {

--- a/src/middleware/packages/ldp/services/resource/actions/get.js
+++ b/src/middleware/packages/ldp/services/resource/actions/get.js
@@ -20,11 +20,14 @@ module.exports = {
       const isRemote = await ctx.call('ldp.remote.isRemote', { resourceUri: ctx.params.resourceUri });
       return !isRemote;
     },
-    keys: ['resourceUri', 'accept', 'jsonContext']
+    keys: ['resourceUri', 'jsonContext']
   },
   async handler(ctx) {
-    const { resourceUri, jsonContext } = ctx.params;
+    const { resourceUri, accept, jsonContext } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
+
+    if (accept && accept !== MIME_TYPES.JSON)
+      throw new Error(`The ldp.resource.get action now only support JSON-LD. Provided: ${accept}`);
 
     if (await ctx.call('ldp.remote.isRemote', { resourceUri })) {
       return await ctx.call('ldp.remote.get', ctx.params);
@@ -34,11 +37,6 @@ module.exports = {
     if (!resourceExist) throw new MoleculerError(`Resource not found ${resourceUri}`, 404, 'NOT_FOUND');
 
     await ctx.call('permissions.check', { uri: resourceUri, type: 'resource', mode: 'acl:Read', webId });
-
-    const { accept } = {
-      ...(await ctx.call('ldp.registry.getByUri', { resourceUri })),
-      ...ctx.params
-    };
 
     const blankNodesQuery = buildBlankNodesQuery(4);
 
@@ -53,21 +51,16 @@ module.exports = {
           ${blankNodesQuery.where}
         }
       `,
-      accept,
       webId: 'system'
     });
 
-    // If we asked for JSON-LD, frame it using the correct context in order to have clean, consistent results
-    if (accept === MIME_TYPES.JSON) {
-      result = await ctx.call('jsonld.parser.frame', {
-        input: result,
-        frame: {
-          '@context': jsonContext || (await ctx.call('jsonld.context.get')),
-          '@id': resourceUri
-        }
-      });
-    }
-
-    return result;
+    // Frame the result using the correct context in order to have clean, consistent results
+    return await ctx.call('jsonld.parser.frame', {
+      input: result,
+      frame: {
+        '@context': jsonContext || (await ctx.call('jsonld.context.get')),
+        '@id': resourceUri
+      }
+    });
   }
 };

--- a/src/middleware/packages/ldp/services/resource/actions/getContainers.js
+++ b/src/middleware/packages/ldp/services/resource/actions/getContainers.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { getContainerFromUri } = require('../../../utils');
 
 module.exports = {
@@ -27,7 +26,6 @@ module.exports = {
           ?containerUri ldp:contains <${resourceUri}> .
         }
       `,
-      accept: MIME_TYPES.JSON,
       dataset,
       webId: 'system'
     });

--- a/src/middleware/packages/ldp/services/resource/actions/getTypes.js
+++ b/src/middleware/packages/ldp/services/resource/actions/getTypes.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -18,7 +16,6 @@ module.exports = {
           <${resourceUri}> a ?type .
         }
       `,
-      accept: MIME_TYPES.JSON,
       webId: 'system'
     });
 

--- a/src/middleware/packages/ldp/services/resource/actions/put.js
+++ b/src/middleware/packages/ldp/services/resource/actions/put.js
@@ -44,7 +44,6 @@ module.exports = {
       'ldp.resource.get',
       {
         resourceUri,
-        accept: MIME_TYPES.JSON,
         webId
       },
       {
@@ -123,7 +122,6 @@ module.exports = {
         'ldp.resource.get',
         {
           resourceUri,
-          accept: MIME_TYPES.JSON,
           webId
         },
         {

--- a/src/middleware/packages/middlewares/index.js
+++ b/src/middleware/packages/middlewares/index.js
@@ -3,6 +3,8 @@ const { negotiateTypeMime, MIME_TYPES } = require('@semapps/mime-types');
 const Busboy = require('busboy');
 const streams = require('memory-streams');
 
+const handledMimeTypes = [MIME_TYPES.JSON, MIME_TYPES.TURTLE, MIME_TYPES.TRIPLE, MIME_TYPES.SPARQL_UPDATE];
+
 // Put requested URL and query string in meta so that services may use them independently
 // Set here https://github.com/moleculerjs/moleculer-web/blob/c6ec80056a64ea15c57d6e2b946ce978d673ae92/src/index.js#L151-L161
 const parseUrl = async (req, res, next) => {
@@ -18,9 +20,25 @@ const parseHeader = async (req, res, next) => {
   next();
 };
 
+const parseRawBody = (req, res, next) => {
+  let data = '';
+  req.on('data', chunk => {
+    data += chunk;
+  });
+  req.on('end', () => {
+    if (data.length > 0) req.$ctx.meta.rawBody = data;
+    req.$ctx.meta.rawBodyParsed = true; // Used to detect if the middleware was added
+    next();
+  });
+};
+
 const negotiateContentType = (req, res, next) => {
   if (!req.$ctx.meta.headers)
     throw new Error(`The parseHeader middleware must be added before the negotiateContentType middleware`);
+
+  if (!req.$ctx.meta.rawBodyParsed)
+    throw new Error(`The parseRawBody middleware must be added before the parseJson middleware`);
+
   if (req.$ctx.meta.headers['content-type'] !== undefined && req.method !== 'DELETE') {
     try {
       req.$ctx.meta.headers['content-type'] = negotiateTypeMime(req.$ctx.meta.headers['content-type']);
@@ -28,9 +46,11 @@ const negotiateContentType = (req, res, next) => {
     } catch (e) {
       next();
     }
-  } else if (req.$params.body) {
-    next(
-      new MoleculerError('Content-Type has to be specified for a non-empty body ', 400, 'CONTENT_TYPE_NOT_SPECIFIED')
+  } else if (req.$ctx.meta.rawBody) {
+    throw new MoleculerError(
+      'Content-Type has to be specified for a non-empty body ',
+      400,
+      'CONTENT_TYPE_NOT_SPECIFIED'
     );
   } else {
     next();
@@ -74,51 +94,13 @@ const negotiateAccept = (req, res, next) => {
   }
 };
 
-const getRawBody = req => {
-  return new Promise((resolve, reject) => {
-    let data = '';
-    req.on('data', chunk => {
-      data += chunk;
-    });
-    req.on('end', () => {
-      resolve(data.length > 0 ? data : undefined);
-    });
-  });
-};
-
-const parseSparql = async (req, res, next) => {
-  if (!req.$ctx.meta.headers)
-    throw new Error(`The parseHeader middleware must be added before the parseSparql middleware`);
-  if (
-    !req.$ctx.meta.parser &&
-    (req.originalUrl.includes('/sparql') ||
-      (req.$ctx.meta.headers['content-type'] && req.$ctx.meta.headers['content-type'].includes('sparql')))
-  ) {
-    req.$ctx.meta.parser = 'sparql';
-    // TODO Store in req.$ctx.meta.rawBody
-    req.$params.body = await getRawBody(req);
-  }
-  next();
-};
-
-const parseTurtle = async (req, res, next) => {
-  if (!req.$ctx.meta.headers)
-    throw new Error(`The parseHeader middleware must be added before the parseTurtle middleware`);
-  if (
-    !req.$ctx.meta.parser &&
-    req.$ctx.meta.headers['content-type'] &&
-    req.$ctx.meta.headers['content-type'].includes('turtle')
-  ) {
-    req.$ctx.meta.parser = 'turtle';
-    // TODO Store in req.$ctx.meta.rawBody
-    req.$params.body = await getRawBody(req);
-  }
-  next();
-};
-
 const parseJson = async (req, res, next) => {
   if (!req.$ctx.meta.headers)
     throw new Error(`The parseHeader middleware must be added before the parseJson middleware`);
+
+  if (!req.$ctx.meta.rawBodyParsed)
+    throw new Error(`The parseRawBody middleware must be added before the parseJson middleware`);
+
   let mimeType = null;
   try {
     if (req.$ctx.meta.headers['content-type']) {
@@ -129,18 +111,13 @@ const parseJson = async (req, res, next) => {
   }
 
   try {
-    if (!req.$ctx.meta.parser && mimeType === MIME_TYPES.JSON) {
-      const body = await getRawBody(req);
-      if (body) {
-        const json = JSON.parse(body);
-        req.$params = { ...json, ...req.$params };
-        // Keep raw body in meta as we need it for digest header verification
-        req.$ctx.meta.rawBody = body;
-      }
-      req.$ctx.meta.parser = 'json';
+    if (mimeType === MIME_TYPES.JSON && req.$ctx.meta.rawBody) {
+      const json = JSON.parse(req.$ctx.meta.rawBody);
+      req.$params = { ...json, ...req.$params };
     }
     next();
   } catch (e) {
+    // If JSON parsing failed, ignore
     next(e);
   }
 };
@@ -148,11 +125,11 @@ const parseJson = async (req, res, next) => {
 const parseFile = (req, res, next) => {
   if (!req.$ctx.meta.headers)
     throw new Error(`The parseHeader middleware must be added before the parseFile middleware`);
-  if (!req.$ctx.meta.parser && (req.method === 'POST' || req.method === 'PUT')) {
-    if (
-      req.$ctx.meta.headers['content-type'] &&
-      req.$ctx.meta.headers['content-type'].includes('multipart/form-data')
-    ) {
+
+  const contentType = req.$ctx.meta.headers['content-type'];
+
+  if (!handledMimeTypes.includes(contentType) && (req.method === 'POST' || req.method === 'PUT')) {
+    if (contentType.includes('multipart/form-data')) {
       const busboy = new Busboy({ headers: req.$ctx.meta.headers });
       const files = [];
       busboy.on('file', (fieldname, file, filename, encoding, mimetype) => {
@@ -179,7 +156,7 @@ const parseFile = (req, res, next) => {
       req.$params.files = [
         {
           readableStream: req,
-          mimetype: req.$ctx.meta.headers['content-type']
+          mimetype: contentType
         }
       ];
       req.$ctx.meta.parser = 'file';
@@ -198,11 +175,10 @@ const saveDatasetMeta = (req, res, next) => {
 module.exports = {
   parseUrl,
   parseHeader,
-  parseSparql,
+  parseRawBody,
   negotiateContentType,
   negotiateAccept,
   parseJson,
-  parseTurtle,
   parseFile,
   saveDatasetMeta,
   throw400,

--- a/src/middleware/packages/mime-types/constants.js
+++ b/src/middleware/packages/mime-types/constants.js
@@ -2,12 +2,13 @@ const MIME_TYPES = {
   JSON: 'application/ld+json',
   TURTLE: 'text/turtle',
   TRIPLE: 'application/n-triples',
+  SPARQL_UPDATE: 'application/sparql-update',
+  // Not supported
   SPARQL_JSON: 'application/sparql-results+json',
   SPARQL_XML: 'application/sparql-results+xml',
   CSV: 'text/csv',
   TSV: 'text/tab-separated-values',
-  RDF: 'application/rdf+xml',
-  SPARQL_UPDATE: 'application/sparql-update'
+  RDF: 'application/rdf+xml'
 };
 
 const TYPES_REPO = [

--- a/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.js
+++ b/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.js
@@ -2,7 +2,6 @@ const urlJoin = require('url-join');
 const { Errors: E } = require('moleculer-web');
 const { SpecialEndpointMixin, ControlledContainerMixin, getDatasetFromUri, arrayOf } = require('@semapps/ldp');
 const { ACTIVITY_TYPES } = require('@semapps/activitypub');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { namedNode } = require('@rdfjs/data-model');
 const { v4: uuidV4 } = require('uuid');
 const moment = require('moment');
@@ -140,7 +139,6 @@ module.exports = {
       return this.actions.get(
         {
           resourceUri: channelUri,
-          accept: MIME_TYPES.JSON,
           webId: 'system'
         },
         { parentCtx: ctx }

--- a/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.js
+++ b/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.js
@@ -120,7 +120,6 @@ module.exports = {
             'notify:sendTo': sendTo,
             'notify:receiveFrom': receiveFrom
           },
-          contentType: MIME_TYPES.JSON,
           webId: 'system'
         },
         { parentCtx: ctx }

--- a/src/middleware/packages/solid/services/notifications/listener.js
+++ b/src/middleware/packages/solid/services/notifications/listener.js
@@ -38,8 +38,8 @@ module.exports = {
         aliases: {
           'POST /': [
             parseHeader,
-            parseRawBody,
             negotiateContentType,
+            parseRawBody,
             parseJson,
             'solid-notifications.listener.transfer'
           ]

--- a/src/middleware/packages/solid/services/notifications/listener.js
+++ b/src/middleware/packages/solid/services/notifications/listener.js
@@ -5,7 +5,7 @@ const LinkHeader = require('http-link-header');
 const { v4: uuidv4 } = require('uuid');
 const DbService = require('moleculer-db');
 const { MoleculerError } = require('moleculer').Errors;
-const { parseHeader, negotiateContentType, parseJson } = require('@semapps/middlewares');
+const { parseHeader, parseRawBody, negotiateContentType, parseJson } = require('@semapps/middlewares');
 const { notify } = require('@semapps/ontologies');
 const { TripleStoreAdapter } = require('@semapps/triplestore');
 
@@ -36,7 +36,13 @@ module.exports = {
         authorization: false,
         authentication: false,
         aliases: {
-          'POST /': [parseHeader, negotiateContentType, parseJson, 'solid-notifications.listener.transfer']
+          'POST /': [
+            parseHeader,
+            parseRawBody,
+            negotiateContentType,
+            parseJson,
+            'solid-notifications.listener.transfer'
+          ]
         },
         bodyParsers: false
       }

--- a/src/middleware/packages/solid/services/type-index/type-indexes.js
+++ b/src/middleware/packages/solid/services/type-index/type-indexes.js
@@ -37,7 +37,6 @@ module.exports = {
           resource: {
             type: ['solid:TypeIndex', 'solid:ListedDocument']
           },
-          contentType: MIME_TYPES.JSON,
           webId
         },
         { parentCtx: ctx }
@@ -102,7 +101,6 @@ module.exports = {
 
       const user = await ctx.call('ldp.resource.get', {
         resourceUri: webId,
-        accept: MIME_TYPES.JSON,
         webId
       });
 

--- a/src/middleware/packages/solid/services/type-index/type-registrations.js
+++ b/src/middleware/packages/solid/services/type-index/type-registrations.js
@@ -1,7 +1,6 @@
 const urlJoin = require('url-join');
 const { namedNode, triple } = require('@rdfjs/data-model');
 const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
-const { MIME_TYPES } = require('@semapps/mime-types');
 
 module.exports = {
   name: 'type-registrations',
@@ -68,7 +67,6 @@ module.exports = {
                 'solid:forClass': expandedTypes,
                 'solid:instanceContainer': containerUri
               },
-              contentType: MIME_TYPES.JSON,
               webId
             },
             { parentCtx: ctx }
@@ -135,11 +133,7 @@ module.exports = {
         // If no default app is defined for this type, use this one
         if (!registration['apods:defaultApp']) registration['apods:defaultApp'] = appUri;
 
-        await ctx.call('type-registrations.put', {
-          resource: registration,
-          contentType: MIME_TYPES.JSON,
-          webId
-        });
+        await ctx.call('type-registrations.put', { resource: registration, webId });
       }
     },
     /**
@@ -171,7 +165,6 @@ module.exports = {
 
         await ctx.call('type-registrations.put', {
           resource: registration,
-          contentType: MIME_TYPES.JSON,
           webId
         });
       }

--- a/src/middleware/packages/sparql-endpoint/getRoute.js
+++ b/src/middleware/packages/sparql-endpoint/getRoute.js
@@ -1,6 +1,6 @@
-const { parseHeader, negotiateAccept, parseSparql, saveDatasetMeta } = require('@semapps/middlewares');
+const { parseHeader, parseRawBody, negotiateAccept, saveDatasetMeta } = require('@semapps/middlewares');
 
-const middlewares = [parseHeader, parseSparql, negotiateAccept, saveDatasetMeta];
+const middlewares = [parseHeader, parseRawBody, negotiateAccept, saveDatasetMeta];
 
 function getRoute(path) {
   return {

--- a/src/middleware/packages/sparql-endpoint/getRoute.js
+++ b/src/middleware/packages/sparql-endpoint/getRoute.js
@@ -1,6 +1,12 @@
-const { parseHeader, parseRawBody, negotiateAccept, saveDatasetMeta } = require('@semapps/middlewares');
+const {
+  parseHeader,
+  parseRawBody,
+  negotiateAccept,
+  saveDatasetMeta,
+  negotiateContentType
+} = require('@semapps/middlewares');
 
-const middlewares = [parseHeader, parseRawBody, negotiateAccept, saveDatasetMeta];
+const middlewares = [parseHeader, negotiateAccept, negotiateContentType, parseRawBody, saveDatasetMeta];
 
 function getRoute(path) {
   return {

--- a/src/middleware/packages/sparql-endpoint/service.js
+++ b/src/middleware/packages/sparql-endpoint/service.js
@@ -23,7 +23,7 @@ const SparqlEndpointService = {
   },
   actions: {
     async query(ctx) {
-      const query = ctx.params.query || ctx.params.body;
+      const query = ctx.params.query || ctx.meta.rawBody;
       const accept = ctx.params.accept || ctx.meta.headers?.accept || this.settings.defaultAccept;
 
       if (this.settings.podProvider) {

--- a/src/middleware/packages/triplestore/actions/countTriplesOfSubject.js
+++ b/src/middleware/packages/triplestore/actions/countTriplesOfSubject.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -34,7 +32,6 @@ module.exports = {
           <${ctx.params.uri}> ?p ?v
         }
       `,
-      accept: MIME_TYPES.JSON,
       webId,
       dataset
     });

--- a/src/middleware/packages/triplestore/actions/insert.js
+++ b/src/middleware/packages/triplestore/actions/insert.js
@@ -30,15 +30,15 @@ module.exports = {
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
     let dataset = ctx.params.dataset || ctx.meta.dataset || this.settings.mainDataset;
 
-    const rdf =
-      contentType === MIME_TYPES.JSON
-        ? await ctx.call('jsonld.parser.toRDF', {
-            input: resource,
-            options: {
-              format: 'application/n-quads'
-            }
-          })
-        : resource;
+    if (contentType && contentType !== MIME_TYPES.JSON)
+      throw new Error(`The triplestore.insert action now only support JSON-LD. Provided: ${contentType}`);
+
+    const rdf = await ctx.call('jsonld.parser.toRDF', {
+      input: resource,
+      options: {
+        format: 'application/n-quads'
+      }
+    });
 
     if (!dataset) throw new Error(`No dataset defined for triplestore insert: ${rdf}`);
     if (dataset !== '*' && !(await ctx.call('triplestore.dataset.exist', { dataset })))

--- a/src/middleware/packages/triplestore/actions/insert.js
+++ b/src/middleware/packages/triplestore/actions/insert.js
@@ -4,12 +4,7 @@ module.exports = {
   visibility: 'public',
   params: {
     resource: {
-      type: 'multi',
-      rules: [{ type: 'string' }, { type: 'object' }]
-    },
-    contentType: {
-      type: 'string',
-      optional: true
+      type: 'object'
     },
     webId: {
       type: 'string',
@@ -29,15 +24,13 @@ module.exports = {
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
     let dataset = ctx.params.dataset || ctx.meta.dataset || this.settings.mainDataset;
 
-    const rdf =
-      typeof resource === 'string'
-        ? resource
-        : await ctx.call('jsonld.parser.toRDF', {
-            input: resource,
-            options: {
-              format: 'application/n-quads'
-            }
-          });
+    // Convert JSON-LD to N-Quads
+    const rdf = await ctx.call('jsonld.parser.toRDF', {
+      input: resource,
+      options: {
+        format: 'application/n-quads'
+      }
+    });
 
     if (!dataset) throw new Error(`No dataset defined for triplestore insert: ${rdf}`);
     if (dataset !== '*' && !(await ctx.call('triplestore.dataset.exist', { dataset })))

--- a/src/middleware/packages/triplestore/actions/insert.js
+++ b/src/middleware/packages/triplestore/actions/insert.js
@@ -1,5 +1,4 @@
 const urlJoin = require('url-join');
-const { MIME_TYPES } = require('@semapps/mime-types');
 
 module.exports = {
   visibility: 'public',
@@ -26,19 +25,19 @@ module.exports = {
     }
   },
   async handler(ctx) {
-    const { resource, contentType, graphName } = ctx.params;
+    const { resource, graphName } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
     let dataset = ctx.params.dataset || ctx.meta.dataset || this.settings.mainDataset;
 
-    if (contentType && contentType !== MIME_TYPES.JSON)
-      throw new Error(`The triplestore.insert action now only support JSON-LD. Provided: ${contentType}`);
-
-    const rdf = await ctx.call('jsonld.parser.toRDF', {
-      input: resource,
-      options: {
-        format: 'application/n-quads'
-      }
-    });
+    const rdf =
+      typeof resource === 'string'
+        ? resource
+        : await ctx.call('jsonld.parser.toRDF', {
+            input: resource,
+            options: {
+              format: 'application/n-quads'
+            }
+          });
 
     if (!dataset) throw new Error(`No dataset defined for triplestore insert: ${rdf}`);
     if (dataset !== '*' && !(await ctx.call('triplestore.dataset.exist', { dataset })))

--- a/src/middleware/packages/triplestore/actions/tripleExist.js
+++ b/src/middleware/packages/triplestore/actions/tripleExist.js
@@ -1,5 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
-
 module.exports = {
   visibility: 'public',
   params: {
@@ -41,7 +39,6 @@ module.exports = {
             : { type: 'bgp', triples: [triple] }
         ]
       },
-      accept: MIME_TYPES.JSON,
       webId,
       dataset
     });

--- a/src/middleware/packages/triplestore/adapter.js
+++ b/src/middleware/packages/triplestore/adapter.js
@@ -65,7 +65,6 @@ class TripleStoreAdapter {
             }
           }
         `,
-        accept: MIME_TYPES.JSON,
         dataset: this.dataset
       })
       .then(result => {
@@ -106,7 +105,6 @@ class TripleStoreAdapter {
             <${sanitizeSparqlUri(_id)}> ?p ?o .
           }
         `,
-        accept: MIME_TYPES.JSON,
         dataset: this.dataset
       })
       .then(result => {

--- a/src/middleware/packages/triplestore/adapter.js
+++ b/src/middleware/packages/triplestore/adapter.js
@@ -155,7 +155,6 @@ class TripleStoreAdapter {
           '@type': this.type,
           ...resource
         },
-        contentType: MIME_TYPES.JSON,
         dataset: this.dataset
       })
       .then(() => this.findById(resource['@id']));

--- a/src/middleware/packages/webacl/bots/groups-manager.js
+++ b/src/middleware/packages/webacl/bots/groups-manager.js
@@ -1,5 +1,4 @@
 const { arrayOf } = require('@semapps/ldp');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { hasType } = require('../utils');
 
 module.exports = {
@@ -21,7 +20,6 @@ module.exports = {
     async refreshAll(ctx) {
       const usersContainer = await ctx.call('ldp.container.get', {
         containerUri: this.settings.usersContainer,
-        accept: MIME_TYPES.JSON,
         webId: 'system'
       });
 

--- a/src/middleware/packages/webacl/routes/getRoutes.js
+++ b/src/middleware/packages/webacl/routes/getRoutes.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { parseHeader, negotiateContentType, negotiateAccept, parseJson } = require('@semapps/middlewares');
+const { parseHeader, parseRawBody, negotiateContentType, negotiateAccept, parseJson } = require('@semapps/middlewares');
 
 const onError = (req, res, err) => {
   const { type, code, message, data, name } = err;
@@ -10,7 +10,7 @@ const onError = (req, res, err) => {
 };
 
 const getRoutes = (basePath, podProvider) => {
-  const middlewares = [parseHeader, parseJson, negotiateContentType, negotiateAccept];
+  const middlewares = [parseHeader, parseRawBody, negotiateContentType, negotiateAccept, parseJson];
 
   return [
     {
@@ -24,9 +24,6 @@ const getRoutes = (basePath, podProvider) => {
         text: {
           type: ['text/turtle', 'application/ld+json']
         }
-      },
-      onBeforeCall(ctx, route, req) {
-        ctx.meta.body = req.body;
       },
       aliases: {
         'PATCH /:slugParts*': [parseHeader, 'webacl.resource.api_addRights'],

--- a/src/middleware/packages/webacl/routes/getRoutes.js
+++ b/src/middleware/packages/webacl/routes/getRoutes.js
@@ -10,7 +10,7 @@ const onError = (req, res, err) => {
 };
 
 const getRoutes = (basePath, podProvider) => {
-  const middlewares = [parseHeader, parseRawBody, negotiateContentType, negotiateAccept, parseJson];
+  const middlewares = [parseHeader, negotiateContentType, negotiateAccept, parseRawBody, parseJson];
 
   return [
     {

--- a/src/middleware/packages/webacl/services/resource/actions/addRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/addRights.js
@@ -127,11 +127,12 @@ module.exports = {
         addRequest += `<${add.auth}> <${add.p}> <${add.o}>.\n`;
       }
 
-      await ctx.call('triplestore.insert', {
-        resource: addRequest,
-        webId: 'system',
-        graphName: this.settings.graphName
-      });
+      if (addRequest.length > 0) {
+        await ctx.call('triplestore.update', {
+          query: `INSERT DATA { GRAPH <${this.settings.graphName}> { ${addRequest} } }`,
+          webId: 'system'
+        });
+      }
 
       if (newRights) {
         const returnValues = { uri: resourceUri, created: true, isContainer };

--- a/src/middleware/packages/webacl/services/resource/actions/addRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/addRights.js
@@ -18,7 +18,7 @@ module.exports = {
     if (!contentType || (contentType !== MIME_TYPES.JSON && contentType !== MIME_TYPES.TURTLE))
       throw new MoleculerError(`Content type not supported : ${contentType}`, 400, 'BAD_REQUEST');
 
-    const addedRights = await convertBodyToTriples(ctx.meta.body, contentType);
+    const addedRights = await convertBodyToTriples(ctx.meta.rawBody, contentType);
     if (addedRights.length === 0) throw new MoleculerError('Nothing to add', 400, 'BAD_REQUEST');
 
     // This is the root container

--- a/src/middleware/packages/webacl/services/resource/actions/getRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/getRights.js
@@ -189,14 +189,14 @@ module.exports = {
 
     return await ctx.call('webacl.resource.getRights', {
       resourceUri: urlJoin(this.settings.baseUrl, ...slugParts),
-      accept: accept
+      accept
     });
   },
   action: {
     visibility: 'public',
     params: {
       resourceUri: { type: 'string' },
-      accept: { type: 'string', optional: true },
+      accept: { type: 'string', default: MIME_TYPES.JSON },
       webId: { type: 'string', optional: true },
       skipResourceCheck: { type: 'boolean', default: false }
     },

--- a/src/middleware/packages/webacl/services/resource/actions/getUsersWithReadRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/getUsersWithReadRights.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { arrayOf } = require('@semapps/ldp');
 
 module.exports = {
@@ -10,10 +9,7 @@ module.exports = {
     async handler(ctx) {
       const { resourceUri } = ctx.params;
 
-      const authorizations = await this.actions.getRights(
-        { resourceUri, accept: MIME_TYPES.JSON, webId: 'system' },
-        { parentCtx: ctx }
-      );
+      const authorizations = await this.actions.getRights({ resourceUri, webId: 'system' }, { parentCtx: ctx });
       const readAuthorization =
         authorizations['@graph'] && authorizations['@graph'].find(auth => auth['@id'] === '#Read');
 

--- a/src/middleware/packages/webacl/services/resource/actions/setRights.js
+++ b/src/middleware/packages/webacl/services/resource/actions/setRights.js
@@ -17,7 +17,7 @@ module.exports = {
     if (!contentType || (contentType !== MIME_TYPES.JSON && contentType !== MIME_TYPES.TURTLE))
       throw new MoleculerError(`Content type not supported : ${contentType}`, 400, 'BAD_REQUEST');
 
-    const newRights = await convertBodyToTriples(ctx.meta.body, contentType);
+    const newRights = await convertBodyToTriples(ctx.meta.rawBody, contentType);
     if (newRights.length === 0) throw new MoleculerError('PUT rights cannot be empty', 400, 'BAD_REQUEST');
 
     // This is the root container

--- a/src/middleware/packages/webacl/utils.js
+++ b/src/middleware/packages/webacl/utils.js
@@ -6,9 +6,6 @@ const { Parser } = require('n3');
 const streamifyString = require('streamify-string');
 const rdfParser = require('rdf-parse').default;
 
-const RESOURCE_CONTAINERS_QUERY = resource => `SELECT ?container
-  WHERE { ?container ldp:contains <${resource}> . }`;
-
 const getSlugFromUri = str => str.match(new RegExp(`.*/(.*)`))[1];
 
 const hasType = (resource, type) => {
@@ -23,12 +20,13 @@ const getDatasetFromUri = uri => {
   if (parts.length > 1) return parts[1];
 };
 
-const findParentContainers = async (ctx, resource) => {
-  const query = `PREFIX ldp: <http://www.w3.org/ns/ldp#>\n${RESOURCE_CONTAINERS_QUERY(resource)}`;
-
+const findParentContainers = async (ctx, resourceUri) => {
   return await ctx.call('triplestore.query', {
-    query,
-    accept: MIME_TYPES.SPARQL_JSON,
+    query: `
+      PREFIX ldp: <http://www.w3.org/ns/ldp#>
+      SELECT ?container
+      WHERE { ?container ldp:contains <${resourceUri}> . }
+    `,
     webId: 'system'
   });
 };
@@ -58,7 +56,6 @@ const getUserGroups = async (ctx, user, graphName) => {
 
   const groups = await ctx.call('triplestore.query', {
     query,
-    accept: MIME_TYPES.JSON,
     webId: 'system'
   });
 
@@ -84,7 +81,6 @@ const getAuthorizationNode = async (ctx, resourceUri, resourceAclUri, mode, grap
 
   const auths = await ctx.call('triplestore.query', {
     query,
-    accept: MIME_TYPES.JSON,
     webId: 'system'
   });
 

--- a/src/middleware/packages/webid/service.js
+++ b/src/middleware/packages/webid/service.js
@@ -1,5 +1,4 @@
 const urlJoin = require('url-join');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { foaf, schema } = require('@semapps/ontologies');
 const { ControlledContainerMixin, DereferenceMixin, getDatasetFromUri } = require('@semapps/ldp');
 
@@ -36,7 +35,6 @@ const WebIdService = {
       return ctx.call(
         'ldp.resource.get',
         {
-          accept: this.settings.accept,
           ...ctx.params,
           webId: 'system'
         },
@@ -78,7 +76,6 @@ const WebIdService = {
               '@id': webId,
               ...resource
             },
-            contentType: MIME_TYPES.JSON,
             webId: 'system'
           },
           { parentCtx: ctx }
@@ -89,7 +86,6 @@ const WebIdService = {
           {
             resource,
             slug: nick,
-            contentType: MIME_TYPES.JSON,
             webId: 'system'
           },
           { parentCtx: ctx }
@@ -99,7 +95,6 @@ const WebIdService = {
       const webIdData = await this.actions.get(
         {
           resourceUri: webId,
-          accept: MIME_TYPES.JSON,
           webId: 'system'
         },
         { parentCtx: ctx }

--- a/src/middleware/tests/activitypub/collection-api.test.js
+++ b/src/middleware/tests/activitypub/collection-api.test.js
@@ -1,6 +1,5 @@
 const urlJoin = require('url-join');
 const fetch = require('node-fetch');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { fetchServer } = require('../utils');
 const initialize = require('./initialize');
 const CONFIG = require('../config');
@@ -33,8 +32,7 @@ describe('Collections API', () => {
             name: `Note #${i}`,
             content: `Contenu de ma note #${i}`,
             published: `2021-01-0${i}T00:00:00.000Z`
-          },
-          contentType: MIME_TYPES.JSON
+          }
         })
       );
     }

--- a/src/middleware/tests/activitypub/collection.test.js
+++ b/src/middleware/tests/activitypub/collection.test.js
@@ -1,5 +1,4 @@
 const urlJoin = require('url-join');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 const CONFIG = require('../config');
 
@@ -32,9 +31,8 @@ describe('Collections', () => {
             '@type': 'Note',
             name: `Note #${i}`,
             content: `Contenu de ma note #${i}`,
-            published: `2021-01-0${i}T00:00:00.000Z`
-          },
-          contentType: MIME_TYPES.JSON
+            published: `2021-01-0${i + 1}T00:00:00.000Z`
+          }
         })
       );
     }
@@ -45,7 +43,6 @@ describe('Collections', () => {
         type: 'Collection',
         summary: 'My non-ordered collection'
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 
@@ -56,7 +53,6 @@ describe('Collections', () => {
         summary: 'My ordered collection',
         'semapps:dereferenceItems': false
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 
@@ -67,7 +63,6 @@ describe('Collections', () => {
         summary: 'Cursor test collection',
         'semapps:itemsPerPage': 2
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 
@@ -172,7 +167,6 @@ describe('Collections', () => {
         summary: 'My non-ordered collection with dereferenceItems: true',
         'semapps:dereferenceItems': true
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 
@@ -237,7 +231,6 @@ describe('Collections', () => {
         'semapps:sortPredicate': 'as:published',
         'semapps:sortOrder': 'semapps:AscOrder'
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 
@@ -282,7 +275,6 @@ describe('Collections', () => {
           summary: 'My paginated collection',
           'semapps:itemsPerPage': 4
         },
-        contentType: MIME_TYPES.JSON,
         webId: 'system'
       });
 
@@ -347,7 +339,6 @@ describe('Collections', () => {
             summary: 'Empty collection',
             'semapps:itemsPerPage': 4
           },
-          contentType: MIME_TYPES.JSON,
           webId: 'system'
         });
 
@@ -371,7 +362,6 @@ describe('Collections', () => {
             summary: 'Exact size collection',
             'semapps:itemsPerPage': 4
           },
-          contentType: MIME_TYPES.JSON,
           webId: 'system'
         });
 

--- a/src/middleware/tests/activitypub/like.test.js
+++ b/src/middleware/tests/activitypub/like.test.js
@@ -72,8 +72,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange likes', m
     await waitForExpect(async () => {
       await expect(
         alice.call('ldp.resource.get', {
-          resourceUri: aliceMessageUri,
-          accept: MIME_TYPES.JSON
+          resourceUri: aliceMessageUri
         })
       ).resolves.toMatchObject({
         likes: `${aliceMessageUri}/likes`

--- a/src/middleware/tests/activitypub/like.test.js
+++ b/src/middleware/tests/activitypub/like.test.js
@@ -1,6 +1,5 @@
 const waitForExpect = require('wait-for-expect');
 const { OBJECT_TYPES, ACTIVITY_TYPES, PUBLIC_URI } = require('@semapps/activitypub');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 
 jest.setTimeout(50000);
@@ -13,7 +12,6 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange likes', m
   let alice;
   let bob;
   let aliceMessageUri;
-  let bobMessageUri;
 
   beforeAll(async () => {
     if (mode === 'single-server') {
@@ -82,10 +80,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange likes', m
     // Ensure Bob has been added to the /likes collection
     await waitForExpect(async () => {
       await expect(
-        alice.call('activitypub.collection.get', {
-          resourceUri: `${aliceMessageUri}/likes`,
-          accept: MIME_TYPES.JSON
-        })
+        alice.call('activitypub.collection.get', { resourceUri: `${aliceMessageUri}/likes` })
       ).resolves.toMatchObject({
         type: 'Collection',
         items: bob.id
@@ -94,12 +89,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange likes', m
 
     // Ensure the note has been added to Bob's /liked collection
     await waitForExpect(async () => {
-      await expect(
-        bob.call('activitypub.collection.get', {
-          resourceUri: `${bob.id}/liked`,
-          accept: MIME_TYPES.JSON
-        })
-      ).resolves.toMatchObject({
+      await expect(bob.call('activitypub.collection.get', { resourceUri: `${bob.id}/liked` })).resolves.toMatchObject({
         type: 'Collection',
         items: aliceMessageUri
       });
@@ -120,19 +110,13 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange likes', m
 
     // Ensure Bob has been removed from the /likes collection
     await waitForExpect(async () => {
-      const likes = await alice.call('activitypub.collection.get', {
-        resourceUri: `${aliceMessageUri}/likes`,
-        accept: MIME_TYPES.JSON
-      });
+      const likes = await alice.call('activitypub.collection.get', { resourceUri: `${aliceMessageUri}/likes` });
       expect(likes.items).toHaveLength(0);
     });
 
     // Ensure the note has been removed from Bob's /liked collection
     await waitForExpect(async () => {
-      const liked = await bob.call('activitypub.collection.get', {
-        resourceUri: `${bob.id}/liked`,
-        accept: MIME_TYPES.JSON
-      });
+      const liked = await bob.call('activitypub.collection.get', { resourceUri: `${bob.id}/liked` });
       expect(liked.items).toHaveLength(0);
     });
   });

--- a/src/middleware/tests/activitypub/message.test.js
+++ b/src/middleware/tests/activitypub/message.test.js
@@ -1,6 +1,5 @@
 const waitForExpect = require('wait-for-expect');
 const { OBJECT_TYPES, ACTIVITY_TYPES } = require('@semapps/activitypub');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 
 jest.setTimeout(70000);
@@ -93,10 +92,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange messages'
 
     await waitForExpect(async () => {
       await expect(
-        alice.call('activitypub.collection.get', {
-          resourceUri: `${aliceMessageUri}/replies`,
-          accept: MIME_TYPES.JSON
-        })
+        alice.call('activitypub.collection.get', { resourceUri: `${aliceMessageUri}/replies` })
       ).resolves.toMatchObject({
         type: 'Collection',
         items: {
@@ -127,10 +123,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange messages'
     });
 
     await waitForExpect(async () => {
-      const replies = await alice.call('activitypub.collection.get', {
-        resourceUri: `${aliceMessageUri}/replies`,
-        accept: MIME_TYPES.JSON
-      });
+      const replies = await alice.call('activitypub.collection.get', { resourceUri: `${aliceMessageUri}/replies` });
       expect(replies.items).toBeUndefinedOrEmptyArray();
     });
   });

--- a/src/middleware/tests/activitypub/message.test.js
+++ b/src/middleware/tests/activitypub/message.test.js
@@ -61,10 +61,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange messages'
     aliceMessageUri = createActivity.object.id;
 
     // Check the object has been created
-    const message = await alice.call('ldp.resource.get', {
-      resourceUri: aliceMessageUri,
-      accept: MIME_TYPES.JSON
-    });
+    const message = await alice.call('ldp.resource.get', { resourceUri: aliceMessageUri });
     expect(message).toMatchObject({
       type: OBJECT_TYPES.NOTE,
       attributedTo: alice.id,
@@ -89,12 +86,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange messages'
     bobMessageUri = createActivity.object.id;
 
     await waitForExpect(async () => {
-      await expect(
-        alice.call('ldp.resource.get', {
-          resourceUri: aliceMessageUri,
-          accept: MIME_TYPES.JSON
-        })
-      ).resolves.toMatchObject({
+      await expect(alice.call('ldp.resource.get', { resourceUri: aliceMessageUri })).resolves.toMatchObject({
         replies: `${aliceMessageUri}/replies`
       });
     });
@@ -127,12 +119,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange messages'
     });
 
     await waitForExpect(async () => {
-      await expect(
-        alice.call('ldp.resource.get', {
-          resourceUri: bobMessageUri,
-          accept: MIME_TYPES.JSON
-        })
-      ).resolves.toMatchObject({
+      await expect(alice.call('ldp.resource.get', { resourceUri: bobMessageUri })).resolves.toMatchObject({
         type: OBJECT_TYPES.TOMBSTONE,
         formerType: 'as:Note',
         deleted: expect.anything()

--- a/src/middleware/tests/activitypub/object.test.js
+++ b/src/middleware/tests/activitypub/object.test.js
@@ -1,5 +1,4 @@
 const { ACTIVITY_TYPES, OBJECT_TYPES } = require('@semapps/activitypub');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const waitForExpect = require('wait-for-expect');
 const initialize = require('./initialize');
 const CONFIG = require('../config');
@@ -66,10 +65,7 @@ describe('Create/Update/Delete objects', () => {
     objectUri = createActivity.object.id;
 
     // Check the object has been created in the container
-    const object = await broker.call('ldp.resource.get', {
-      resourceUri: objectUri,
-      accept: MIME_TYPES.JSON
-    });
+    const object = await broker.call('ldp.resource.get', { resourceUri: objectUri });
     expect(object).toHaveProperty('type', OBJECT_TYPES.ARTICLE);
     expect(object).toHaveProperty('id', objectUri);
   });
@@ -102,10 +98,7 @@ describe('Create/Update/Delete objects', () => {
     expect(updateActivity.object).not.toHaveProperty('name');
 
     // Check the object has been updated
-    const object = await broker.call('ldp.resource.get', {
-      resourceUri: objectUri,
-      accept: MIME_TYPES.JSON
-    });
+    const object = await broker.call('ldp.resource.get', { resourceUri: objectUri });
     expect(object).toMatchObject({
       id: objectUri,
       type: OBJECT_TYPES.ARTICLE,
@@ -122,12 +115,7 @@ describe('Create/Update/Delete objects', () => {
     });
 
     await waitForExpect(async () => {
-      await expect(
-        broker.call('ldp.resource.get', {
-          resourceUri: objectUri,
-          accept: MIME_TYPES.JSON
-        })
-      ).resolves.toMatchObject({
+      await expect(broker.call('ldp.resource.get', { resourceUri: objectUri })).resolves.toMatchObject({
         type: OBJECT_TYPES.TOMBSTONE,
         formerType: 'as:Article',
         deleted: expect.anything()

--- a/src/middleware/tests/activitypub/outbox.test.js
+++ b/src/middleware/tests/activitypub/outbox.test.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { ACTIVITY_TYPES, OBJECT_TYPES, PUBLIC_URI } = require('@semapps/activitypub');
 const waitForExpect = require('wait-for-expect');
 const initialize = require('./initialize');
@@ -105,7 +104,6 @@ describe('Permissions are correctly set on outbox', () => {
     // await expect(() =>
     //   broker.call('ldp.resource.get', {
     //     resourceUri: objectPrivateFirst.id,
-    //     accept: MIME_TYPES.JSON,
     //     webId: simon.id
     //   })
     // ).rejects.toThrow();
@@ -360,7 +358,6 @@ describe('Permissions are correctly set on outbox', () => {
       await expect(() =>
         broker.call('ldp.resource.get', {
           resourceUri: objectUri,
-          accept: MIME_TYPES.JSON,
           webId: simon.id
         })
       ).rejects.toThrow();

--- a/src/middleware/tests/activitypub/shares.test.js
+++ b/src/middleware/tests/activitypub/shares.test.js
@@ -1,6 +1,5 @@
 const waitForExpect = require('wait-for-expect');
 const { OBJECT_TYPES, ACTIVITY_TYPES, PUBLIC_URI } = require('@semapps/activitypub');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 
 jest.setTimeout(50000);
@@ -85,10 +84,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange shares', 
     // Ensure only the public announce activity has been added to the /shares collection
     await waitForExpect(async () => {
       await expect(
-        alice.call('activitypub.collection.get', {
-          resourceUri: `${aliceMessageUri}/shares`,
-          accept: MIME_TYPES.JSON
-        })
+        alice.call('activitypub.collection.get', { resourceUri: `${aliceMessageUri}/shares` })
       ).resolves.toMatchObject({
         type: 'Collection',
         items: publicShareActivity.id
@@ -108,10 +104,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange shares', 
     // Ensure the public announce activity has been removed from the /shares collection
     await waitForExpect(async () => {
       await expect(
-        alice.call('activitypub.collection.get', {
-          resourceUri: `${aliceMessageUri}/shares`,
-          accept: MIME_TYPES.JSON
-        })
+        alice.call('activitypub.collection.get', { resourceUri: `${aliceMessageUri}/shares` })
       ).resolves.not.toMatchObject({
         items: publicShareActivity.id
       });

--- a/src/middleware/tests/activitypub/shares.test.js
+++ b/src/middleware/tests/activitypub/shares.test.js
@@ -77,12 +77,7 @@ describe.each(['single-server', 'multi-server'])('In mode %s, exchange shares', 
 
     // Ensure the /shares collection has been created
     await waitForExpect(async () => {
-      await expect(
-        alice.call('ldp.resource.get', {
-          resourceUri: aliceMessageUri,
-          accept: MIME_TYPES.JSON
-        })
-      ).resolves.toMatchObject({
+      await expect(alice.call('ldp.resource.get', { resourceUri: aliceMessageUri })).resolves.toMatchObject({
         shares: `${aliceMessageUri}/shares`
       });
     });

--- a/src/middleware/tests/crypto/keys.test.js
+++ b/src/middleware/tests/crypto/keys.test.js
@@ -1,5 +1,4 @@
 const { KEY_TYPES } = require('@semapps/crypto');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { arrayOf, waitForResource } = require('@semapps/ldp');
 const { wait } = require('../utils');
 const initialize = require('./initialize');
@@ -57,14 +56,7 @@ describe('keys', () => {
         const [keyPair] = await broker.call('keys.getByType', { webId: user.webId, keyType: KEY_TYPES.RSA });
 
         const webIdDocument = await waitForResource(500, 'publicKey', 5, () =>
-          broker.call(
-            'webid.get',
-            {
-              resourceUri: user.webId,
-              accept: MIME_TYPES.JSON
-            },
-            { meta: { $cache: false } }
-          )
+          broker.call('webid.get', { resourceUri: user.webId }, { meta: { $cache: false } })
         );
 
         expect(webIdDocument).toBeDefined();
@@ -87,7 +79,6 @@ describe('keys', () => {
 
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -98,7 +89,6 @@ describe('keys', () => {
         await broker.call('keys.attachPublicKeyToWebId', { webId: user.webId, keyId: keyPair['@id'] || keyPair.id });
         const webIdDocumentNew = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -119,7 +109,6 @@ describe('keys', () => {
         // Expect webId not to have key.
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -148,7 +137,6 @@ describe('keys', () => {
         // Expect webId to not have old key but new key.
         const webIdDocumentNew = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -161,7 +149,6 @@ describe('keys', () => {
         // Expect publicKey to be present in `/public-keys` container.
         const publicKey = await broker.call('keys.public-container.get', {
           resourceUri: newKeyPair['rdfs:seeAlso'],
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(publicKey).toBeTruthy();
@@ -180,8 +167,7 @@ describe('keys', () => {
         await expect(
           broker.call('keys.container.get', {
             resourceUri: keyPair['@id'] || keyPair.id,
-            webId: user2.webId,
-            accept: MIME_TYPES.JSON
+            webId: user2.webId
           })
         ).rejects.toThrow('Forbidden');
       });
@@ -196,7 +182,6 @@ describe('keys', () => {
 
         const publicKey = await broker.call('keys.container.get', {
           resourceUri: keyPair['rdfs:seeAlso'],
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(publicKey).toBeTruthy();
@@ -204,7 +189,6 @@ describe('keys', () => {
         // Should not be present in webId.
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -222,7 +206,6 @@ describe('keys', () => {
         // Expect the new key to be findable in the webId and the old one to be removed.
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         // Expect the public key of the webId to be the key published in the public key container (referenced rdfs:seeAlso).
@@ -242,7 +225,6 @@ describe('keys', () => {
         // Should not be present in webId.
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -288,14 +270,7 @@ describe('keys', () => {
       test('public key present in webId', async () => {
         const [keyPair] = await broker.call('keys.getByType', { webId: user.webId, keyType: KEY_TYPES.ED25519 });
 
-        const webIdDocument = await broker.call(
-          'webid.get',
-          {
-            resourceUri: user.webId,
-            accept: MIME_TYPES.JSON
-          },
-          { meta: { $cache: false } }
-        );
+        const webIdDocument = await broker.call('webid.get', { resourceUri: user.webId }, { meta: { $cache: false } });
         expect(webIdDocument.assertionMethod).toBeDefined();
         expect(
           arrayOf(webIdDocument.assertionMethod).find(
@@ -314,7 +289,6 @@ describe('keys', () => {
 
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -325,7 +299,6 @@ describe('keys', () => {
         await broker.call('keys.attachPublicKeyToWebId', { webId: user.webId, keyId: keyPair['@id'] || keyPair.id });
         const webIdDocumentNew = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -346,7 +319,6 @@ describe('keys', () => {
         // Expect webId not to have key.
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -377,7 +349,6 @@ describe('keys', () => {
         // Expect webId to not have old key but new key.
         const webIdDocumentNew = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(
@@ -394,7 +365,6 @@ describe('keys', () => {
         // Expect publicKey to be present in `/public-keys` container.
         const publicKey = await broker.call('keys.public-container.get', {
           resourceUri: newKeyPair['rdfs:seeAlso'],
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         expect(publicKey).toBeTruthy();
@@ -413,8 +383,7 @@ describe('keys', () => {
         await expect(
           broker.call('keys.container.get', {
             resourceUri: keyPair.id || keyPair['@id'],
-            webId: user2.webId,
-            accept: MIME_TYPES.JSON
+            webId: user2.webId
           })
         ).rejects.toThrow('Forbidden');
       });
@@ -430,7 +399,6 @@ describe('keys', () => {
         // Expect the new key to be findable in the webId
         const webIdDocument = await broker.call('webid.get', {
           resourceUri: user.webId,
-          accept: MIME_TYPES.JSON,
           webId: user.webId
         });
         // Expect the public key of the webId to be the key published in the public key container (referenced by rdfs:seeAlso).
@@ -493,10 +461,7 @@ describe('keys', () => {
         const { publicKey, privateKey } = await broker.call('signature.keypair.get', { actorUri: user.webId });
         expect(publicKey).toBeDefined();
         expect(privateKey).toBeDefined();
-        const webIdDocument = await broker.call('webid.get', {
-          resourceUri: user.webId,
-          accept: MIME_TYPES.JSON
-        });
+        const webIdDocument = await broker.call('webid.get', { resourceUri: user.webId });
         expect(webIdDocument).toBeDefined();
         expect(webIdDocument.publicKey).toBeDefined();
         expect(webIdDocument.publicKey.publicKeyPem).toBe(publicKey);
@@ -523,10 +488,7 @@ describe('keys', () => {
           const { publicKey, privateKey } = await broker.call('signature.keypair.get', { actorUri: user.webId });
           expect(publicKey).toBeDefined();
           expect(privateKey).toBeDefined();
-          const webIdDocument = await broker.call('webid.get', {
-            resourceUri: user.webId,
-            accept: MIME_TYPES.JSON
-          });
+          const webIdDocument = await broker.call('webid.get', { resourceUri: user.webId });
           expect(webIdDocument).toBeDefined();
           expect(webIdDocument.publicKey.publicKeyPem).toBe(publicKey);
           expect(webIdDocument.privateKey).toBeUndefined();
@@ -550,8 +512,7 @@ describe('keys', () => {
           const [keyPair] = await broker.call('keys.getByType', { webId: user.webId, keyType: KEY_TYPES.RSA });
 
           const webIdDocument = await broker.call('webid.get', {
-            resourceUri: user.webId,
-            accept: MIME_TYPES.JSON
+            resourceUri: user.webId
           });
           expect(webIdDocument).toBeDefined();
           const { publicKey } = webIdDocument;

--- a/src/middleware/tests/crypto/verifiable-credentials.test.js
+++ b/src/middleware/tests/crypto/verifiable-credentials.test.js
@@ -26,8 +26,7 @@ const setUpUser = async (broker, username) => {
   });
   user.webIdDoc = await broker.call('ldp.resource.get', {
     resourceUri: user.webId,
-    webId: 'system',
-    accept: MIME_TYPES.JSON
+    webId: 'system'
   });
 
   user.fetch = async (uri, init) => {

--- a/src/middleware/tests/interop/mirror-protected.test.js
+++ b/src/middleware/tests/interop/mirror-protected.test.js
@@ -1,6 +1,5 @@
 const urlJoin = require('url-join');
 const waitForExpect = require('wait-for-expect');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { ACTIVITY_TYPES } = require('@semapps/activitypub');
 const initialize = require('./initialize');
 
@@ -60,7 +59,6 @@ describe('Resource on server1 is shared with user on server2', () => {
         '@type': 'Resource',
         label: 'My protected resource'
       },
-      contentType: MIME_TYPES.JSON,
       containerUri: 'http://localhost:3001/protected-resources',
       webId: 'system'
     });

--- a/src/middleware/tests/interop/mirror.test.js
+++ b/src/middleware/tests/interop/mirror.test.js
@@ -1,7 +1,6 @@
 const urlJoin = require('url-join');
 const waitForExpect = require('wait-for-expect');
 const { triple, namedNode } = require('@rdfjs/data-model');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 
 jest.setTimeout(100000);
@@ -58,7 +57,6 @@ describe('Server2 mirror server1', () => {
         '@type': 'Resource',
         label: 'My resource'
       },
-      contentType: MIME_TYPES.JSON,
       containerUri: 'http://localhost:3001/resources'
     });
 
@@ -86,8 +84,7 @@ describe('Server2 mirror server1', () => {
         '@id': resourceUri,
         '@type': 'Resource',
         label: 'My resource updated'
-      },
-      contentType: MIME_TYPES.JSON
+      }
     });
 
     await waitForExpect(async () => {

--- a/src/middleware/tests/interop/patch-remote.test.js
+++ b/src/middleware/tests/interop/patch-remote.test.js
@@ -1,6 +1,5 @@
 const waitForExpect = require('wait-for-expect');
 const { triple, namedNode } = require('@rdfjs/data-model');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 
 jest.setTimeout(50000);
@@ -29,7 +28,6 @@ describe('Server2 imports a single resource from server1', () => {
         '@type': 'Resource',
         label: 'My resource'
       },
-      contentType: MIME_TYPES.JSON,
       containerUri: 'http://localhost:3001/resources'
     });
 
@@ -77,8 +75,7 @@ describe('Server2 imports a single resource from server1', () => {
         '@id': resourceUri,
         '@type': 'Resource',
         label: 'My resource updated'
-      },
-      contentType: MIME_TYPES.JSON
+      }
     });
 
     // Force call of updateSingleMirroredResources

--- a/src/middleware/tests/interop/remote-inference.test.js
+++ b/src/middleware/tests/interop/remote-inference.test.js
@@ -1,6 +1,5 @@
 const { triple, namedNode } = require('rdf-data-model');
 const waitForExpect = require('wait-for-expect');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const initialize = require('./initialize');
 
 jest.setTimeout(100000);
@@ -30,7 +29,6 @@ describe('An inference is added between server1 et server2', () => {
         '@type': 'Resource',
         label: 'My parent resource'
       },
-      contentType: MIME_TYPES.JSON,
       containerUri: 'http://localhost:3001/resources'
     });
 
@@ -45,14 +43,11 @@ describe('An inference is added between server1 et server2', () => {
           '@id': resourceUri1
         }
       },
-      contentType: MIME_TYPES.JSON,
       containerUri: 'http://localhost:3002/resources'
     });
 
     await waitForExpect(async () => {
-      await expect(
-        server1.call('ldp.resource.get', { resourceUri: resourceUri1, accept: MIME_TYPES.JSON })
-      ).resolves.toMatchObject({
+      await expect(server1.call('ldp.resource.get', { resourceUri: resourceUri1 })).resolves.toMatchObject({
         id: resourceUri1,
         'pair:hasPart': resourceUri2
       });
@@ -72,9 +67,7 @@ describe('An inference is added between server1 et server2', () => {
     });
 
     await waitForExpect(async () => {
-      await expect(
-        server2.call('ldp.resource.get', { resourceUri: resourceUri2, accept: MIME_TYPES.JSON })
-      ).resolves.toMatchObject({
+      await expect(server2.call('ldp.resource.get', { resourceUri: resourceUri2 })).resolves.toMatchObject({
         id: resourceUri2,
         'pair:inspiredBy': resourceUri1
       });
@@ -94,14 +87,13 @@ describe('An inference is added between server1 et server2', () => {
         partOf: {
           '@id': resourceUri1
         }
-      },
-      contentType: MIME_TYPES.JSON
+      }
     });
 
     await waitForExpect(async () => {
-      await expect(
-        server1.call('ldp.resource.get', { resourceUri: resourceUri1, accept: MIME_TYPES.JSON })
-      ).resolves.not.toHaveProperty('pair:hasInspired');
+      await expect(server1.call('ldp.resource.get', { resourceUri: resourceUri1 })).resolves.not.toHaveProperty(
+        'pair:hasInspired'
+      );
     });
   });
 
@@ -109,9 +101,9 @@ describe('An inference is added between server1 et server2', () => {
     await server2.call('ldp.resource.delete', { resourceUri: resourceUri2 });
 
     await waitForExpect(async () => {
-      await expect(
-        server1.call('ldp.resource.get', { resourceUri: resourceUri1, accept: MIME_TYPES.JSON })
-      ).resolves.not.toHaveProperty('pair:hasPart');
+      await expect(server1.call('ldp.resource.get', { resourceUri: resourceUri1 })).resolves.not.toHaveProperty(
+        'pair:hasPart'
+      );
     });
   });
 });

--- a/src/middleware/tests/ldp/binary.test.js
+++ b/src/middleware/tests/ldp/binary.test.js
@@ -2,7 +2,6 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const { join: pathJoin } = require('path');
 const urlJoin = require('url-join');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { getSlugFromUri } = require('@semapps/ldp');
 const { fetchServer } = require('../utils');
 const initialize = require('./initialize');
@@ -75,12 +74,7 @@ describe('Binary handling of LDP server', () => {
   });
 
   test('Get image as resource (via Moleculer action)', async () => {
-    await expect(
-      broker.call('ldp.resource.get', {
-        resourceUri: fileUri,
-        accept: MIME_TYPES.JSON
-      })
-    ).resolves.toMatchObject({
+    await expect(broker.call('ldp.resource.get', { resourceUri: fileUri })).resolves.toMatchObject({
       '@id': fileUri,
       '@type': 'semapps:File',
       'semapps:fileName': fileName,

--- a/src/middleware/tests/ldp/container.test.js
+++ b/src/middleware/tests/ldp/container.test.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const waitForExpect = require('wait-for-expect');
 const CONFIG = require('../config');
 const initialize = require('./initialize');
@@ -33,8 +32,7 @@ describe('LDP container tests', () => {
 
     await expect(
       broker.call('ldp.container.get', {
-        containerUri: `${CONFIG.HOME_URL}objects`,
-        accept: MIME_TYPES.JSON
+        containerUri: `${CONFIG.HOME_URL}objects`
       })
     ).resolves.toMatchObject({
       '@id': `${CONFIG.HOME_URL}objects`,
@@ -62,7 +60,6 @@ describe('LDP container tests', () => {
     await expect(
       broker.call('ldp.container.get', {
         containerUri: `${CONFIG.HOME_URL}`,
-        accept: MIME_TYPES.JSON,
         webId: 'system'
       })
     ).resolves.toMatchObject({
@@ -77,7 +74,6 @@ describe('LDP container tests', () => {
     await expect(
       broker.call('ldp.container.get', {
         containerUri: `${CONFIG.HOME_URL}parent`,
-        accept: MIME_TYPES.JSON,
         webId: 'system'
       })
     ).resolves.toMatchObject({
@@ -93,7 +89,6 @@ describe('LDP container tests', () => {
   test('Post a resource in a container', async () => {
     resourceUri = await broker.call('ldp.container.post', {
       containerUri: `${CONFIG.HOME_URL}resources`,
-      contentType: MIME_TYPES.JSON,
       resource: {
         '@context': {
           '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
@@ -105,8 +100,7 @@ describe('LDP container tests', () => {
 
     await expect(
       broker.call('ldp.container.get', {
-        containerUri: `${CONFIG.HOME_URL}resources`,
-        accept: MIME_TYPES.JSON
+        containerUri: `${CONFIG.HOME_URL}resources`
       })
     ).resolves.toMatchObject({
       '@id': `${CONFIG.HOME_URL}resources`,
@@ -125,7 +119,6 @@ describe('LDP container tests', () => {
     await expect(
       broker.call('ldp.container.post', {
         containerUri: `${CONFIG.HOME_URL}unknownContainer`,
-        contentType: MIME_TYPES.JSON,
         resource: {
           '@context': {
             '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
@@ -150,7 +143,6 @@ describe('LDP container tests', () => {
     await expect(
       broker.call('ldp.container.get', {
         containerUri: `${CONFIG.HOME_URL}resources`,
-        accept: MIME_TYPES.JSON,
         jsonContext: {
           '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
         }
@@ -174,7 +166,6 @@ describe('LDP container tests', () => {
   test('Get container with filters param', async () => {
     await broker.call('ldp.container.post', {
       containerUri: `${CONFIG.HOME_URL}resources`,
-      contentType: MIME_TYPES.JSON,
       resource: {
         '@context': {
           '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
@@ -187,8 +178,7 @@ describe('LDP container tests', () => {
     // Get without filters param
     await expect(
       broker.call('ldp.container.get', {
-        containerUri: `${CONFIG.HOME_URL}resources`,
-        accept: MIME_TYPES.JSON
+        containerUri: `${CONFIG.HOME_URL}resources`
       })
     ).resolves.toMatchObject({
       '@id': `${CONFIG.HOME_URL}resources`,
@@ -207,7 +197,6 @@ describe('LDP container tests', () => {
     await expect(
       broker.call('ldp.container.get', {
         containerUri: `${CONFIG.HOME_URL}resources`,
-        accept: MIME_TYPES.JSON,
         filters: {
           'pair:label': 'My project 2'
         }
@@ -226,7 +215,6 @@ describe('LDP container tests', () => {
   test('Get container without resources', async () => {
     const container = await broker.call('ldp.container.get', {
       containerUri: `${CONFIG.HOME_URL}resources`,
-      accept: MIME_TYPES.JSON,
       doNotIncludeResources: true
     });
 
@@ -242,8 +230,7 @@ describe('LDP container tests', () => {
     // Project 1 should have disappeared from the container
     await expect(
       broker.call('ldp.container.get', {
-        containerUri: `${CONFIG.HOME_URL}resources`,
-        accept: MIME_TYPES.JSON
+        containerUri: `${CONFIG.HOME_URL}resources`
       })
     ).resolves.toMatchObject({
       '@id': `${CONFIG.HOME_URL}resources`,
@@ -263,10 +250,7 @@ describe('LDP container tests', () => {
 
     // Container should now be empty
     await waitForExpect(async () => {
-      const container = await broker.call('ldp.container.get', {
-        containerUri: `${CONFIG.HOME_URL}resources`,
-        accept: MIME_TYPES.JSON
-      });
+      const container = await broker.call('ldp.container.get', { containerUri: `${CONFIG.HOME_URL}resources` });
 
       expect(container['ldp:contains']).toHaveLength(0);
     });

--- a/src/middleware/tests/ldp/content-negotiation.test.js
+++ b/src/middleware/tests/ldp/content-negotiation.test.js
@@ -107,4 +107,59 @@ describe('Content negotiation', () => {
       )
     );
   });
+
+  test('Post resource in Turtle format', async () => {
+    const { headers, status, statusText } = await fetchServer(containerUri, {
+      method: 'POST',
+      body: `
+        @prefix pair: <http://virtual-assembly.org/ontologies/pair#>.
+        <> a pair:Project;
+          pair:label "myProject 2" .
+      `,
+      headers: new fetch.Headers({
+        'Content-Type': MIME_TYPES.TURTLE
+      })
+    });
+
+    expect(status).toBe(201);
+
+    const project2Uri = headers.get('Location');
+
+    const project2 = await broker.call('ldp.resource.get', {
+      resourceUri: project2Uri
+    });
+    expect(project2).toMatchObject({
+      '@context': 'http://localhost:3000/.well-known/context.jsonld',
+      '@id': project2Uri,
+      '@type': 'pair:Project',
+      'pair:label': 'myProject 2'
+    });
+  });
+
+  test('Post resource in N-Triples format', async () => {
+    const { headers, status, statusText } = await fetchServer(containerUri, {
+      method: 'POST',
+      body: `
+        <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://virtual-assembly.org/ontologies/pair#Project> .
+        <> <http://virtual-assembly.org/ontologies/pair#label> "myProject 3" .
+      `,
+      headers: new fetch.Headers({
+        'Content-Type': MIME_TYPES.TRIPLE
+      })
+    });
+
+    expect(status).toBe(201);
+
+    const project3Uri = headers.get('Location');
+
+    const project2 = await broker.call('ldp.resource.get', {
+      resourceUri: project3Uri
+    });
+    expect(project2).toMatchObject({
+      '@context': 'http://localhost:3000/.well-known/context.jsonld',
+      '@id': project3Uri,
+      '@type': 'pair:Project',
+      'pair:label': 'myProject 3'
+    });
+  });
 });

--- a/src/middleware/tests/ldp/content-negotiation.test.js
+++ b/src/middleware/tests/ldp/content-negotiation.test.js
@@ -1,0 +1,110 @@
+const urlJoin = require('url-join');
+const fetch = require('node-fetch');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const { fetchServer } = require('../utils');
+const CONFIG = require('../config');
+const initialize = require('./initialize');
+
+jest.setTimeout(20000);
+let broker;
+
+beforeAll(async () => {
+  broker = await initialize();
+});
+
+afterAll(async () => {
+  await broker.stop();
+});
+
+describe('Content negotiation', () => {
+  const containerUri = urlJoin(CONFIG.HOME_URL, 'resources');
+  let resourceUri;
+
+  test('Post resource in JSON-LD', async () => {
+    const { headers } = await fetchServer(containerUri, {
+      method: 'POST',
+      body: {
+        '@context': {
+          '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
+        },
+        '@type': 'Project',
+        description: 'myProject',
+        label: 'myLabel'
+      }
+    });
+
+    resourceUri = headers.get('Location');
+
+    expect(resourceUri).not.toBeNull();
+  });
+
+  test('Get resource in Turtle format', async () => {
+    const { body } = await fetchServer(resourceUri, {
+      headers: new fetch.Headers({
+        Accept: MIME_TYPES.TURTLE
+      })
+    });
+
+    expect(body).toMatch(new RegExp(`<${resourceUri}> a pair:Project`));
+    expect(body).toMatch(new RegExp(`pair:description.*"myProject"`));
+    expect(body).toMatch(new RegExp(`pair:label.*"myLabel"`));
+  });
+
+  test('Get resource in N-Triples format', async () => {
+    const { body } = await fetchServer(resourceUri, {
+      headers: new fetch.Headers({
+        Accept: MIME_TYPES.TRIPLE
+      })
+    });
+
+    expect(body).toMatch(
+      new RegExp(
+        `<${resourceUri}>.*<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://virtual-assembly.org/ontologies/pair#Project>`
+      )
+    );
+    expect(body).toMatch(
+      new RegExp(`<${resourceUri}>.*<http://virtual-assembly.org/ontologies/pair#description> "myProject"`)
+    );
+    expect(body).toMatch(new RegExp(`<${resourceUri}>.*<http://virtual-assembly.org/ontologies/pair#label> "myLabel"`));
+  });
+
+  test('Get container in Turtle format', async () => {
+    const { body } = await fetchServer(containerUri, {
+      headers: new fetch.Headers({
+        Accept: MIME_TYPES.TURTLE
+      })
+    });
+
+    expect(body).toMatch(new RegExp(`<${containerUri}> a ldp:BasicContainer, ldp:Container`));
+    expect(body).toMatch(new RegExp(`ldp:contains <${resourceUri}>`));
+
+    expect(body).toMatch(new RegExp(`<${resourceUri}> a pair:Project`));
+    expect(body).toMatch(new RegExp(`pair:description.*"myProject"`));
+    expect(body).toMatch(new RegExp(`pair:label.*"myLabel"`));
+  });
+
+  test('Get container in N-Triples format', async () => {
+    const { body } = await fetchServer(containerUri, {
+      headers: new fetch.Headers({
+        Accept: MIME_TYPES.TRIPLE
+      })
+    });
+
+    expect(body).toMatch(
+      new RegExp(
+        `<${containerUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#BasicContainer>`
+      )
+    );
+    expect(body).toMatch(
+      new RegExp(
+        `<${containerUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container>`
+      )
+    );
+    expect(body).toMatch(new RegExp(`<${containerUri}> <http://www.w3.org/ns/ldp#contains> <${resourceUri}>`));
+    expect(body).toMatch(
+      new RegExp(
+        `<${resourceUri}>.*<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://virtual-assembly.org/ontologies/pair#Project>`
+      )
+    );
+  });
+});

--- a/src/middleware/tests/ldp/resource.test.js
+++ b/src/middleware/tests/ldp/resource.test.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { quad, namedNode, blankNode, literal } = require('rdf-data-model');
 const CONFIG = require('../config');
 const initialize = require('./initialize');
@@ -39,22 +38,15 @@ describe('Resource CRUD operations', () => {
           description: 'The place to be'
         }
       },
-      contentType: MIME_TYPES.JSON,
       containerUri: `${CONFIG.HOME_URL}resources`
     });
 
-    project1 = await broker.call('ldp.resource.get', {
-      resourceUri,
-      accept: MIME_TYPES.JSON
-    });
+    project1 = await broker.call('ldp.resource.get', { resourceUri });
     expect(project1['pair:description']).toBe('myProject');
   }, 20000);
 
   test('Get resource', async () => {
-    const newProject = await broker.call('ldp.resource.get', {
-      accept: MIME_TYPES.JSON,
-      resourceUri: project1['@id']
-    });
+    const newProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
     expect(newProject).toMatchObject({
       '@context': 'http://localhost:3000/.well-known/context.jsonld',
       '@id': project1['@id'],
@@ -83,15 +75,10 @@ describe('Resource CRUD operations', () => {
         hasLocation: {
           label: 'Nantes'
         }
-      },
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
+      }
     });
 
-    const updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    const updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -124,16 +111,9 @@ describe('Resource CRUD operations', () => {
         }
       ]
     };
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    let updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    let updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -156,16 +136,9 @@ describe('Resource CRUD operations', () => {
       }
     ];
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -187,16 +160,9 @@ describe('Resource CRUD operations', () => {
       }
     ];
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -226,16 +192,9 @@ describe('Resource CRUD operations', () => {
       }
     ];
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -256,16 +215,9 @@ describe('Resource CRUD operations', () => {
       }
     ];
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -284,16 +236,9 @@ describe('Resource CRUD operations', () => {
 
     resourceUpdated.hasLocation = undefined;
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject['pair:hasLocation']).toBeUndefined();
 
@@ -301,16 +246,9 @@ describe('Resource CRUD operations', () => {
       { 'petr:endingTime': '2021-10-07T09:40:56.131Z', 'petr:startingTime': '2021-10-07T06:40:56.123Z' }
     ];
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -325,16 +263,9 @@ describe('Resource CRUD operations', () => {
       { 'petr:startingTime': '2021-10-07T10:44:54.883Z', 'petr:endingTime': '2021-10-07T16:44:54.888Z' }
     ];
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project1['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project1['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -363,14 +294,10 @@ describe('Resource CRUD operations', () => {
 
     const resourceUri = await broker.call('ldp.container.post', {
       resource: resourceToPost,
-      contentType: MIME_TYPES.JSON,
       containerUri: `${CONFIG.HOME_URL}resources2`
     });
 
-    project2 = await broker.call('ldp.resource.get', {
-      resourceUri,
-      accept: MIME_TYPES.JSON
-    });
+    project2 = await broker.call('ldp.resource.get', { resourceUri });
 
     expect(project2).toMatchObject({
       'pair:hasLocation': {
@@ -398,14 +325,10 @@ describe('Resource CRUD operations', () => {
 
     const resourceUri3 = await broker.call('ldp.container.post', {
       resource: resourceToPost,
-      contentType: MIME_TYPES.JSON,
       containerUri: `${CONFIG.HOME_URL}resources2`
     });
 
-    const project3 = await broker.call('ldp.resource.get', {
-      resourceUri: resourceUri3,
-      accept: MIME_TYPES.JSON
-    });
+    const project3 = await broker.call('ldp.resource.get', { resourceUri: resourceUri3 });
 
     expect(project3).toMatchObject({
       'pair:hasLocation': [
@@ -441,14 +364,10 @@ describe('Resource CRUD operations', () => {
 
     const resourceUri4 = await broker.call('ldp.container.post', {
       resource: resourceToPost,
-      contentType: MIME_TYPES.JSON,
       containerUri: `${CONFIG.HOME_URL}resources2`
     });
 
-    const project4 = await broker.call('ldp.resource.get', {
-      resourceUri: resourceUri4,
-      accept: MIME_TYPES.JSON
-    });
+    const project4 = await broker.call('ldp.resource.get', { resourceUri: resourceUri4 });
 
     expect(project4).toMatchObject({
       'pair:hasLocation': {
@@ -483,16 +402,9 @@ describe('Resource CRUD operations', () => {
       ]
     };
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    let updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project2['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    let updatedProject = await broker.call('ldp.resource.get', { resourceUri: project2['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -527,16 +439,9 @@ describe('Resource CRUD operations', () => {
       }
     ];
 
-    await broker.call('ldp.resource.put', {
-      resource: resourceUpdated,
-      accept: MIME_TYPES.JSON,
-      contentType: MIME_TYPES.JSON
-    });
+    await broker.call('ldp.resource.put', { resource: resourceUpdated });
 
-    updatedProject = await broker.call('ldp.resource.get', {
-      resourceUri: project2['@id'],
-      accept: MIME_TYPES.JSON
-    });
+    updatedProject = await broker.call('ldp.resource.get', { resourceUri: project2['@id'] });
 
     expect(updatedProject).toMatchObject({
       'pair:description': 'myProjectUpdatedAgain',
@@ -560,7 +465,6 @@ describe('Resource CRUD operations', () => {
         '@type': 'Theme',
         label: 'Permaculture'
       },
-      contentType: MIME_TYPES.JSON,
       slug: 'Permaculture'
     });
 
@@ -576,8 +480,7 @@ describe('Resource CRUD operations', () => {
         hasTopic: {
           '@id': themeUri
         }
-      },
-      contentType: MIME_TYPES.JSON
+      }
     });
 
     // Remove the relation to the theme
@@ -589,15 +492,11 @@ describe('Resource CRUD operations', () => {
         '@type': 'Project',
         '@id': project1['@id'],
         label: 'myTitle'
-      },
-      contentType: MIME_TYPES.JSON
+      }
     });
 
     // Ensure the theme has not been deleted
-    const theme = await broker.call('ldp.resource.get', {
-      resourceUri: themeUri,
-      accept: MIME_TYPES.JSON
-    });
+    const theme = await broker.call('ldp.resource.get', { resourceUri: themeUri });
 
     expect(theme).toMatchObject({
       '@id': themeUri,
@@ -616,7 +515,6 @@ describe('Resource CRUD operations', () => {
         '@type': 'Project',
         label: 'SemanticApps'
       },
-      contentType: MIME_TYPES.JSON,
       slug: 'SemApps'
     });
 
@@ -636,14 +534,10 @@ describe('Resource CRUD operations', () => {
           namedNode('http://virtual-assembly.org/ontologies/pair#label'),
           literal('SemanticApps')
         )
-      ],
-      contentType: MIME_TYPES.JSON
+      ]
     });
 
-    const project = await broker.call('ldp.resource.get', {
-      resourceUri: projectUri,
-      accept: MIME_TYPES.JSON
-    });
+    const project = await broker.call('ldp.resource.get', { resourceUri: projectUri });
 
     expect(project).toMatchObject({
       '@id': projectUri,
@@ -662,7 +556,6 @@ describe('Resource CRUD operations', () => {
         '@type': 'Project',
         label: 'ActivityPods'
       },
-      contentType: MIME_TYPES.JSON,
       slug: 'ActivityPods'
     });
 
@@ -680,14 +573,10 @@ describe('Resource CRUD operations', () => {
           namedNode('http://virtual-assembly.org/ontologies/pair#Place')
         ),
         quad(blankNode('b_0'), namedNode('http://virtual-assembly.org/ontologies/pair#label'), literal('Paris'))
-      ],
-      contentType: MIME_TYPES.JSON
+      ]
     });
 
-    let project = await broker.call('ldp.resource.get', {
-      resourceUri: projectUri,
-      accept: MIME_TYPES.JSON
-    });
+    let project = await broker.call('ldp.resource.get', { resourceUri: projectUri });
 
     expect(project).toMatchObject({
       '@id': projectUri,
@@ -712,14 +601,10 @@ describe('Resource CRUD operations', () => {
           namedNode('http://virtual-assembly.org/ontologies/pair#Place')
         ),
         quad(blankNode('b_0'), namedNode('http://virtual-assembly.org/ontologies/pair#label'), literal('Compiègne'))
-      ],
-      contentType: MIME_TYPES.JSON
+      ]
     });
 
-    project = await broker.call('ldp.resource.get', {
-      resourceUri: projectUri,
-      accept: MIME_TYPES.JSON
-    });
+    project = await broker.call('ldp.resource.get', { resourceUri: projectUri });
 
     expect(project).toMatchObject({
       '@id': projectUri,
@@ -742,11 +627,6 @@ describe('Resource CRUD operations', () => {
       resourceUri: project1['@id']
     });
 
-    await expect(
-      broker.call('ldp.resource.get', {
-        resourceUri: project1['@id'],
-        accept: MIME_TYPES.JSON
-      })
-    ).rejects.toThrow(`not found`);
+    await expect(broker.call('ldp.resource.get', { resourceUri: project1['@id'] })).rejects.toThrow(`not found`);
   }, 20000);
 });

--- a/src/middleware/tests/ldp/resource.test.js
+++ b/src/middleware/tests/ldp/resource.test.js
@@ -50,41 +50,23 @@ describe('Resource CRUD operations', () => {
     expect(project1['pair:description']).toBe('myProject');
   }, 20000);
 
-  test('Get resource in JSON-LD format', async () => {
+  test('Get resource', async () => {
     const newProject = await broker.call('ldp.resource.get', {
       accept: MIME_TYPES.JSON,
       resourceUri: project1['@id']
     });
-    expect(newProject['pair:description']).toBe('myProject');
-  }, 20000);
-
-  test('Get resource in turtle format', async () => {
-    const newProject = await broker.call('ldp.resource.get', {
-      accept: MIME_TYPES.TURTLE,
-      resourceUri: project1['@id']
+    expect(newProject).toMatchObject({
+      '@context': 'http://localhost:3000/.well-known/context.jsonld',
+      '@id': project1['@id'],
+      '@type': 'pair:Project',
+      'pair:affiliates': expect.arrayContaining([
+        'http://localhost:3000/users/guillaume',
+        'http://localhost:3000/users/sebastien'
+      ]),
+      'pair:description': 'myProject',
+      'pair:hasLocation': expect.objectContaining({ 'pair:description': 'The place to be', 'pair:label': 'Paris' }),
+      'pair:label': 'myTitle'
     });
-    expect(newProject).toMatch(new RegExp(`<${project1['@id']}>`));
-    expect(newProject).toMatch(new RegExp(`a.*pair:Project`));
-    expect(newProject).toMatch(new RegExp(`pair:description.*"myProject"`));
-    expect(newProject).toMatch(new RegExp(`pair:label.*"myTitle"`));
-  }, 20000);
-
-  test('Get resource in triple format', async () => {
-    const newProject = await broker.call('ldp.resource.get', {
-      accept: MIME_TYPES.TRIPLE,
-      resourceUri: project1['@id']
-    });
-    expect(newProject).toMatch(
-      new RegExp(
-        `<${project1['@id']}>.*<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>.*<http://virtual-assembly.org/ontologies/pair#Project>`
-      )
-    );
-    expect(newProject).toMatch(
-      new RegExp(`<${project1['@id']}>.*<http://virtual-assembly.org/ontologies/pair#description>.*"myProject"`)
-    );
-    expect(newProject).toMatch(
-      new RegExp(`<${project1['@id']}>.*<http://virtual-assembly.org/ontologies/pair#label>.*"myTitle"`)
-    );
   }, 20000);
 
   test('Put resource', async () => {

--- a/src/middleware/tests/webacl/resource.test.js
+++ b/src/middleware/tests/webacl/resource.test.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { namedNode, triple, literal } = require('@rdfjs/data-model');
 const CONFIG = require('../config');
 const initialize = require('./initialize');
@@ -30,14 +29,12 @@ describe('Permissions check on a specific resource', () => {
         type: 'Event',
         name: 'My event #1'
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 
     await expect(
       broker.call('ldp.resource.get', {
         resourceUri,
-        accept: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).rejects.toThrow('Forbidden');
@@ -63,7 +60,6 @@ describe('Permissions check on a specific resource', () => {
           type: 'Event',
           name: 'My event #1 - edited'
         },
-        contentType: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).rejects.toThrow('Forbidden');
@@ -88,7 +84,6 @@ describe('Permissions check on a specific resource', () => {
     await expect(
       broker.call('ldp.resource.get', {
         resourceUri,
-        accept: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).resolves.toBeDefined();
@@ -96,7 +91,6 @@ describe('Permissions check on a specific resource', () => {
     await expect(
       broker.call('ldp.container.get', {
         containerUri,
-        accept: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).rejects.toThrow('Forbidden');
@@ -114,7 +108,6 @@ describe('Permissions check on a specific resource', () => {
     await expect(
       broker.call('ldp.container.get', {
         containerUri,
-        accept: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).resolves.toMatchObject({
@@ -142,7 +135,6 @@ describe('Permissions check on a specific resource', () => {
     await expect(
       broker.call('ldp.resource.get', {
         resourceUri,
-        accept: MIME_TYPES.JSON,
         webId: BOB_WEBID
       })
     ).resolves.toBeDefined();
@@ -156,7 +148,6 @@ describe('Permissions check on a specific resource', () => {
           type: 'Event',
           name: 'My event #2'
         },
-        contentType: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).rejects.toThrow();
@@ -178,7 +169,6 @@ describe('Permissions check on a specific resource', () => {
           type: 'Event',
           name: 'My event #2'
         },
-        contentType: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).resolves.toBeDefined();
@@ -216,7 +206,6 @@ describe('Permissions check on a specific resource', () => {
           content: 'Welcome everybody',
           startTime: '2014-12-31T23:00:00-08:00'
         },
-        contentType: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).resolves.toBeDefined();
@@ -244,7 +233,6 @@ describe('Permissions check on a specific resource', () => {
           type: 'Event',
           name: 'My event #1 - edited'
         },
-        contentType: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).rejects.toThrow();
@@ -280,7 +268,6 @@ describe('Permissions check on a specific resource', () => {
           type: 'Event',
           name: 'My event #1 - edited'
         },
-        contentType: MIME_TYPES.JSON,
         webId: ALICE_WEBID
       })
     ).resolves.toBeDefined();

--- a/src/middleware/tests/webacl/resourceCRUD.test.js
+++ b/src/middleware/tests/webacl/resourceCRUD.test.js
@@ -1,5 +1,4 @@
 const urlJoin = require('url-join');
-const { MIME_TYPES } = require('@semapps/mime-types');
 const { getSlugFromUri } = require('@semapps/ldp');
 const { fetchServer } = require('../utils');
 const CONFIG = require('../config');
@@ -109,8 +108,7 @@ describe('middleware CRUD resource with perms', () => {
           ?auth ?p <${resourceUri}>.
           FILTER (?p IN (acl:accessTo, acl:default ) )
           ?auth ?p2 ?o  } }`,
-      webId: 'system',
-      accept: MIME_TYPES.JSON
+      webId: 'system'
     });
 
     expect(result.length).toBe(0);

--- a/src/middleware/tests/webacl/resourceCRUD.test.js
+++ b/src/middleware/tests/webacl/resourceCRUD.test.js
@@ -33,7 +33,6 @@ describe('middleware CRUD resource with perms', () => {
             description: 'myProject',
             label: 'myTitle'
           },
-          contentType: MIME_TYPES.JSON,
           containerUri: `${CONFIG.HOME_URL}resources`
         },
         { meta: { webId: 'anon' } }
@@ -51,15 +50,12 @@ describe('middleware CRUD resource with perms', () => {
           type: 'Event',
           name: 'My event #1'
         },
-        contentType: MIME_TYPES.JSON,
         containerUri: `${CONFIG.HOME_URL}resources`
       },
       { meta: { webId: ALICE_WEBID } }
     );
 
-    await expect(
-      broker.call('ldp.resource.get', { resourceUri, accept: MIME_TYPES.JSON, webId: ALICE_WEBID })
-    ).resolves.toMatchObject({
+    await expect(broker.call('ldp.resource.get', { resourceUri, webId: ALICE_WEBID })).resolves.toMatchObject({
       type: 'Event',
       name: 'My event #1'
     });

--- a/src/middleware/tests/webacl/utils.test.js
+++ b/src/middleware/tests/webacl/utils.test.js
@@ -1,4 +1,3 @@
-const { MIME_TYPES } = require('@semapps/mime-types');
 const CONFIG = require('../config');
 const initialize = require('./initialize');
 
@@ -52,11 +51,7 @@ describe('Test various actions of the webacl.resource service', () => {
       control: true
     });
 
-    const rights = await broker.call('webacl.resource.getRights', {
-      resourceUri,
-      accept: MIME_TYPES.JSON,
-      webId: ALICE_WEBID
-    });
+    const rights = await broker.call('webacl.resource.getRights', { resourceUri, webId: ALICE_WEBID });
 
     expect(rights['@graph']).toHaveLength(3);
 
@@ -89,10 +84,7 @@ describe('Test various actions of the webacl.resource service', () => {
   });
 
   test('Anonymous user cannot see Alice rights', async () => {
-    const rights = await broker.call('webacl.resource.getRights', {
-      resourceUri,
-      accept: MIME_TYPES.JSON
-    });
+    const rights = await broker.call('webacl.resource.getRights', { resourceUri });
 
     await expect(
       broker.call('webacl.resource.hasRights', {
@@ -141,11 +133,7 @@ describe('Test various actions of the webacl.resource service', () => {
       control: false
     });
 
-    const rights = await broker.call('webacl.resource.getRights', {
-      resourceUri,
-      accept: MIME_TYPES.JSON,
-      webId: BOB_WEBID
-    });
+    const rights = await broker.call('webacl.resource.getRights', { resourceUri, webId: BOB_WEBID });
 
     expect(rights['@graph']).toHaveLength(2);
 

--- a/src/middleware/tests/webacl/utils.test.js
+++ b/src/middleware/tests/webacl/utils.test.js
@@ -1,5 +1,4 @@
 const { MIME_TYPES } = require('@semapps/mime-types');
-const { namedNode, triple, literal } = require('@rdfjs/data-model');
 const CONFIG = require('../config');
 const initialize = require('./initialize');
 
@@ -29,7 +28,6 @@ describe('Test various actions of the webacl.resource service', () => {
         type: 'Event',
         name: 'My event #1'
       },
-      contentType: MIME_TYPES.JSON,
       webId: 'system'
     });
 

--- a/src/middleware/yarn.lock
+++ b/src/middleware/yarn.lock
@@ -8306,6 +8306,14 @@ mute-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
 
+n3@^1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.26.0.tgz#3d69de04bee680b9ebec9dbc1033dc1e6934d351"
+  integrity sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==
+  dependencies:
+    buffer "^6.0.3"
+    readable-stream "^4.0.0"
+
 n3@^1.6.3, n3@^1.8.0:
   version "1.23.1"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.23.1.tgz#42a5aded4802db7a3c5d22feec19bdd919190268"


### PR DESCRIPTION
Close #1226 

- Handle content negotiation in the LdpApiService so that we only exchange JSON-LD in Moleculer actions
- Improve the JsonLdService `fromRdf` and `toRdf` actions to handle Turtle and N-Triples
- Default `webacl.resource.getRights` accept param to JSON-LD aea50d18
- Remove unneeded `accept` param from `activitypub.collection.get` action a9247f2d
- Remove unneeded `accept` param from `triplestore.query` action 9ba4b1c

## Breaking changes

- The `accept` parameter has been deprecated from the following actions (if a value other than `application/ld+json` is provided, an error will be thrown):
  - `ldp.resource.get`
  - `ldp.container.get` 
- The `contentType` parameter has been deprecated from the following actions (if a value other than `application/ld+json` is provided, an error will be thrown):
  - `ldp.container.post`
  - `ldp.resource.create`
  - `ldp.resource.put` 
- The `triplestore.insert` now only accept JSON-LD objects. If you need to insert triples, use the `triplestore.update` action with `INSERT DATA { }`.
- A new `parseRawBody` middleware has been added. It must be loaded after the `negotiateContentType` middleware and before the `parseJson` middleware.
- The `parseTurtle` and `parseSparql` middlewares have been removed