### PR TITLE
chore: remove defineAction and defineServiceEvent wrappers

### DIFF
--- a/src/middleware/packages/activitypub/mixins/activities-handler.ts
+++ b/src/middleware/packages/activitypub/mixins/activities-handler.ts
@@ -1,4 +1,4 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const ActivitiesHandlerMixin = {
   dependencies: ['activitypub.side-effects'],
@@ -32,7 +32,7 @@ const ActivitiesHandlerMixin = {
     }
   },
   actions: {
-    processActivity: defineAction({
+    processActivity: {
       async handler(ctx) {
         const { key, boxType, dereferencedActivity, actorUri } = ctx.params;
 
@@ -54,7 +54,7 @@ const ActivitiesHandlerMixin = {
           return dereferencedActivity;
         }
       }
-    })
+    }
   }
 } satisfies Partial<ServiceSchema>;
 

--- a/src/middleware/packages/activitypub/mixins/bot.ts
+++ b/src/middleware/packages/activitypub/mixins/bot.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
 import { MIME_TYPES } from '@semapps/mime-types';
 import { arrayOf } from '@semapps/ldp';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { ACTOR_TYPES } from '../constants.ts';
 import { getSlugFromUri, getContainerFromUri } from '../utils.ts';
 
@@ -71,14 +71,14 @@ const BotMixin = {
     }
   },
   actions: {
-    getUri: defineAction({
+    getUri: {
       handler() {
         return this.settings.actor.uri;
       }
-    })
+    }
   },
   events: {
-    'activitypub.inbox.received': defineServiceEvent({
+    'activitypub.inbox.received': {
       handler(ctx) {
         // @ts-expect-error TS(2339): Property 'inboxReceived' does not exist on type 'S... Remove this comment to see the full error message
         if (this.inboxReceived) {
@@ -89,7 +89,7 @@ const BotMixin = {
           }
         }
       }
-    })
+    }
   },
   methods: {
     async getFollowers() {

--- a/src/middleware/packages/activitypub/services/activity-mapping.ts
+++ b/src/middleware/packages/activitypub/services/activity-mapping.ts
@@ -1,5 +1,5 @@
 import Handlebars from 'handlebars';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import matchActivity from '../utils/matchActivity.ts';
 import { ACTIVITY_TYPES } from '../constants.ts';
 
@@ -26,7 +26,7 @@ const ActivityMappingService = {
     }
   },
   actions: {
-    map: defineAction({
+    map: {
       async handler(ctx) {
         let { activity, locale, ...rest } = ctx.params;
 
@@ -85,9 +85,9 @@ const ActivityMappingService = {
           }
         }
       }
-    }),
+    },
 
-    addMapper: defineAction({
+    addMapper: {
       async handler(ctx) {
         const { match, mapping, priority = 1 } = ctx.params;
 
@@ -102,13 +102,13 @@ const ActivityMappingService = {
         // Reorder cached mappings
         this.prioritizeMappers();
       }
-    }),
+    },
 
-    getMappers: defineAction({
+    getMappers: {
       handler() {
         return this.mappers;
       }
-    })
+    }
   },
   methods: {
     matchActivity(ctx, pattern, activityOrObject) {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/activity.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/activity.ts
@@ -2,7 +2,7 @@
 import { Errors as E } from 'moleculer-web';
 import { ControlledContainerMixin } from '@semapps/ldp';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import setRightsHandler from './activity-handlers/setRightsHandler.ts';
 import { objectCurrentToId, objectIdToCurrent, arrayOf } from '../../../utils.ts';
 import { PUBLIC_URI, FULL_ACTIVITY_TYPES } from '../../../constants.ts';
@@ -32,13 +32,13 @@ const ActivityService = {
   },
   dependencies: ['ldp.container'],
   actions: {
-    forbidden: defineAction({
+    forbidden: {
       handler() {
         throw new E.ForbiddenError();
       }
-    }),
+    },
 
-    getRecipients: defineAction({
+    getRecipients: {
       async handler(ctx) {
         const { activity } = ctx.params;
         const output = [];
@@ -80,17 +80,17 @@ const ActivityService = {
         // Remove duplicates
         return [...new Set(output)];
       }
-    }),
+    },
 
-    getLocalRecipients: defineAction({
+    getLocalRecipients: {
       async handler(ctx) {
         const { activity } = ctx.params;
         const recipients = await this.actions.getRecipients({ activity }, { parentCtx: ctx });
         return recipients.filter((recipientUri: any) => this.isLocalActor(recipientUri));
       }
-    }),
+    },
 
-    isPublic: defineAction({
+    isPublic: {
       handler(ctx) {
         const { activity } = ctx.params;
         // We accept all three representations, as required by https://www.w3.org/TR/activitypub/#public-addressing
@@ -99,7 +99,7 @@ const ActivityService = {
           ? arrayOf(activity.to).some(r => publicRepresentations.includes(r))
           : false;
       }
-    })
+    }
   },
   methods: {
     isLocalActor(uri) {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/api.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/api.ts
@@ -14,7 +14,7 @@ import {
   saveDatasetMeta
 } from '@semapps/middlewares';
 
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { FULL_ACTOR_TYPES } from '../../../constants.ts';
 
 const ApiService = {
@@ -49,7 +49,7 @@ const ApiService = {
     }
   },
   actions: {
-    inbox: defineAction({
+    inbox: {
       async handler(ctx) {
         const { actorSlug, ...activity } = ctx.params;
         // @ts-expect-error TS(2339): Property 'requestUrl' does not exist on type '{}'.
@@ -64,9 +64,9 @@ const ApiService = {
         // @ts-expect-error TS(2339): Property '$statusCode' does not exist on type '{}'... Remove this comment to see the full error message
         ctx.meta.$statusCode = 202;
       }
-    }),
+    },
 
-    outbox: defineAction({
+    outbox: {
       async handler(ctx) {
         let { actorSlug, ...activity } = ctx.params;
         // @ts-expect-error TS(2339): Property 'requestUrl' does not exist on type '{}'.
@@ -89,10 +89,10 @@ const ApiService = {
         // @ts-expect-error TS(2339): Property '$statusCode' does not exist on type '{}'... Remove this comment to see the full error message
         ctx.meta.$statusCode = 201;
       }
-    })
+    }
   },
   events: {
-    'ldp.registry.registered': defineServiceEvent({
+    'ldp.registry.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'container' does not exist on type 'Optio... Remove this comment to see the full error message
         const { container } = ctx.params;
@@ -114,7 +114,7 @@ const ApiService = {
           });
         }
       }
-    })
+    }
   },
   methods: {
     getBoxesRoute(actorsPath) {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/actions/get.ts
@@ -1,6 +1,6 @@
 import { MIME_TYPES } from '@semapps/mime-types';
 import { sanitizeSparqlUri } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { getValueFromDataType } from '../../../../../utils.ts';
 
 import { Errors } from 'moleculer';
@@ -275,7 +275,7 @@ function formatResponse(
   };
 }
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -350,6 +350,6 @@ const Schema = defineAction({
       context: jsonContext || localContext
     });
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collection/index.ts
@@ -3,7 +3,7 @@ import { MIME_TYPES } from '@semapps/mime-types';
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
 // @ts-expect-error TS(2614): Module '"moleculer-web"' has no exported member 'E... Remove this comment to see the full error message
 import { Errors as E } from 'moleculer-web';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import getAction from './actions/get.ts';
 
 import { Errors } from 'moleculer';
@@ -55,13 +55,13 @@ const CollectionService = {
   },
   dependencies: ['triplestore', 'ldp.resource'],
   actions: {
-    put: defineAction({
+    put: {
       handler() {
         throw new E.ForbiddenError();
       }
-    }),
+    },
 
-    patch: defineAction({
+    patch: {
       async handler(ctx) {
         const { resourceUri: collectionUri, triplesToAdd, triplesToRemove } = ctx.params;
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type '{}'.
@@ -100,9 +100,9 @@ const CollectionService = {
           }
         }
       }
-    }),
+    },
 
-    post: defineAction({
+    post: {
       async handler(ctx) {
         if (!ctx.params.containerUri) {
           ctx.params.containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
@@ -129,9 +129,9 @@ const CollectionService = {
 
         return await ctx.call('ldp.container.post', ctx.params);
       }
-    }),
+    },
 
-    isEmpty: defineAction({
+    isEmpty: {
       /*
        * Checks if the collection is empty
        * @param collectionUri The full URI of the collection
@@ -154,9 +154,9 @@ const CollectionService = {
         });
         return Number(res[0].count.value) === 0;
       }
-    }),
+    },
 
-    includes: defineAction({
+    includes: {
       /*
        * Checks if an item is in a collection
        * @param collectionUri The full URI of the collection
@@ -180,9 +180,9 @@ const CollectionService = {
           webId: 'system'
         });
       }
-    }),
+    },
 
-    add: defineAction({
+    add: {
       /*
        * Attach an object to a collection
        * @param collectionUri The full URI of the collection
@@ -216,9 +216,9 @@ const CollectionService = {
           itemUri
         });
       }
-    }),
+    },
 
-    remove: defineAction({
+    remove: {
       /*
        * Detach an object from a collection
        * @param collectionUri The full URI of the collection
@@ -247,11 +247,11 @@ const CollectionService = {
           itemUri
         });
       }
-    }),
+    },
 
     get: getAction,
 
-    clear: defineAction({
+    clear: {
       /*
        * Empty the collection, deleting all items it contains.
        * @param collectionUri The full URI of the collection
@@ -274,9 +274,9 @@ const CollectionService = {
           webId: 'system'
         });
       }
-    }),
+    },
 
-    getOwner: defineAction({
+    getOwner: {
       /*
        * Get the owner of collections attached to actors
        * @param collectionUri The full URI of the collection
@@ -304,7 +304,7 @@ const CollectionService = {
 
         return results.length > 0 ? results[0].actorUri.value : null;
       }
-    })
+    }
   },
   methods: {
     getCollectionDataset(collectionUri) {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/collections-registry.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/collections-registry.ts
@@ -2,7 +2,7 @@ import urlJoin from 'url-join';
 import { quad, namedNode } from '@rdfjs/data-model';
 import { MIME_TYPES } from '@semapps/mime-types';
 import { getWebIdFromUri, arrayOf } from '@semapps/ldp';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { ACTOR_TYPES, FULL_ACTOR_TYPES, AS_PREFIX } from '../../../constants.ts';
 
 const CollectionsRegistryService = {
@@ -17,7 +17,7 @@ const CollectionsRegistryService = {
     this.collectionsInCreation = [];
   },
   actions: {
-    register: defineAction({
+    register: {
       async handler(ctx) {
         let { path, name, attachToTypes, ...options } = ctx.params;
         if (!name) name = path;
@@ -30,15 +30,15 @@ const CollectionsRegistryService = {
         // Persist the collection in memory
         this.registeredCollections.push({ path, name, attachToTypes, ...options });
       }
-    }),
+    },
 
-    list: defineAction({
+    list: {
       handler() {
         return this.registeredCollections;
       }
-    }),
+    },
 
-    createAndAttachCollection: defineAction({
+    createAndAttachCollection: {
       async handler(ctx) {
         const { objectUri, collection } = ctx.params;
         const {
@@ -96,9 +96,9 @@ const CollectionsRegistryService = {
 
         return collectionUri;
       }
-    }),
+    },
 
-    deleteCollection: defineAction({
+    deleteCollection: {
       async handler(ctx) {
         const { objectUri, collection } = ctx.params;
         const resourceUri = urlJoin(objectUri, collection.path);
@@ -109,9 +109,9 @@ const CollectionsRegistryService = {
           await ctx.call('activitypub.collection.delete', { resourceUri, webId: 'system' });
         }
       }
-    }),
+    },
 
-    createAndAttachMissingCollections: defineAction({
+    createAndAttachMissingCollections: {
       async handler(ctx) {
         for (const collection of this.registeredCollections) {
           this.logger.info(`Looking for containers with types: ${JSON.stringify(collection.attachToTypes)}`);
@@ -141,9 +141,9 @@ const CollectionsRegistryService = {
           }
         }
       }
-    }),
+    },
 
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         let { collection, dataset } = ctx.params;
         let { attachPredicate, ordered, summary, dereferenceItems, itemsPerPage, sortPredicate, sortOrder } =
@@ -218,7 +218,7 @@ const CollectionsRegistryService = {
           }
         }
       }
-    })
+    }
   },
   methods: {
     // Get the collections attached to the given type
@@ -263,7 +263,7 @@ const CollectionsRegistryService = {
     }
   },
   events: {
-    'ldp.resource.created': defineServiceEvent({
+    'ldp.resource.created': {
       async handler(ctx) {
         // @ts-expect-error
         const { resourceUri, newData, webId } = ctx.params;
@@ -287,9 +287,9 @@ const CollectionsRegistryService = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.updated': defineServiceEvent({
+    'ldp.resource.updated': {
       async handler(ctx) {
         // @ts-expect-error
         const { resourceUri, newData, oldData, webId } = ctx.params;
@@ -317,9 +317,9 @@ const CollectionsRegistryService = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.patched': defineServiceEvent({
+    'ldp.resource.patched': {
       async handler(ctx) {
         // @ts-expect-error
         const { resourceUri, triplesAdded, webId } = ctx.params;
@@ -349,9 +349,9 @@ const CollectionsRegistryService = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.deleted': defineServiceEvent({
+    'ldp.resource.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'oldData' does not exist on type 'Optiona... Remove this comment to see the full error message
         const { oldData } = ctx.params;
@@ -365,7 +365,7 @@ const CollectionsRegistryService = {
           );
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/follow.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/follow.ts
@@ -1,4 +1,4 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import ActivitiesHandlerMixin from '../../../mixins/activities-handler.ts';
 import { ACTIVITY_TYPES, ACTOR_TYPES } from '../../../constants.ts';
 import { collectionPermissionsWithAnonRead } from '../../../utils.ts';
@@ -31,7 +31,7 @@ const FollowService = {
     await this.broker.call('activitypub.collections-registry.register', this.settings.followingCollectionOptions);
   },
   actions: {
-    addFollower: defineAction({
+    addFollower: {
       async handler(ctx) {
         const { follower, following } = ctx.params;
 
@@ -58,9 +58,9 @@ const FollowService = {
 
         ctx.emit('activitypub.follow.added', { follower, following }, { meta: { webId: null, dataset: null } });
       }
-    }),
+    },
 
-    removeFollower: defineAction({
+    removeFollower: {
       async handler(ctx) {
         const { follower, following } = ctx.params;
 
@@ -87,9 +87,9 @@ const FollowService = {
 
         ctx.emit('activitypub.follow.removed', { follower, following }, { meta: { webId: null, dataset: null } });
       }
-    }),
+    },
 
-    isFollowing: defineAction({
+    isFollowing: {
       async handler(ctx) {
         const { follower, following } = ctx.params;
 
@@ -102,9 +102,9 @@ const FollowService = {
           itemUri: following
         });
       }
-    }),
+    },
 
-    listFollowers: defineAction({
+    listFollowers: {
       async handler(ctx) {
         const { collectionUri } = ctx.params;
 
@@ -112,9 +112,9 @@ const FollowService = {
           resourceUri: collectionUri
         });
       }
-    }),
+    },
 
-    listFollowing: defineAction({
+    listFollowing: {
       async handler(ctx) {
         const { collectionUri } = ctx.params;
 
@@ -122,9 +122,9 @@ const FollowService = {
           resourceUri: collectionUri
         });
       }
-    }),
+    },
 
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         await ctx.call('activitypub.collections-registry.updateCollectionsOptions', {
@@ -136,7 +136,7 @@ const FollowService = {
           dataset
         });
       }
-    })
+    }
   },
   activities: {
     follow: {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/inbox.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error TS(2614): Module '"moleculer-web"' has no exported member 'E... Remove this comment to see the full error message
 import { Errors as E } from 'moleculer-web';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { objectIdToCurrent, collectionPermissionsWithAnonRead } from '../../../utils.ts';
 import { ACTOR_TYPES } from '../../../constants.ts';
 import AwaitActivityMixin from '../../../mixins/await-activity.ts';
@@ -33,7 +33,7 @@ const InboxService = {
     await this.broker.call('activitypub.collections-registry.register', this.settings.collectionOptions);
   },
   actions: {
-    post: defineAction({
+    post: {
       async handler(ctx) {
         const { collectionUri, ...activity } = ctx.params;
 
@@ -158,9 +158,9 @@ const InboxService = {
           { meta: { webId: null, dataset: null } }
         );
       }
-    }),
+    },
 
-    getByDates: defineAction({
+    getByDates: {
       async handler(ctx) {
         const { collectionUri, fromDate, toDate } = ctx.params;
 
@@ -196,9 +196,9 @@ const InboxService = {
 
         return activities;
       }
-    }),
+    },
 
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         await ctx.call('activitypub.collections-registry.updateCollectionsOptions', {
@@ -206,7 +206,7 @@ const InboxService = {
           dataset
         });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/like.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/like.ts
@@ -1,4 +1,4 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import ActivitiesHandlerMixin from '../../../mixins/activities-handler.ts';
 import { ACTIVITY_TYPES, ACTOR_TYPES } from '../../../constants.ts';
 import { collectionPermissionsWithAnonRead } from '../../../utils.ts';
@@ -30,7 +30,7 @@ const LikeService = {
     await this.broker.call('activitypub.collections-registry.register', this.settings.likedCollectionOptions);
   },
   actions: {
-    addObjectToActorLikedCollection: defineAction({
+    addObjectToActorLikedCollection: {
       async handler(ctx) {
         const { actorUri, objectUri } = ctx.params;
 
@@ -44,9 +44,9 @@ const LikeService = {
           });
         }
       }
-    }),
+    },
 
-    addActorToObjectLikesCollection: defineAction({
+    addActorToObjectLikesCollection: {
       async handler(ctx) {
         const { actorUri, objectUri } = ctx.params;
 
@@ -60,9 +60,9 @@ const LikeService = {
           item: actorUri
         });
       }
-    }),
+    },
 
-    removeObjectFromActorLikedCollection: defineAction({
+    removeObjectFromActorLikedCollection: {
       async handler(ctx) {
         const { actorUri, objectUri } = ctx.params;
 
@@ -76,9 +76,9 @@ const LikeService = {
           });
         }
       }
-    }),
+    },
 
-    removeActorFromObjectLikesCollection: defineAction({
+    removeActorFromObjectLikesCollection: {
       async handler(ctx) {
         const { actorUri, objectUri } = ctx.params;
 
@@ -92,9 +92,9 @@ const LikeService = {
           });
         }
       }
-    }),
+    },
 
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         await ctx.call('activitypub.collections-registry.updateCollectionsOptions', {
@@ -106,7 +106,7 @@ const LikeService = {
           dataset
         });
       }
-    })
+    }
   },
   activities: {
     likeObject: {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/object.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/object.ts
@@ -1,7 +1,7 @@
 import { getType } from '@semapps/ldp';
 import { MIME_TYPES } from '@semapps/mime-types';
 import { OBJECT_TYPES, ACTIVITY_TYPES } from '../../../constants.ts';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const ObjectService = {
   name: 'activitypub.object' as const,
@@ -12,7 +12,7 @@ const ObjectService = {
   },
   dependencies: ['ldp.resource'],
   actions: {
-    get: defineAction({
+    get: {
       async handler(ctx) {
         const { objectUri, actorUri, ...rest } = ctx.params;
 
@@ -26,9 +26,9 @@ const ObjectService = {
           accept: MIME_TYPES.JSON
         });
       }
-    }),
+    },
 
-    wrap: defineAction({
+    wrap: {
       // If an object is passed directly, wrap it in a Create activity
       async handler(ctx) {
         const { activity } = ctx.params;
@@ -47,9 +47,9 @@ const ObjectService = {
           return activity;
         }
       }
-    }),
+    },
 
-    process: defineAction({
+    process: {
       async handler(ctx) {
         let { activity, actorUri } = ctx.params;
         let objectUri;
@@ -179,9 +179,9 @@ const ObjectService = {
 
         return activity;
       }
-    }),
+    },
 
-    createTombstone: defineAction({
+    createTombstone: {
       async handler(ctx) {
         const { resourceUri, formerType } = ctx.params;
         const expandedFormerTypes = await ctx.call('jsonld.parser.expandTypes', { types: formerType });
@@ -203,10 +203,10 @@ const ObjectService = {
           webId: 'system'
         });
       }
-    })
+    }
   },
   events: {
-    'ldp.resource.deleted': defineServiceEvent({
+    'ldp.resource.deleted': {
       async handler(ctx) {
         // Check if tombstones are globally activated
         // @ts-expect-error TS(2339): Property 'settings' does not exist on type 'Servic... Remove this comment to see the full error message
@@ -231,7 +231,7 @@ const ObjectService = {
           }
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/outbox.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/outbox.ts
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import { Errors as E } from 'moleculer-web';
 import { MIME_TYPES } from '@semapps/mime-types';
 import { getType, arrayOf } from '@semapps/ldp';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { collectionPermissionsWithAnonRead, getSlugFromUri, objectIdToCurrent } from '../../../utils.ts';
 import { ACTOR_TYPES } from '../../../constants.ts';
 import AwaitActivityMixin from '../../../mixins/await-activity.ts';
@@ -43,7 +43,7 @@ const OutboxService = {
     await this.broker.call('activitypub.collections-registry.register', this.settings.collectionOptions);
   },
   actions: {
-    post: defineAction({
+    post: {
       async handler(ctx) {
         let { collectionUri, username, transient, ...activity } = ctx.params;
         let activityUri;
@@ -174,9 +174,9 @@ const OutboxService = {
 
         return activity;
       }
-    }),
+    },
 
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         await ctx.call('activitypub.collections-registry.updateCollectionsOptions', {
@@ -184,7 +184,7 @@ const OutboxService = {
           dataset
         });
       }
-    })
+    }
   },
   methods: {
     isLocalActor(uri) {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/reply.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/reply.ts
@@ -1,5 +1,5 @@
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import ActivitiesHandlerMixin from '../../../mixins/activities-handler.ts';
 import { ACTIVITY_TYPES, OBJECT_TYPES } from '../../../constants.ts';
 import { collectionPermissionsWithAnonRead } from '../../../utils.ts';
@@ -21,7 +21,7 @@ const ReplyService = {
   },
   dependencies: ['activitypub.outbox', 'activitypub.collection'],
   actions: {
-    addReply: defineAction({
+    addReply: {
       async handler(ctx) {
         const { objectUri, replyUri } = ctx.params;
 
@@ -34,9 +34,9 @@ const ReplyService = {
 
         await ctx.call('activitypub.collection.add', { collectionUri, item: replyUri });
       }
-    }),
+    },
 
-    removeReply: defineAction({
+    removeReply: {
       async handler(ctx) {
         const { objectUri, replyUri } = ctx.params;
 
@@ -47,9 +47,9 @@ const ReplyService = {
           await ctx.call('activitypub.collection.remove', { collectionUri: object.replies, item: replyUri });
         }
       }
-    }),
+    },
 
-    removeFromAllRepliesCollections: defineAction({
+    removeFromAllRepliesCollections: {
       async handler(ctx) {
         const { objectUri } = ctx.params;
 
@@ -68,9 +68,9 @@ const ReplyService = {
           webId: 'system'
         });
       }
-    }),
+    },
 
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         await ctx.call('activitypub.collections-registry.updateCollectionsOptions', {
@@ -78,7 +78,7 @@ const ReplyService = {
           dataset
         });
       }
-    })
+    }
   },
   activities: {
     postReply: {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/share.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/share.ts
@@ -1,4 +1,4 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import ActivitiesHandlerMixin from '../../../mixins/activities-handler.ts';
 import { ACTIVITY_TYPES, OBJECT_TYPES } from '../../../constants.ts';
 import { collectionPermissionsWithAnonRead } from '../../../utils.ts';
@@ -20,7 +20,7 @@ const ShareService = {
   },
   dependencies: ['activitypub.outbox', 'activitypub.collection'],
   actions: {
-    addShare: defineAction({
+    addShare: {
       async handler(ctx) {
         const { objectUri, announce } = ctx.params;
 
@@ -34,9 +34,9 @@ const ShareService = {
         // Add the announce to the shares collection
         await ctx.call('activitypub.collection.add', { collectionUri, item: announce.id });
       }
-    }),
+    },
 
-    removeShare: defineAction({
+    removeShare: {
       async handler(ctx) {
         const { objectUri, announce } = ctx.params;
 
@@ -50,9 +50,9 @@ const ShareService = {
           });
         }
       }
-    }),
+    },
 
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         await ctx.call('activitypub.collections-registry.updateCollectionsOptions', {
@@ -60,7 +60,7 @@ const ShareService = {
           dataset
         });
       }
-    })
+    }
   },
   activities: {
     shareObject: {

--- a/src/middleware/packages/activitypub/services/activitypub/subservices/side-effects.ts
+++ b/src/middleware/packages/activitypub/services/activitypub/subservices/side-effects.ts
@@ -1,7 +1,7 @@
 import { credentialsContext } from '@semapps/crypto';
 import { arrayOf } from '@semapps/ldp';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import matchActivity from '../../../utils/matchActivity.ts';
 
 /**
@@ -18,7 +18,7 @@ const ActivitypubSideEffectsSchema = {
     this.processors = [];
   },
   actions: {
-    addProcessor: defineAction({
+    addProcessor: {
       /**
        * Add a new processor to handle activities
        */
@@ -30,9 +30,9 @@ const ActivitypubSideEffectsSchema = {
         // Sort processors by priority
         this.processors.sort((a: any, b: any) => a.priority - b.priority);
       }
-    }),
+    },
 
-    processOutbox: defineAction({
+    processOutbox: {
       /**
        * Called by activitypub.outbox.post when an activity is posted
        */
@@ -48,9 +48,9 @@ const ActivitypubSideEffectsSchema = {
 
         await job.finished();
       }
-    }),
+    },
 
-    processInbox: defineAction({
+    processInbox: {
       /**
        * Called by activitypub.inbox.post when an activity is received
        * and by activitypub.outbox.post when an activity is sent to a local actor
@@ -67,13 +67,13 @@ const ActivitypubSideEffectsSchema = {
 
         await job.finished();
       }
-    }),
+    },
 
-    getProcessors: defineAction({
+    getProcessors: {
       handler() {
         return this.processors;
       }
-    })
+    }
   },
   methods: {
     matchActivity(pattern, activity, fetcher) {

--- a/src/middleware/packages/activitypub/services/migration.ts
+++ b/src/middleware/packages/activitypub/services/migration.ts
@@ -1,9 +1,9 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const ActivitypubMigrationSchema = {
   name: 'activitypub.migration' as const,
   actions: {
-    updateCollectionsOptions: defineAction({
+    updateCollectionsOptions: {
       async handler(ctx) {
         await ctx.call('activitypub.follow.updateCollectionsOptions');
         await ctx.call('activitypub.inbox.updateCollectionsOptions');
@@ -11,9 +11,9 @@ const ActivitypubMigrationSchema = {
         await ctx.call('activitypub.like.updateCollectionsOptions');
         await ctx.call('activitypub.reply.updateCollectionsOptions');
       }
-    }),
+    },
 
-    addCollectionsToContainer: defineAction({
+    addCollectionsToContainer: {
       // This shouldn't be used in Pod provider config
       async handler(ctx) {
         const collectionsContainerUri = await ctx.call('activitypub.collection.getContainerUri');
@@ -34,7 +34,7 @@ const ActivitypubMigrationSchema = {
           webId: 'system'
         });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/activitypub/services/relay.ts
+++ b/src/middleware/packages/activitypub/services/relay.ts
@@ -1,6 +1,6 @@
 import urlJoin from 'url-join';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { ACTOR_TYPES } from '../constants.ts';
 import { delay } from '../utils.ts';
 
@@ -72,12 +72,12 @@ const RelayService = {
     this.relayActor = await this.broker.call('activitypub.actor.awaitCreateComplete', { actorUri });
   },
   actions: {
-    getActor: defineAction({
+    getActor: {
       visibility: 'public',
       handler() {
         return this.relayActor;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/auth/mixins/auth.sso.ts
+++ b/src/middleware/packages/auth/mixins/auth.sso.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'expr... Remove this comment to see the full error message
 import session from 'express-session';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import AuthMixin from './auth.ts';
 import saveRedirectUrl from '../middlewares/saveRedirectUrl.ts';
 import redirectToFront from '../middlewares/redirectToFront.ts';
@@ -20,7 +20,7 @@ const AuthSSOMixin = {
     selectSsoData: null
   },
   actions: {
-    loginOrSignup: defineAction({
+    loginOrSignup: {
       async handler(ctx) {
         const { ssoData } = ctx.params;
 
@@ -70,7 +70,7 @@ const AuthSSOMixin = {
 
         return { token, newUser };
       }
-    })
+    }
   },
   methods: {
     getApiRoutes(basePath) {

--- a/src/middleware/packages/auth/mixins/auth.ts
+++ b/src/middleware/packages/auth/mixins/auth.ts
@@ -3,7 +3,7 @@ import passport from 'passport';
 // @ts-expect-error TS(2614): Module '"moleculer-web"' has no exported member 'E... Remove this comment to see the full error message
 import { Errors as E } from 'moleculer-web';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import AuthAccountService from '../services/account.ts';
 import AuthJWTService from '../services/jwt.ts';
 
@@ -114,7 +114,7 @@ const AuthMixin = {
     }
   },
   actions: {
-    authenticate: defineAction({
+    authenticate: {
       // See https://moleculer.services/docs/0.13/moleculer-web.html#Authentication
       async handler(ctx) {
         const { route, req, res } = ctx.params;
@@ -153,9 +153,9 @@ const AuthMixin = {
         ctx.meta.webId = 'anon';
         return Promise.resolve(null);
       }
-    }),
+    },
 
-    authorize: defineAction({
+    authorize: {
       // See https://moleculer.services/docs/0.13/moleculer-web.html#Authorization
       async handler(ctx) {
         const { route, req, res } = ctx.params;
@@ -187,9 +187,9 @@ const AuthMixin = {
 
         return Promise.reject(new E.UnAuthorizedError(E.ERR_INVALID_TOKEN));
       }
-    }),
+    },
 
-    impersonate: defineAction({
+    impersonate: {
       async handler(ctx) {
         const { webId } = ctx.params;
         return await ctx.call('auth.jwt.generateServerSignedToken', {
@@ -198,7 +198,7 @@ const AuthMixin = {
           }
         });
       }
-    })
+    }
   },
   methods: {
     async validateCapability(ctx, token) {

--- a/src/middleware/packages/auth/services/account.ts
+++ b/src/middleware/packages/auth/services/account.ts
@@ -5,7 +5,7 @@ import createSlug from 'speakingurl';
 import DbService from 'moleculer-db';
 import { TripleStoreAdapter } from '@semapps/triplestore';
 import crypto from 'crypto';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 // Taken from https://stackoverflow.com/a/9204568/7900695
 const emailRegexp = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -22,7 +22,7 @@ const AuthAccountSchema = {
   },
   dependencies: ['triplestore'],
   actions: {
-    create: defineAction({
+    create: {
       async handler(ctx) {
         let { uuid, username, password, email, webId, ...rest } = ctx.params;
 
@@ -91,9 +91,9 @@ const AuthAccountSchema = {
           webId
         });
       }
-    }),
+    },
 
-    attachWebId: defineAction({
+    attachWebId: {
       async handler(ctx) {
         const { accountUri, webId } = ctx.params;
 
@@ -102,9 +102,9 @@ const AuthAccountSchema = {
           webId
         });
       }
-    }),
+    },
 
-    verify: defineAction({
+    verify: {
       async handler(ctx) {
         const { username, password } = ctx.params;
 
@@ -123,58 +123,58 @@ const AuthAccountSchema = {
           throw new Error('account.not-found');
         }
       }
-    }),
+    },
 
-    usernameExists: defineAction({
+    usernameExists: {
       async handler(ctx) {
         const { username } = ctx.params;
         const accounts = await this._find(ctx, { query: { username } });
         return accounts.length > 0;
       }
-    }),
+    },
 
-    emailExists: defineAction({
+    emailExists: {
       async handler(ctx) {
         const { email } = ctx.params;
         const accounts = await this._find(ctx, { query: { email } });
         return accounts.length > 0;
       }
-    }),
+    },
 
-    find: defineAction({
+    find: {
       /** Overwrite find method, to filter accounts with tombstone. */
       async handler(ctx) {
         /** @type {object[]} */
         const accounts = await this._find(ctx, ctx.params);
         return accounts.filter((account: any) => !account.deletedAt);
       }
-    }),
+    },
 
-    findByUsername: defineAction({
+    findByUsername: {
       async handler(ctx) {
         const { username } = ctx.params;
         const accounts = await this._find(ctx, { query: { username } });
         return accounts.length > 0 ? accounts[0] : null;
       }
-    }),
+    },
 
-    findByWebId: defineAction({
+    findByWebId: {
       async handler(ctx) {
         const { webId } = ctx.params;
         const accounts = await this._find(ctx, { query: { webId } });
         return accounts.length > 0 ? accounts[0] : null;
       }
-    }),
+    },
 
-    findByEmail: defineAction({
+    findByEmail: {
       async handler(ctx) {
         const { email } = ctx.params;
         const accounts = await this._find(ctx, { query: { email } });
         return accounts.length > 0 ? accounts[0] : null;
       }
-    }),
+    },
 
-    setPassword: defineAction({
+    setPassword: {
       async handler(ctx) {
         const { webId, password } = ctx.params;
         const hashedPassword = await this.hashPassword(password);
@@ -185,9 +185,9 @@ const AuthAccountSchema = {
           hashedPassword
         });
       }
-    }),
+    },
 
-    setNewPassword: defineAction({
+    setNewPassword: {
       async handler(ctx) {
         const { webId, token, password } = ctx.params;
         const hashedPassword = await this.hashPassword(password);
@@ -203,9 +203,9 @@ const AuthAccountSchema = {
           resetPasswordToken: undefined
         });
       }
-    }),
+    },
 
-    generateResetPasswordToken: defineAction({
+    generateResetPasswordToken: {
       async handler(ctx) {
         const { webId } = ctx.params;
         const resetPasswordToken = await this.generateResetPasswordToken();
@@ -218,18 +218,18 @@ const AuthAccountSchema = {
 
         return resetPasswordToken;
       }
-    }),
+    },
 
-    findDatasetByWebId: defineAction({
+    findDatasetByWebId: {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type '{}'.
         const webId = ctx.params.webId || ctx.meta.webId;
         const account = await ctx.call('auth.account.findByWebId', { webId });
         return account?.username;
       }
-    }),
+    },
 
-    findSettingsByWebId: defineAction({
+    findSettingsByWebId: {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type '{}'.
         const { webId } = ctx.meta;
@@ -241,9 +241,9 @@ const AuthAccountSchema = {
           preferredLocale: account.preferredLocale
         };
       }
-    }),
+    },
 
-    updateAccountSettings: defineAction({
+    updateAccountSettings: {
       async handler(ctx) {
         const { currentPassword, email, newPassword } = ctx.params;
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type '{}'.
@@ -275,9 +275,9 @@ const AuthAccountSchema = {
           ...params
         });
       }
-    }),
+    },
 
-    deleteByWebId: defineAction({
+    deleteByWebId: {
       async handler(ctx) {
         const { webId } = ctx.params;
         const account = await ctx.call('auth.account.findByWebId', { webId });
@@ -289,9 +289,9 @@ const AuthAccountSchema = {
 
         return false;
       }
-    }),
+    },
 
-    setTombstone: defineAction({
+    setTombstone: {
       // Remove email and password from an account, set deletedAt timestamp.
       async handler(ctx) {
         const { webId } = ctx.params;
@@ -308,7 +308,7 @@ const AuthAccountSchema = {
           deletedAt: new Date().toISOString()
         });
       }
-    })
+    }
   },
   methods: {
     async isValidUsername(ctx, username) {

--- a/src/middleware/packages/auth/services/auth.local.ts
+++ b/src/middleware/packages/auth/services/auth.local.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'pass... Remove this comment to see the full error message
 import { Strategy } from 'passport-local';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import AuthMixin from '../mixins/auth.ts';
 import sendToken from '../middlewares/sendToken.ts';
 import AuthMailService from './mail.ts';
@@ -53,7 +53,7 @@ const AuthLocalService = {
     }
   },
   actions: {
-    signup: defineAction({
+    signup: {
       async handler(ctx) {
         const { username, email, password, ...rest } = ctx.params;
 
@@ -90,9 +90,9 @@ const AuthLocalService = {
           throw e;
         }
       }
-    }),
+    },
 
-    login: defineAction({
+    login: {
       async handler(ctx) {
         const { username, password } = ctx.params;
 
@@ -104,9 +104,9 @@ const AuthLocalService = {
 
         return { token, webId: accountData.webId, newUser: false };
       }
-    }),
+    },
 
-    logout: defineAction({
+    logout: {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property '$statusCode' does not exist on type '{}'... Remove this comment to see the full error message
         ctx.meta.$statusCode = 302;
@@ -115,9 +115,9 @@ const AuthLocalService = {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type '{}'.
         ctx.emit('auth.disconnected', { webId: ctx.meta.webId });
       }
-    }),
+    },
 
-    redirectToForm: defineAction({
+    redirectToForm: {
       async handler(ctx) {
         if (this.settings.formUrl) {
           const formUrl = new URL(this.settings.formUrl);
@@ -134,9 +134,9 @@ const AuthLocalService = {
           throw new Error('No formUrl defined in auth.local settings');
         }
       }
-    }),
+    },
 
-    resetPassword: defineAction({
+    resetPassword: {
       async handler(ctx) {
         const { email } = ctx.params;
 
@@ -153,9 +153,9 @@ const AuthLocalService = {
           token
         });
       }
-    }),
+    },
 
-    setNewPassword: defineAction({
+    setNewPassword: {
       async handler(ctx) {
         const { email, token, password } = ctx.params;
 
@@ -167,7 +167,7 @@ const AuthLocalService = {
 
         await ctx.call('auth.account.setNewPassword', { webId: account.webId, token, password });
       }
-    })
+    }
   },
   methods: {
     getStrategy() {

--- a/src/middleware/packages/auth/services/jwt.ts
+++ b/src/middleware/packages/auth/services/jwt.ts
@@ -3,7 +3,7 @@ import path from 'path';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'json... Remove this comment to see the full error message
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 /**
  * Service that creates and validates JSON web tokens(JWT).
@@ -33,7 +33,7 @@ const AuthJwtSchema = {
     this.publicKey = fs.readFileSync(publicKeyPath);
   },
   actions: {
-    generateKeyPair: defineAction({
+    generateKeyPair: {
       handler(ctx) {
         const { privateKeyPath, publicKeyPath } = ctx.params;
 
@@ -73,16 +73,16 @@ const AuthJwtSchema = {
           );
         });
       }
-    }),
+    },
 
-    generateServerSignedToken: defineAction({
+    generateServerSignedToken: {
       async handler(ctx) {
         const { payload } = ctx.params;
         return jwt.sign(payload, this.privateKey, { algorithm: 'RS256' });
       }
-    }),
+    },
 
-    verifyServerSignedToken: defineAction({
+    verifyServerSignedToken: {
       /** Verifies that the token was signed by this server. */
       async handler(ctx) {
         const { token } = ctx.params;
@@ -92,17 +92,17 @@ const AuthJwtSchema = {
           return false;
         }
       }
-    }),
+    },
 
-    generateUnsignedToken: defineAction({
+    generateUnsignedToken: {
       async handler(ctx) {
         const { payload } = ctx.params;
         const token = jwt.sign(payload, null, { algorithm: 'none' });
         return token;
       }
-    }),
+    },
 
-    decodeToken: defineAction({
+    decodeToken: {
       // Warning, this does NOT verify if signature is valid
       async handler(ctx) {
         const { token } = ctx.params;
@@ -112,7 +112,7 @@ const AuthJwtSchema = {
           return false;
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/auth/services/mail.ts
+++ b/src/middleware/packages/auth/services/mail.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import urlJoin from 'url-join';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'mole... Remove this comment to see the full error message
 import MailService from 'moleculer-mail';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { fileURLToPath } from 'url';
 
 // @ts-expect-error TS(1470): The 'import.meta' meta-property is not allowed in ... Remove this comment to see the full error message
@@ -21,7 +21,7 @@ const AuthMailSchema = {
     transport: null
   },
   actions: {
-    sendResetPasswordEmail: defineAction({
+    sendResetPasswordEmail: {
       async handler(ctx) {
         const { account, token } = ctx.params;
 
@@ -40,7 +40,7 @@ const AuthMailSchema = {
           }
         );
       }
-    })
+    }
   },
   methods: {
     getTemplateLocale(userLocale) {

--- a/src/middleware/packages/auth/services/migration.ts
+++ b/src/middleware/packages/auth/services/migration.ts
@@ -1,11 +1,11 @@
 import { MIME_TYPES } from '@semapps/mime-types';
 import { getSlugFromUri } from '@semapps/ldp';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const AuthMigrationSchema = {
   name: 'auth.migration' as const,
   actions: {
-    migrateUsersToAccounts: defineAction({
+    migrateUsersToAccounts: {
       async handler(ctx) {
         const { usersContainer, emailPredicate, usernamePredicate } = ctx.params;
 
@@ -28,7 +28,7 @@ const AuthMigrationSchema = {
           }
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/backup/index.ts
+++ b/src/middleware/packages/backup/index.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'fs-e... Remove this comment to see the full error message
 import { emptyDirSync } from 'fs-extra';
 import pathModule from 'path';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import fsCopy from './utils/fsCopy.ts';
 import ftpCopy from './utils/ftpCopy.ts';
 import rsyncCopy from './utils/rsyncCopy.ts';
@@ -59,14 +59,14 @@ const BackupService = {
     }
   },
   actions: {
-    backupAll: defineAction({
+    backupAll: {
       async handler(ctx) {
         await this.actions.backupDatasets({}, { parentCtx: ctx });
         await this.actions.backupOtherDirs({}, { parentCtx: ctx });
       }
-    }),
+    },
 
-    backupDatasets: defineAction({
+    backupDatasets: {
       async handler(ctx) {
         // Generate a new backup of all datasets
         const datasets = await ctx.call('triplestore.dataset.list');
@@ -87,9 +87,9 @@ const BackupService = {
           emptyDirSync(backupsDirPath);
         }
       }
-    }),
+    },
 
-    backupOtherDirs: defineAction({
+    backupOtherDirs: {
       async handler(ctx) {
         const { otherDirsPaths } = this.settings.localServer;
 
@@ -103,9 +103,9 @@ const BackupService = {
           await this.actions.copyToRemoteServer({ path, subDir: key }, { parentCtx: ctx });
         }
       }
-    }),
+    },
 
-    copyToRemoteServer: defineAction({
+    copyToRemoteServer: {
       async handler(ctx) {
         const { path, subDir } = ctx.params;
         const { copyMethod, remoteServer } = this.settings;
@@ -137,9 +137,9 @@ const BackupService = {
           return false;
         }
       }
-    }),
+    },
 
-    deleteDataset: defineAction({
+    deleteDataset: {
       params: {
         dataset: { type: 'string' }
       },
@@ -177,9 +177,9 @@ const BackupService = {
           }
         }
       }
-    }),
+    },
 
-    listBackupsForDataset: defineAction({
+    listBackupsForDataset: {
       // Returns an array of file paths to the backups relative to `this.settings.localServer.fusekiBase`.
       async handler(ctx) {
         const { dataset } = ctx.params;
@@ -195,7 +195,7 @@ const BackupService = {
 
         return filenames;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/keys/key-container.ts
+++ b/src/middleware/packages/crypto/keys/key-container.ts
@@ -1,7 +1,7 @@
 import { ControlledContainerMixin } from '@semapps/ldp';
 // @ts-expect-error TS(2614): Module '"moleculer-web"' has no exported member 'E... Remove this comment to see the full error message
 import { Errors as E } from 'moleculer-web';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { arrayOf } from '../utils/utils.ts';
 import { KEY_TYPES } from '../constants.ts';
 
@@ -51,13 +51,13 @@ const KeysContainerSchema = {
     }
   },
   actions: {
-    forbidden: defineAction({
+    forbidden: {
       async handler(ctx) {
         throw new E.ForbiddenError();
       }
-    }),
+    },
 
-    get: defineAction({
+    get: {
       /**
        * Get action that sets the multikey context and multikey type for those keys correctly. This is required by the spec.
        * See:
@@ -81,7 +81,7 @@ const KeysContainerSchema = {
 
         return resource;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/keys/keys.ts
+++ b/src/middleware/packages/crypto/keys/keys.ts
@@ -5,7 +5,7 @@ import { MIME_TYPES } from '@semapps/mime-types';
 import { sec } from '@semapps/ontologies';
 // @ts-expect-error TS(7016): Could not find a declaration file for module '@dig... Remove this comment to see the full error message
 import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { arrayOf } from '../utils/utils.ts';
 import { KEY_TYPES } from '../constants.ts';
 import KeyContainerService from './key-container.ts';
@@ -80,7 +80,7 @@ const KeysService = {
      * Returns all available keys of the given `keyType` in the `/key` container.
      * If none is available `[]` is returned.
      */
-    getByType: defineAction({
+    getByType: {
       params: {
         keyType: { type: 'string' },
         webId: { type: 'string', optional: true }
@@ -104,7 +104,7 @@ const KeysService = {
 
         return matchedKeys;
       }
-    }),
+    },
 
     /**
      * Gets the keys by type that are present in the actor's webId.
@@ -112,7 +112,7 @@ const KeysService = {
      * TODO: If this becomes a performance bottleneck, we can use SPARQL queries.
      * @returns An array of keys present in the webId.
      */
-    getOrCreateWebIdKeys: defineAction({
+    getOrCreateWebIdKeys: {
       params: {
         keyType: { type: 'string' },
         webId: { type: 'string' }
@@ -148,14 +148,14 @@ const KeysService = {
           })
         );
       }
-    }),
+    },
 
     /**
      * Returns a signing key instance for a given key or key type. If no key is available, a new one is created.
      * Currently supports Ed25519Multikey only.
      * @returns {object} The Multikey object.
      */
-    getMultikey: defineAction({
+    getMultikey: {
       params: {
         webId: { type: 'string' },
         // @ts-expect-error TS(2322): Type '{ type: "object"; optional: true; }' is not ... Remove this comment to see the full error message
@@ -192,7 +192,7 @@ const KeysService = {
 
         return keyObject;
       }
-    }),
+    },
 
     /**
      * Generates key, stores it in the `/key` container.
@@ -200,7 +200,7 @@ const KeysService = {
      * If `attachToWebId` is true (not default), it will publish the key and attach the key to the webId document.
      * @returns {object} The key resource as located in the `/key` container.
      */
-    createKeyForActor: defineAction({
+    createKeyForActor: {
       params: {
         webId: { type: 'string' },
         keyType: { type: 'string' },
@@ -239,13 +239,13 @@ const KeysService = {
 
         return keyObject;
       }
-    }),
+    },
 
     /**
      * Generate a key of the type specified.
      * Type must be in the form of a {@link KEY_TYPES} URI.
      */
-    generateKey: defineAction({
+    generateKey: {
       params: {
         keyType: { type: 'string' }
       },
@@ -261,13 +261,13 @@ const KeysService = {
 
         throw new Error('Key type not supported.');
       }
-    }),
+    },
 
     /**
      * Generate ED25519 key pair.
      * @returns {object} Key pair in [MultiKey format](https://www.w3.org/TR/controller-document/#Multikey).
      */
-    generateEd25519Key: defineAction({
+    generateEd25519Key: {
       params: {},
       async handler() {
         const keyPair = await Ed25519Multikey.generate();
@@ -281,7 +281,7 @@ const KeysService = {
         keyObject['@type'] = [KEY_TYPES.ED25519, KEY_TYPES.MULTI_KEY, KEY_TYPES.VERIFICATION_METHOD];
         return keyObject;
       }
-    }),
+    },
 
     /**
      * Generate a RSA key pair and returns public and private key in spki pkcs8 PEM encodings, respectively.
@@ -292,7 +292,7 @@ const KeysService = {
      *    'privateKeyPem': privateKeyPkcs8PemString }
      *  ```
      */
-    generateRsaKey: defineAction({
+    generateRsaKey: {
       params: {},
       async handler() {
         return new Promise((resolve, reject) => {
@@ -323,7 +323,7 @@ const KeysService = {
           );
         });
       }
-    }),
+    },
 
     /**
      * Attaches a given key to the webId document.
@@ -334,7 +334,7 @@ const KeysService = {
      * @param {string} ctx.keyId The id of the public-private key pair resource.
      * @param {string} ctx.keyObject Alternatively, the public-private key pair resource itself.
      */
-    attachPublicKeyToWebId: defineAction({
+    attachPublicKeyToWebId: {
       params: {
         webId: { type: 'string' },
         keyId: { type: 'string', optional: true },
@@ -393,10 +393,10 @@ const KeysService = {
           webId
         });
       }
-    }),
+    },
 
     /** Given a key object, remove the key from the webId document. */
-    detachFromWebId: defineAction({
+    detachFromWebId: {
       params: {
         webId: { type: 'string' },
         publicKeyId: { type: 'string' }
@@ -414,10 +414,10 @@ const KeysService = {
           webId
         });
       }
-    }),
+    },
 
     /** Given a local key (stored in `/key`), add the public key part to the `/public-key` container. */
-    publishPublicKeyLocally: defineAction({
+    publishPublicKeyLocally: {
       params: {
         keyId: { type: 'string', optional: true },
         // @ts-expect-error TS(2322): Type '{ type: "object"; optional: true; }' is not ... Remove this comment to see the full error message
@@ -456,12 +456,12 @@ const KeysService = {
         });
         return publicKeyUri;
       }
-    }),
+    },
 
     /**
      * Removes key from `key` container and detaches it from webId document and `public-key` container.
      */
-    delete: defineAction({
+    delete: {
       params: {
         resourceUri: { type: 'string', optional: true },
         // @ts-expect-error TS(2322): Type '{ type: "object"; optional: true; }' is not ... Remove this comment to see the full error message
@@ -488,10 +488,10 @@ const KeysService = {
           await this.actions.detachFromWebId({ webId, publicKeyId }, { parentCtx: ctx });
         }
       }
-    }),
+    },
 
     /** Delete all keys belonging to an actor. */
-    deleteAllKeysForWebId: defineAction({
+    deleteAllKeysForWebId: {
       params: {
         webId: { type: 'string' }
       },
@@ -502,14 +502,14 @@ const KeysService = {
           await ctx.call('keys.delete', { resourceUri: key.id, webId });
         }
       }
-    }),
+    },
 
     /**
      * Fetches remote keys from a webId (publicKey or assertionMethod field).
      * Returns all keys of the given `keyType` or all, if `keyType` is `null`.
      * Does not filter outdated keys.
      */
-    getRemotePublicKeys: defineAction({
+    getRemotePublicKeys: {
       params: {
         webId: { type: 'string' },
         keyType: { type: 'string', optional: true, default: KEY_TYPES.RSA, nullable: true }
@@ -555,12 +555,12 @@ const KeysService = {
 
         return keyObjects;
       }
-    }),
+    },
 
     /**
      * Returns the public key part of a given `keyObject`.
      */
-    getPublicKeyObject: defineAction({
+    getPublicKeyObject: {
       params: {
         // @ts-expect-error TS(2322): Type '{ type: "object"; optional: true; }' is not ... Remove this comment to see the full error message
         keyObject: { type: 'object', optional: true },
@@ -600,9 +600,9 @@ const KeysService = {
         /** @type {never} Not implemented yet. */
         throw new Error(`Key type ${keyType} not supported.`);
       }
-    }),
+    },
 
-    findPrivateKeyUri: defineAction({
+    findPrivateKeyUri: {
       params: {
         publicKeyUri: { type: 'string' }
       },
@@ -621,7 +621,7 @@ const KeysService = {
 
         return queryResult[0]?.privateKey?.value;
       }
-    })
+    }
   },
   methods: {},
   hooks: {
@@ -636,14 +636,14 @@ const KeysService = {
     }
   },
   events: {
-    'keys.migration.migrated': defineServiceEvent({
+    'keys.migration.migrated': {
       async handler() {
         // @ts-expect-error TS(2339): Property 'isMigrated' does not exist on type 'Serv... Remove this comment to see the full error message
         this.isMigrated = true;
       }
-    }),
+    },
 
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId } = ctx.params;
@@ -680,7 +680,7 @@ const KeysService = {
           this.actions.createKeyForActor({ webId, attachToWebId: true, keyType: KEY_TYPES.ED25519 }, { parentCtx: ctx })
         ]);
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/keys/migration.ts
+++ b/src/middleware/packages/crypto/keys/migration.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
 import fs from 'fs';
 import path from 'path';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { KEY_TYPES } from '../constants.ts';
 
 /** @type {import('moleculer').ServiceSchema} */
@@ -12,7 +12,7 @@ const KeysMigrationSchema = {
     podProvider: false
   },
   actions: {
-    migrateKeysToDb: defineAction({
+    migrateKeysToDb: {
       /** Migrates cryptographic RSA keys from filesystem storage to the `/keys` ldp containers */
       async handler(ctx) {
         // Check actorsKeyPairsDir for existing keys.
@@ -112,9 +112,9 @@ const KeysMigrationSchema = {
         this.logger.info('=== Keys migration completed ===');
         await ctx.emit('keys.migration.migrated');
       }
-    }),
+    },
 
-    isMigrated: defineAction({
+    isMigrated: {
       /** Returns true, if the server has migrated to the new keys service yet, i.e. keys are stored in the user dataset, not on fs. */
       async handler() {
         // If the `actorsKeyPairsDir` setting is not set, we assume migration has happened or was never needed.
@@ -133,7 +133,7 @@ const KeysMigrationSchema = {
 
         return !anyKeyFile;
       }
-    })
+    }
   },
   methods: {
     // Delete old public key blank node and data from the webId.

--- a/src/middleware/packages/crypto/keys/public-key-container.ts
+++ b/src/middleware/packages/crypto/keys/public-key-container.ts
@@ -2,7 +2,7 @@ import { triple, namedNode } from '@rdfjs/data-model';
 import { ControlledContainerMixin } from '@semapps/ldp';
 // @ts-expect-error TS(2614): Module '"moleculer-web"' has no exported member 'E... Remove this comment to see the full error message
 import { Errors as E } from 'moleculer-web';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { KEY_TYPES } from '../constants.ts';
 
 /**
@@ -51,11 +51,11 @@ const KeysPublicContainerSchema = {
   },
 
   actions: {
-    forbidden: defineAction({
+    forbidden: {
       async handler(ctx) {
         throw new E.ForbiddenError();
       }
-    })
+    }
   },
 
   hooks: {

--- a/src/middleware/packages/crypto/signature/http-signatures.ts
+++ b/src/middleware/packages/crypto/signature/http-signatures.ts
@@ -5,7 +5,7 @@ import { parseRequest, verifySignature } from 'http-signature';
 import { createAuthzHeader, createSignatureString } from 'http-signature-header';
 // @ts-expect-error TS(2614): Module '"moleculer-web"' has no exported member 'E... Remove this comment to see the full error message
 import { Errors as E } from 'moleculer-web';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { KEY_TYPES } from '../constants.ts';
 import { arrayOf } from '../utils/utils.ts';
 
@@ -13,7 +13,7 @@ const HttpSignatureService = {
   // TODO: Rename to signature.http-signatures in a major release.
   name: 'signature' as const,
   actions: {
-    generateSignatureHeaders: defineAction({
+    generateSignatureHeaders: {
       async handler(ctx) {
         const { url, method, body, actorUri } = ctx.params;
         // TODO: Use new service.
@@ -49,16 +49,16 @@ const HttpSignatureService = {
 
         return headers;
       }
-    }),
+    },
 
-    verifyDigest: defineAction({
+    verifyDigest: {
       async handler(ctx) {
         const { body, headers } = ctx.params;
         return headers.digest ? this.buildDigest(body) === headers.digest : true;
       }
-    }),
+    },
 
-    verifyHttpSignature: defineAction({
+    verifyHttpSignature: {
       /**
        * Given url, path, method, headers, validates a given http signature.
        * If the signature is valid, it returns the actorUri and the publicKeyPem used to verify the signature.
@@ -110,9 +110,9 @@ const HttpSignatureService = {
 
         return { isValid: keyValid, actorUri, publicKeyPem };
       }
-    }),
+    },
 
-    authenticate: defineAction({
+    authenticate: {
       // See https://moleculer.services/docs/0.13/moleculer-web.html#Authentication
       async handler(ctx) {
         const { route, req, res } = ctx.params;
@@ -134,9 +134,9 @@ const HttpSignatureService = {
         ctx.meta.webId = 'anon';
         return Promise.resolve(null);
       }
-    }),
+    },
 
-    authorize: defineAction({
+    authorize: {
       // See https://moleculer.services/docs/0.13/moleculer-web.html#Authorization
       async handler(ctx) {
         const { route, req, res } = ctx.params;
@@ -158,7 +158,7 @@ const HttpSignatureService = {
         ctx.meta.webId = 'anon';
         return Promise.reject(new E.UnAuthorizedError(E.ERR_NO_TOKEN));
       }
-    })
+    }
   },
   methods: {
     buildDigest(body) {

--- a/src/middleware/packages/crypto/signature/keypair.ts
+++ b/src/middleware/packages/crypto/signature/keypair.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import { generateKeyPair } from 'crypto';
 import { namedNode, blankNode, literal, triple } from '@rdfjs/data-model';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { KEY_TYPES } from '../constants.ts';
 
 /**
@@ -31,7 +31,7 @@ const SignatureService = {
     this.isMigrated = await this.broker.call('keys.migration.isMigrated');
   },
   actions: {
-    generate: defineAction({
+    generate: {
       async handler(ctx) {
         const { actorUri } = ctx.params;
 
@@ -77,9 +77,9 @@ const SignatureService = {
           );
         });
       }
-    }),
+    },
 
-    delete: defineAction({
+    delete: {
       async handler(ctx) {
         const { actorUri } = ctx.params;
 
@@ -98,9 +98,9 @@ const SignatureService = {
           console.log(`Could not delete key pair for actor ${actorUri}`);
         }
       }
-    }),
+    },
 
-    attachPublicKey: defineAction({
+    attachPublicKey: {
       async handler(ctx) {
         const { actorUri } = ctx.params;
 
@@ -132,9 +132,9 @@ const SignatureService = {
           });
         }
       }
-    }),
+    },
 
-    getPaths: defineAction({
+    getPaths: {
       async handler(ctx) {
         const { actorUri } = ctx.params;
 
@@ -147,9 +147,9 @@ const SignatureService = {
         }
         throw new Error(`No account found with URI ${actorUri}`);
       }
-    }),
+    },
 
-    get: defineAction({
+    get: {
       async handler(ctx) {
         const { actorUri } = ctx.params;
 
@@ -171,9 +171,9 @@ const SignatureService = {
           return {};
         }
       }
-    }),
+    },
 
-    getRemotePublicKey: defineAction({
+    getRemotePublicKey: {
       async handler(ctx) {
         const { actorUri } = ctx.params;
 
@@ -200,7 +200,7 @@ const SignatureService = {
           return actor.publicKey.publicKeyPem;
         }
       }
-    })
+    }
   },
   hooks: {
     before: {
@@ -229,7 +229,7 @@ const SignatureService = {
     }
   },
   events: {
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId } = ctx.params;
@@ -243,14 +243,14 @@ const SignatureService = {
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.attachPublicKey({ actorUri: webId }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'keys.migration.migrated': defineServiceEvent({
+    'keys.migration.migrated': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'isMigrated' does not exist on type 'Serv... Remove this comment to see the full error message
         this.isMigrated = true;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/signature/proxy.ts
+++ b/src/middleware/packages/crypto/signature/proxy.ts
@@ -4,7 +4,7 @@ import { parseHeader, parseFile, saveDatasetMeta } from '@semapps/middlewares';
 import fetch from 'node-fetch';
 // @ts-expect-error TS(2614): Module '"moleculer-web"' has no exported member 'E... Remove this comment to see the full error message
 import { Errors as E } from 'moleculer-web';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const stream2buffer = (stream: any) => {
   return new Promise((resolve, reject) => {
@@ -42,7 +42,7 @@ const ProxyService = {
     }
   },
   actions: {
-    api_query: defineAction({
+    api_query: {
       async handler(ctx) {
         const url = ctx.params.id;
         const method = ctx.params.method || 'GET';
@@ -91,9 +91,9 @@ const ProxyService = {
           ctx.meta.$statusMessage = e.message;
         }
       }
-    }),
+    },
 
-    query: defineAction({
+    query: {
       async handler(ctx) {
         let { url, method, headers, body, actorUri } = ctx.params;
 
@@ -151,10 +151,10 @@ const ProxyService = {
           };
         }
       }
-    })
+    }
   },
   events: {
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId } = ctx.params;
@@ -170,7 +170,7 @@ const ProxyService = {
           }
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/verifiable-credentials/challenge-service.ts
+++ b/src/middleware/packages/crypto/verifiable-credentials/challenge-service.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 /**
  * Service to generate challenges upon request.
@@ -19,7 +19,7 @@ const ChallengeService = {
     this.challenges = {};
   },
   actions: {
-    create: defineAction({
+    create: {
       handler() {
         if (!this.cleanupTimerSetUp) {
           this.startCleanupTimer();
@@ -30,21 +30,21 @@ const ChallengeService = {
 
         return { challenge };
       }
-    }),
+    },
 
-    getAll: defineAction({
+    getAll: {
       handler() {
         return this.challenges;
       }
-    }),
+    },
 
-    clearAll: defineAction({
+    clearAll: {
       handler() {
         this.challenges = {};
       }
-    }),
+    },
 
-    validate: defineAction({
+    validate: {
       handler(ctx) {
         const { challenge } = ctx.params;
 
@@ -63,9 +63,9 @@ const ChallengeService = {
 
         return { valid: true };
       }
-    }),
+    },
 
-    cleanElapsed: defineAction({
+    cleanElapsed: {
       handler() {
         const now = Date.now();
         // @ts-expect-error TS(2339): Property 'issued' does not exist on type 'unknown'... Remove this comment to see the full error message
@@ -75,7 +75,7 @@ const ChallengeService = {
           }
         }
       }
-    })
+    }
   },
   methods: {
     startCleanupTimer() {

--- a/src/middleware/packages/crypto/verifiable-credentials/data-integrity-service.ts
+++ b/src/middleware/packages/crypto/verifiable-credentials/data-integrity-service.ts
@@ -9,7 +9,7 @@ import { DataIntegrityProof } from '@digitalbazaar/data-integrity';
 // @ts-expect-error TS(7016): Could not find a declaration file for module '@dig... Remove this comment to see the full error message
 import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
 
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { KEY_TYPES } from '../constants.ts';
 
 const {
@@ -40,7 +40,7 @@ const DataIntegrityService = {
      * Verify an object.
      * @param {object} ctx.params.object - The object to verify.
      */
-    verifyObject: defineAction({
+    verifyObject: {
       params: {
         // @ts-expect-error TS(2322): Type '{ type: "object"; }' is not assignable to ty... Remove this comment to see the full error message
         object: { type: 'object' },
@@ -68,7 +68,7 @@ const DataIntegrityService = {
 
         return jsigs.verify(object, { purpose, documentLoader: this.documentLoader, suite });
       }
-    }),
+    },
 
     /**
      * Sign an object.
@@ -78,7 +78,7 @@ const DataIntegrityService = {
      * @param {object} [ctx.params.keyObject] - The key object to use.
      * @param {string} [ctx.params.keyId] - The key ID to use.
      */
-    signObject: defineAction({
+    signObject: {
       params: {
         // @ts-expect-error TS(2322): Type '{ type: "object"; }' is not assignable to ty... Remove this comment to see the full error message
         object: { type: 'object' },
@@ -118,7 +118,7 @@ const DataIntegrityService = {
 
         return jsigs.sign(object, { purpose, documentLoader: this.documentLoader, suite });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-credential-container.ts
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-credential-container.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { ControlledContainerMixin, PseudoIdMixin } from '@semapps/ldp';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { credentialsContext, credentialsContextNoGraphProof, VC_API_PATH } from '../constants.ts';
 
 /**
@@ -52,7 +52,7 @@ const VCCredentialsContainer = {
    * We can't handle that internally so we use a copy of the context with the `@graph`s removed.
    */
   actions: {
-    get: defineAction({
+    get: {
       async handler(ctx) {
         const resource = await ctx.call('ldp.resource.get', {
           ...ctx.params,
@@ -66,9 +66,9 @@ const VCCredentialsContainer = {
         };
         return { ...resource, '@context': credentialsContext };
       }
-    }),
+    },
 
-    put: defineAction({
+    put: {
       async handler(ctx) {
         const { resource } = ctx.params;
         return await ctx.call('ldp.resource.put', {
@@ -79,9 +79,9 @@ const VCCredentialsContainer = {
           }
         });
       }
-    }),
+    },
 
-    post: defineAction({
+    post: {
       async handler(ctx) {
         const { resource } = ctx.params;
         return await ctx.call('ldp.container.post', {
@@ -93,9 +93,9 @@ const VCCredentialsContainer = {
           }
         });
       }
-    }),
+    },
 
-    list: defineAction({
+    list: {
       async handler(ctx) {
         const container = await ctx.call('ldp.container.list', {
           ...ctx.params,
@@ -103,7 +103,7 @@ const VCCredentialsContainer = {
         });
         return { ...container, '@context': credentialsContext };
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-holder-service.ts
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-holder-service.ts
@@ -12,7 +12,7 @@ import * as vc from '@digitalbazaar/vc';
 // @ts-expect-error TS(7016): Could not find a declaration file for module '@dig... Remove this comment to see the full error message
 import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
 
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { KEY_TYPES, credentialsContext } from '../constants.ts';
 
 const {
@@ -43,7 +43,7 @@ const VCHolderService = {
      * @param {object} ctx.params - The parameters for creating the presentation.
      * @returns {object} The signed presentation.
      */
-    createPresentation: defineAction({
+    createPresentation: {
       params: {
         presentation: {
           type: 'object',
@@ -135,7 +135,7 @@ const VCHolderService = {
 
         return signedPresentation;
       }
-    })
+    }
   },
 
   methods: {

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-issuer-service.ts
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-issuer-service.ts
@@ -10,7 +10,7 @@ import * as vc from '@digitalbazaar/vc';
 // @ts-expect-error TS(7016): Could not find a declaration file for module '@dig... Remove this comment to see the full error message
 import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
 
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { KEY_TYPES, credentialsContext } from '../constants.ts';
 
 const {
@@ -57,7 +57,7 @@ const VCCredentialService = {
      * @param {object} ctx.params - The parameters for creating the VC.
      * @returns {object} The signed credential.
      */
-    createVC: defineAction({
+    createVC: {
       params: {
         credential: {
           type: 'object',
@@ -146,7 +146,7 @@ const VCCredentialService = {
 
         return signedCredential;
       }
-    })
+    }
   },
   methods: {
     /** Creates an ldp resource from the presentation and sets rights. */

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-presentation-container.ts
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-presentation-container.ts
@@ -1,5 +1,5 @@
 import { ControlledContainerMixin, PseudoIdMixin } from '@semapps/ldp';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { credentialsContext, credentialsContextNoGraphProof } from '../constants.ts';
 
 /**
@@ -41,7 +41,7 @@ const VCPresentationContainer = {
    * We can't handle that internally so we use a copy of the context with the `@graph`s removed.
    */
   actions: {
-    get: defineAction({
+    get: {
       async handler(ctx) {
         const resource = await ctx.call('ldp.resource.get', {
           ...ctx.params,
@@ -55,9 +55,9 @@ const VCPresentationContainer = {
         };
         return { ...resource, '@context': credentialsContext };
       }
-    }),
+    },
 
-    put: defineAction({
+    put: {
       async handler(ctx) {
         const { resource } = ctx.params;
         return await ctx.call('ldp.resource.put', {
@@ -68,9 +68,9 @@ const VCPresentationContainer = {
           }
         });
       }
-    }),
+    },
 
-    post: defineAction({
+    post: {
       async handler(ctx) {
         // FIXME: The action fails to store the VC with the VP.
         // This is okay because persisting VPs is not required
@@ -85,9 +85,9 @@ const VCPresentationContainer = {
           }
         });
       }
-    }),
+    },
 
-    list: defineAction({
+    list: {
       async handler(ctx) {
         const container = await ctx.call('ldp.container.list', {
           ...ctx.params,
@@ -95,7 +95,7 @@ const VCPresentationContainer = {
         });
         return { ...container, '@context': credentialsContext };
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/crypto/verifiable-credentials/vc-verifier-service.ts
+++ b/src/middleware/packages/crypto/verifiable-credentials/vc-verifier-service.ts
@@ -4,7 +4,7 @@ import { cryptosuite } from '@digitalbazaar/eddsa-rdfc-2022-cryptosuite';
 import { DataIntegrityProof } from '@digitalbazaar/data-integrity';
 // @ts-expect-error TS(7016): Could not find a declaration file for module '@dig... Remove this comment to see the full error message
 import * as vc from '@digitalbazaar/vc';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import VCCapabilityPresentationProofPurpose from './VcCapabilityPresentationProofPurpose.ts';
 import VCPurpose from './VcPurpose.ts';
 import { arrayOf } from '../utils/utils.ts';
@@ -34,7 +34,7 @@ const VCPresentationService = {
     /**
      * Verify a verifiable credential.
      */
-    verifyVC: defineAction({
+    verifyVC: {
       params: {
         verifiableCredential: {
           type: 'object',
@@ -82,12 +82,12 @@ const VCPresentationService = {
 
         return verificationResult;
       }
-    }),
+    },
 
     /**
      * Verify a presentation.
      */
-    verifyPresentation: defineAction({
+    verifyPresentation: {
       params: {
         // @ts-expect-error TS(2322): Type '{ type: "object"; }' is not assignable to ty... Remove this comment to see the full error message
         verifiablePresentation: { type: 'object' },
@@ -150,14 +150,14 @@ const VCPresentationService = {
           return { verified: false, error: e.message };
         }
       }
-    }),
+    },
 
     /**
      * Verify a capability presentation.
      * @param {object} ctx.params - The parameters for verifying the capability presentation.
      * @returns {object} The verification result.
      */
-    verifyCapabilityPresentation: defineAction({
+    verifyCapabilityPresentation: {
       params: {
         // @ts-expect-error TS(2322): Type '{ type: "object"; }' is not assignable to ty... Remove this comment to see the full error message
         verifiablePresentation: { type: 'object' },
@@ -210,7 +210,7 @@ const VCPresentationService = {
 
         return { ...verificationResult, presentation };
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/importer/mixins/importer.ts
+++ b/src/middleware/packages/importer/mixins/importer.ts
@@ -3,7 +3,7 @@ import cronParser from 'cron-parser';
 import { promises as fsPromises } from 'fs';
 import { ACTIVITY_TYPES, PUBLIC_URI } from '@semapps/activitypub';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { isDir } from '../utils.ts';
 
 const Schema = {
@@ -93,7 +93,7 @@ const Schema = {
     }
   },
   actions: {
-    freshImport: defineAction({
+    freshImport: {
       async handler(ctx) {
         if (ctx.params.clear === undefined || ctx.params.clear === true) {
           this.logger.info('Clearing all existing data...');
@@ -165,9 +165,9 @@ const Schema = {
 
         this.logger.info(`Import finished !`);
       }
-    }),
+    },
 
-    synchronize: defineAction({
+    synchronize: {
       handler() {
         if (this.createJob) {
           this.createJob(this.name, 'synchronize', {});
@@ -180,9 +180,9 @@ const Schema = {
           });
         }
       }
-    }),
+    },
 
-    importOne: defineAction({
+    importOne: {
       async handler(ctx) {
         let { sourceUri, destUri, data } = ctx.params;
 
@@ -280,9 +280,9 @@ const Schema = {
 
         return destUri;
       }
-    }),
+    },
 
-    deleteImported: defineAction({
+    deleteImported: {
       async handler(ctx) {
         for (const resourceUri of Object.values(this.imported)) {
           this.logger.info(`Deleting ${resourceUri}...`);
@@ -296,25 +296,25 @@ const Schema = {
 
         this.imported = {};
       }
-    }),
+    },
 
-    list: defineAction({
+    list: {
       async handler(ctx) {
         return await this.list(ctx.params.url || this.settings.source.getAllFull);
       }
-    }),
+    },
 
-    getOne: defineAction({
+    getOne: {
       async handler(ctx) {
         return await this.getOne(this.settings.source.getOneFull(ctx.params.data));
       }
-    }),
+    },
 
-    getImported: defineAction({
+    getImported: {
       handler() {
         return this.imported;
       }
-    })
+    }
   },
   methods: {
     async prepare() {

--- a/src/middleware/packages/inference/service.ts
+++ b/src/middleware/packages/inference/service.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
 import N3 from 'n3';
-import { ServiceSchema, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import RemoteService from './subservices/remote.ts';
 
 const { DataFactory } = N3;
@@ -151,7 +151,7 @@ const InferenceSchema = {
     }
   },
   events: {
-    'ldp.resource.created': defineServiceEvent({
+    'ldp.resource.created': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'newData' does not exist on type 'Optiona... Remove this comment to see the full error message
         let { newData } = ctx.params;
@@ -189,9 +189,9 @@ const InferenceSchema = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.deleted': defineServiceEvent({
+    'ldp.resource.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'oldData' does not exist on type 'Optiona... Remove this comment to see the full error message
         let { oldData } = ctx.params;
@@ -224,9 +224,9 @@ const InferenceSchema = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.updated': defineServiceEvent({
+    'ldp.resource.updated': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'oldData' does not exist on type 'Optiona... Remove this comment to see the full error message
         let { oldData, newData } = ctx.params;
@@ -300,9 +300,9 @@ const InferenceSchema = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.patched': defineServiceEvent({
+    'ldp.resource.patched': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'triplesAdded' does not exist on type 'Op... Remove this comment to see the full error message
         const { triplesAdded, triplesRemoved, skipInferenceCheck } = ctx.params;
@@ -371,9 +371,9 @@ const InferenceSchema = {
           }
         }
       }
-    }),
+    },
 
-    'ontologies.registered': defineServiceEvent({
+    'ontologies.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'owl' does not exist on type 'Optionalize... Remove this comment to see the full error message
         const { owl } = ctx.params;
@@ -386,7 +386,7 @@ const InferenceSchema = {
           this.inverseRelations = { ...this.inverseRelations, ...result };
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/inference/subservices/remote.ts
+++ b/src/middleware/packages/inference/subservices/remote.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import N3 from 'n3';
 import { ACTIVITY_TYPES, OBJECT_TYPES, ActivitiesHandlerMixin, matchActivity } from '@semapps/activitypub';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const { DataFactory } = N3;
 const { triple, namedNode } = DataFactory;
@@ -19,7 +19,7 @@ const InferenceRemoteSchema = {
     this.relayActor = await this.broker.call('activitypub.relay.getActor');
   },
   actions: {
-    offerInference: defineAction({
+    offerInference: {
       visibility: 'public',
       params: {
         subject: { type: 'string', optional: false },
@@ -87,7 +87,7 @@ const InferenceRemoteSchema = {
           }
         }
       }
-    })
+    }
   },
   activities: {
     offerInference: {

--- a/src/middleware/packages/jsonld/services/api/index.ts
+++ b/src/middleware/packages/jsonld/services/api/index.ts
@@ -1,4 +1,4 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const JsonldApiSchema = {
   name: 'jsonld.api' as const,
@@ -21,13 +21,13 @@ const JsonldApiSchema = {
     });
   },
   actions: {
-    getContext: defineAction({
+    getContext: {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property '$responseType' does not exist on type '{... Remove this comment to see the full error message
         ctx.meta.$responseType = 'application/ld+json';
         return await ctx.call('jsonld.context.getLocal');
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/jsonld/services/context/actions/get.ts
+++ b/src/middleware/packages/jsonld/services/context/actions/get.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   cache: true,
   async handler(ctx) {
@@ -23,6 +23,6 @@ const Schema = defineAction({
 
     return context;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/jsonld/services/context/actions/getLocal.ts
+++ b/src/middleware/packages/jsonld/services/context/actions/getLocal.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   cache: true,
   async handler(ctx) {
@@ -27,6 +27,6 @@ const Schema = defineAction({
       '@context': context
     };
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/jsonld/services/context/actions/merge.ts
+++ b/src/middleware/packages/jsonld/services/context/actions/merge.ts
@@ -1,7 +1,7 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { isURL, isObject, mergeObjectInArray } from '../../../utils/utils.ts';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     a: {
@@ -51,6 +51,6 @@ const Schema = defineAction({
 
     throw new Error('Could not merge JSON-LD contexts');
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/jsonld/services/context/actions/parse.ts
+++ b/src/middleware/packages/jsonld/services/context/actions/parse.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     context: {
@@ -16,6 +16,6 @@ const Schema = defineAction({
     const { contextRaw } = await this.contextParser.parse(context, options);
     return contextRaw;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/jsonld/services/context/actions/validate.ts
+++ b/src/middleware/packages/jsonld/services/context/actions/validate.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     context: {
@@ -20,6 +20,6 @@ const Schema = defineAction({
       return false;
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/jsonld/services/document-loader/index.ts
+++ b/src/middleware/packages/jsonld/services/document-loader/index.ts
@@ -2,7 +2,7 @@ import jsonld from 'jsonld';
 import fsModule from 'fs';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'lru-... Remove this comment to see the full error message
 import LRU from 'lru-cache';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const fsPromises = fsModule.promises;
 
@@ -53,7 +53,7 @@ const JsonldDocumentLoaderSchema = {
     }
   },
   actions: {
-    loadWithCache: defineAction({
+    loadWithCache: {
       async handler(ctx) {
         const { url, options } = ctx.params;
         if (url === this.settings.localContextUri) {
@@ -75,17 +75,17 @@ const JsonldDocumentLoaderSchema = {
         cache.set(url, context);
         return context;
       }
-    }),
+    },
 
-    getCache: defineAction({
+    getCache: {
       handler(ctx) {
         const { uri } = ctx.params;
         const context = cache.get(uri);
         return context?.document;
       }
-    }),
+    },
 
-    setCache: defineAction({
+    setCache: {
       handler(ctx) {
         const { uri, json } = ctx.params;
         cache.set(uri, {
@@ -94,7 +94,7 @@ const JsonldDocumentLoaderSchema = {
           document: json
         });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/jsonld/services/parser/index.ts
+++ b/src/middleware/packages/jsonld/services/parser/index.ts
@@ -1,7 +1,7 @@
 import jsonld from 'jsonld';
 import { JsonLdParser } from 'jsonld-streaming-parser';
 import streamifyString from 'streamify-string';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { arrayOf, isURI } from '../../utils/utils.ts';
 
 const JsonldParserSchema = {
@@ -19,56 +19,56 @@ const JsonldParserSchema = {
     });
   },
   actions: {
-    compact: defineAction({
+    compact: {
       handler(ctx) {
         const { input, context, options } = ctx.params;
         return this.jsonld.compact(input, context, options);
       }
-    }),
+    },
 
-    expand: defineAction({
+    expand: {
       handler(ctx) {
         const { input, options } = ctx.params;
         return this.jsonld.expand(input, options);
       }
-    }),
+    },
 
-    flatten: defineAction({
+    flatten: {
       handler(ctx) {
         const { input, context, options } = ctx.params;
         return this.jsonld.flatten(input, context, options);
       }
-    }),
+    },
 
-    frame: defineAction({
+    frame: {
       handler(ctx) {
         const { input, frame, options } = ctx.params;
         return this.jsonld.frame(input, frame, options);
       }
-    }),
+    },
 
-    normalize: defineAction({
+    normalize: {
       handler(ctx) {
         const { input, options } = ctx.params;
         return this.jsonld.normalize(input, options);
       }
-    }),
+    },
 
-    fromRDF: defineAction({
+    fromRDF: {
       handler(ctx) {
         const { dataset, options } = ctx.params;
         return this.jsonld.fromRDF(dataset, options);
       }
-    }),
+    },
 
-    toRDF: defineAction({
+    toRDF: {
       handler(ctx) {
         const { input, options } = ctx.params;
         return this.jsonld.toRDF(input, options);
       }
-    }),
+    },
 
-    toQuads: defineAction({
+    toQuads: {
       // Return quads in RDF.JS data model
       // (this.jsonld.toRDF does not use the same model)
       // https://github.com/rdfjs/data-model-spec
@@ -85,9 +85,9 @@ const JsonldParserSchema = {
             .on('end', () => resolve(res));
         });
       }
-    }),
+    },
 
-    expandPredicate: defineAction({
+    expandPredicate: {
       // TODO move to ontologies service ??
       async handler(ctx) {
         let { predicate, context } = ctx.params;
@@ -115,9 +115,9 @@ const JsonldParserSchema = {
 
         return expandedPredicate;
       }
-    }),
+    },
 
-    expandTypes: defineAction({
+    expandTypes: {
       async handler(ctx) {
         let { types, context } = ctx.params;
 
@@ -145,7 +145,7 @@ const JsonldParserSchema = {
 
         return expandedTypes;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/ldp/mixins/controlled-container.ts
+++ b/src/middleware/packages/ldp/mixins/controlled-container.ts
@@ -1,5 +1,5 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { delay, getParentContainerUri } from '../utils.ts';
 
 const Schema = {
@@ -42,43 +42,43 @@ const Schema = {
     if (!path) this.settings.path = registration.path;
   },
   actions: {
-    post: defineAction({
+    post: {
       async handler(ctx) {
         if (!ctx.params.containerUri) {
           ctx.params.containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
         }
         return await ctx.call('ldp.container.post', ctx.params);
       }
-    }),
+    },
 
-    list: defineAction({
+    list: {
       async handler(ctx) {
         if (!ctx.params.containerUri) {
           ctx.params.containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
         }
         return ctx.call('ldp.container.get', ctx.params);
       }
-    }),
+    },
 
-    attach: defineAction({
+    attach: {
       async handler(ctx) {
         if (!ctx.params.containerUri) {
           ctx.params.containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
         }
         return ctx.call('ldp.container.attach', ctx.params);
       }
-    }),
+    },
 
-    detach: defineAction({
+    detach: {
       async handler(ctx) {
         if (!ctx.params.containerUri) {
           ctx.params.containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
         }
         return ctx.call('ldp.container.detach', ctx.params);
       }
-    }),
+    },
 
-    get: defineAction({
+    get: {
       handler(ctx) {
         const containerParams = {};
         // @ts-expect-error TS(2339): Property 'accept' does not exist on type '{}'.
@@ -88,45 +88,45 @@ const Schema = {
           ...ctx.params
         });
       }
-    }),
+    },
 
-    getHeaderLinks: defineAction({
+    getHeaderLinks: {
       handler(ctx) {
         return [];
       }
-    }),
+    },
 
-    create: defineAction({
+    create: {
       handler(ctx) {
         return ctx.call('ldp.resource.create', ctx.params);
       }
-    }),
+    },
 
-    patch: defineAction({
+    patch: {
       handler(ctx) {
         return ctx.call('ldp.resource.patch', ctx.params);
       }
-    }),
+    },
 
-    put: defineAction({
+    put: {
       handler(ctx) {
         return ctx.call('ldp.resource.put', ctx.params);
       }
-    }),
+    },
 
-    delete: defineAction({
+    delete: {
       handler(ctx) {
         return ctx.call('ldp.resource.delete', ctx.params);
       }
-    }),
+    },
 
-    exist: defineAction({
+    exist: {
       handler(ctx) {
         return ctx.call('ldp.resource.exist', ctx.params);
       }
-    }),
+    },
 
-    getContainerUri: defineAction({
+    getContainerUri: {
       handler(ctx) {
         return ctx.call('ldp.registry.getUri', {
           path: this.settings.path,
@@ -134,9 +134,9 @@ const Schema = {
           webId: ctx.params?.webId || ctx.meta?.webId
         });
       }
-    }),
+    },
 
-    waitForContainerCreation: defineAction({
+    waitForContainerCreation: {
       async handler(ctx) {
         let { containerUri } = ctx.params;
         let containerExist;
@@ -171,7 +171,7 @@ const Schema = {
           } while (!containerAttached);
         }
       }
-    })
+    }
   }
 } satisfies Partial<ServiceSchema>;
 

--- a/src/middleware/packages/ldp/mixins/document-tagger.ts
+++ b/src/middleware/packages/ldp/mixins/document-tagger.ts
@@ -1,5 +1,5 @@
 import { dc } from '@semapps/ontologies';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { getDatasetFromUri } from '../utils.ts';
 
 const Schema = {
@@ -14,7 +14,7 @@ const Schema = {
     await this.broker.call('ontologies.register', dc);
   },
   actions: {
-    tagCreatedResource: defineAction({
+    tagCreatedResource: {
       async handler(ctx) {
         const { resourceUri, newData, webId, dataset } = ctx.params;
         const now = new Date();
@@ -48,9 +48,9 @@ const Schema = {
           });
         }
       }
-    }),
+    },
 
-    tagUpdatedResource: defineAction({
+    tagUpdatedResource: {
       async handler(ctx) {
         const { resourceUri, dataset } = ctx.params;
         const now = new Date();
@@ -66,10 +66,10 @@ const Schema = {
           webId: 'system'
         });
       }
-    })
+    }
   },
   events: {
-    'ldp.resource.created': defineServiceEvent({
+    'ldp.resource.created': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, newData, webId, dataset } = ctx.params;
@@ -80,25 +80,25 @@ const Schema = {
           { parentCtx: ctx }
         );
       }
-    }),
+    },
 
-    'ldp.resource.updated': defineServiceEvent({
+    'ldp.resource.updated': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, dataset } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         this.actions.tagUpdatedResource({ resourceUri, dataset }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.resource.patched': defineServiceEvent({
+    'ldp.resource.patched': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, dataset } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         this.actions.tagUpdatedResource({ resourceUri, dataset }, { parentCtx: ctx });
       }
-    })
+    }
   }
 } satisfies Partial<ServiceSchema>;
 

--- a/src/middleware/packages/ldp/mixins/image-processor.ts
+++ b/src/middleware/packages/ldp/mixins/image-processor.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'shar... Remove this comment to see the full error message
 import sharp from 'sharp';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { arrayOf } from '../utils.ts';
 
 const SUPPORTED_IMAGES_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
@@ -23,7 +23,7 @@ const Schema = {
     }
   },
   actions: {
-    processImage: defineAction({
+    processImage: {
       async handler(ctx) {
         const { resourceUri } = ctx.params;
 
@@ -68,9 +68,9 @@ const Schema = {
           this.logger.warn(`Image processing failed (${e.message})`);
         }
       }
-    }),
+    },
 
-    processAllImages: defineAction({
+    processAllImages: {
       async handler(ctx) {
         const { webId } = ctx.params;
         const container = await this.actions.list({ webId }, { parentCtx: ctx });
@@ -84,7 +84,7 @@ const Schema = {
         }
         this.logger.info('Finished !');
       }
-    })
+    }
   },
   methods: {
     getMaxSize(width, height) {

--- a/src/middleware/packages/ldp/mixins/orphan-files-deletion.ts
+++ b/src/middleware/packages/ldp/mixins/orphan-files-deletion.ts
@@ -1,5 +1,5 @@
 import { CronJob } from 'cron';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const Schema = {
   settings: {
@@ -12,7 +12,7 @@ const Schema = {
   },
   dependencies: ['triplestore', 'ldp.resource'],
   actions: {
-    checkOrphanFiles: defineAction({
+    checkOrphanFiles: {
       async handler(ctx) {
         try {
           this.logger.info('OrphanFilesDeletion - Check...');
@@ -47,7 +47,7 @@ const Schema = {
           this.logger.error(`OrphanFilesDeletion - Error: ${error.message}`);
         }
       }
-    })
+    }
   },
   created() {
     this.actions.checkOrphanFiles();

--- a/src/middleware/packages/ldp/mixins/single-resource-container.ts
+++ b/src/middleware/packages/ldp/mixins/single-resource-container.ts
@@ -1,5 +1,5 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction, defineServiceEvent, Errors } from 'moleculer';
+import { ServiceSchema, Errors } from 'moleculer';
 import ControlledContainerMixin from './controlled-container.ts';
 import { delay } from '../utils.ts';
 
@@ -23,7 +23,7 @@ const Schema = {
     }
   },
   actions: {
-    initializeResource: defineAction({
+    initializeResource: {
       async handler(ctx) {
         const { webId } = ctx.params;
 
@@ -38,24 +38,24 @@ const Schema = {
           { parentCtx: ctx }
         );
       }
-    }),
+    },
 
-    getResourceUri: defineAction({
+    getResourceUri: {
       async handler(ctx) {
         const containerUri = await this.actions.getContainerUri({ webId: ctx.params.webId }, { parentCtx: ctx });
         const resourcesUris = await ctx.call('ldp.container.getUris', { containerUri });
         return resourcesUris[0];
       }
-    }),
+    },
 
-    exist: defineAction({
+    exist: {
       async handler(ctx) {
         const resourceUri = await this.actions.getResourceUri({ webId: ctx.params.webId }, { parentCtx: ctx });
         return !!resourceUri;
       }
-    }),
+    },
 
-    waitForResourceCreation: defineAction({
+    waitForResourceCreation: {
       async handler(ctx) {
         const { webId } = ctx.params;
         let resource;
@@ -84,7 +84,7 @@ const Schema = {
 
         return resource.id || resource['@id'];
       }
-    })
+    }
   },
   hooks: {
     before: {
@@ -112,7 +112,7 @@ const Schema = {
     }
   },
   events: {
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'settings' does not exist on type 'Servic... Remove this comment to see the full error message
         if (this.settings.podProvider) {
@@ -122,7 +122,7 @@ const Schema = {
           await this.actions.initializeResource({ webId });
         }
       }
-    })
+    }
   }
 } satisfies Partial<ServiceSchema>;
 

--- a/src/middleware/packages/ldp/mixins/special-endpoint.ts
+++ b/src/middleware/packages/ldp/mixins/special-endpoint.ts
@@ -2,7 +2,7 @@ import urlJoin from 'url-join';
 import { namedNode, triple } from '@rdfjs/data-model';
 import { MIME_TYPES } from '@semapps/mime-types';
 import { parseUrl, parseHeader, negotiateAccept, parseJson, parseTurtle } from '@semapps/middlewares';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const Schema = {
   settings: {
@@ -62,7 +62,7 @@ const Schema = {
     }
   },
   actions: {
-    endpointAdd: defineAction({
+    endpointAdd: {
       async handler(ctx) {
         const { predicate, object } = ctx.params;
 
@@ -76,9 +76,9 @@ const Schema = {
           { meta: { dataset: this.settings.settingsDataset, skipEmitEvent: true, skipObjectsWatcher: true } }
         );
       }
-    }),
+    },
 
-    endpointGet: defineAction({
+    endpointGet: {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property '$responseType' does not exist on type '{... Remove this comment to see the full error message
         ctx.meta.$responseType = ctx.meta.headers?.accept;
@@ -94,7 +94,7 @@ const Schema = {
           { meta: { dataset: this.settings.settingsDataset } }
         );
       }
-    })
+    }
   }
 } satisfies Partial<ServiceSchema>;
 

--- a/src/middleware/packages/ldp/service.ts
+++ b/src/middleware/packages/ldp/service.ts
@@ -1,5 +1,5 @@
 import { ldp, semapps } from '@semapps/ontologies';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import LdpApiService from './services/api/index.ts';
 import LdpContainerService from './services/container/index.ts';
 import LdpCacheService from './services/cache/index.ts';
@@ -109,25 +109,25 @@ const LdpSchema = {
     await this.broker.call('ontologies.register', semapps);
   },
   actions: {
-    getBaseUrl: defineAction({
+    getBaseUrl: {
       handler() {
         return this.settings.baseUrl;
       }
-    }),
+    },
 
-    getBasePath: defineAction({
+    getBasePath: {
       handler() {
         const { pathname } = new URL(this.settings.baseUrl);
         return pathname;
       }
-    }),
+    },
 
-    getSetting: defineAction({
+    getSetting: {
       handler(ctx) {
         const { key } = ctx.params;
         return this.settings[key];
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/ldp/services/api/actions/put.ts
+++ b/src/middleware/packages/ldp/services/api/actions/put.ts
@@ -1,8 +1,8 @@
-import { defineAction, Errors } from 'moleculer';
+import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-export default defineAction({
+export default {
   async handler(ctx) {
     const { username, slugParts, body, ...resource } = ctx.params;
 
@@ -45,4 +45,4 @@ export default defineAction({
       ctx.meta.$statusMessage = e.message;
     }
   }
-});
+};

--- a/src/middleware/packages/ldp/services/cache/index.ts
+++ b/src/middleware/packages/ldp/services/cache/index.ts
@@ -1,11 +1,11 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const LdpCacheSchema = {
   name: 'ldp.cache' as const,
   dependencies: ['ldp.container'],
   actions: {
-    generate: defineAction({
+    generate: {
       async handler(ctx) {
         const containersUris = await ctx.call('ldp.container.getAll');
         for (const containerUri of containersUris) {
@@ -18,9 +18,9 @@ const LdpCacheSchema = {
           }
         }
       }
-    }),
+    },
 
-    invalidateResource: defineAction({
+    invalidateResource: {
       async handler(ctx) {
         if (this.broker.cacher) {
           const { resourceUri, dataset } = ctx.params;
@@ -34,9 +34,9 @@ const LdpCacheSchema = {
           }
         }
       }
-    }),
+    },
 
-    invalidateContainer: defineAction({
+    invalidateContainer: {
       async handler(ctx) {
         if (this.broker.cacher) {
           const { containerUri } = ctx.params;
@@ -44,91 +44,91 @@ const LdpCacheSchema = {
           await this.broker.cacher.clean(`ldp.resource.getTypes:${containerUri}**`);
         }
       }
-    })
+    }
   },
   events: {
-    'ldp.resource.deleted': defineServiceEvent({
+    'ldp.resource.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, dataset } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateResource({ resourceUri, dataset }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.resource.updated': defineServiceEvent({
+    'ldp.resource.updated': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, dataset } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateResource({ resourceUri, dataset }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.resource.patched': defineServiceEvent({
+    'ldp.resource.patched': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, dataset } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateResource({ resourceUri, dataset }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.container.attached': defineServiceEvent({
+    'ldp.container.attached': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'containerUri' does not exist on type 'Op... Remove this comment to see the full error message
         const { containerUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateContainer({ containerUri }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.container.patched': defineServiceEvent({
+    'ldp.container.patched': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'containerUri' does not exist on type 'Op... Remove this comment to see the full error message
         const { containerUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateContainer({ containerUri }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.container.deleted': defineServiceEvent({
+    'ldp.container.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'containerUri' does not exist on type 'Op... Remove this comment to see the full error message
         const { containerUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateContainer({ containerUri }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.container.detached': defineServiceEvent({
+    'ldp.container.detached': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'containerUri' does not exist on type 'Op... Remove this comment to see the full error message
         const { containerUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateContainer({ containerUri }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.remote.deleted': defineServiceEvent({
+    'ldp.remote.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, dataset } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateResource({ resourceUri, dataset }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'ldp.remote.stored': defineServiceEvent({
+    'ldp.remote.stored': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, dataset } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateResource({ resourceUri, dataset }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'webacl.resource.updated': defineServiceEvent({
+    'webacl.resource.updated': {
       // Invalidate cache also when ACL rights are changed
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'uri' does not exist on type 'Optionalize... Remove this comment to see the full error message
@@ -141,9 +141,9 @@ const LdpCacheSchema = {
           await this.actions.invalidateResource({ resourceUri: uri, dataset }, { parentCtx: ctx });
         }
       }
-    }),
+    },
 
-    'webacl.resource.deleted': defineServiceEvent({
+    'webacl.resource.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'uri' does not exist on type 'Optionalize... Remove this comment to see the full error message
         const { uri, isContainer, dataset } = ctx.params;
@@ -155,7 +155,7 @@ const LdpCacheSchema = {
           await this.actions.invalidateResource({ resourceUri: uri, dataset }, { parentCtx: ctx });
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/ldp/services/container/actions/attach.ts
+++ b/src/middleware/packages/ldp/services/container/actions/attach.ts
@@ -1,9 +1,9 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' },
@@ -52,6 +52,6 @@ const Schema = defineAction({
 
     return returnValues;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/clear.ts
+++ b/src/middleware/packages/ldp/services/container/actions/clear.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' },
@@ -18,6 +18,6 @@ const Schema = defineAction({
       await ctx.call('ldp.resource.delete', { resourceUri, webId });
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/create.ts
+++ b/src/middleware/packages/ldp/services/container/actions/create.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' },
@@ -29,6 +29,6 @@ const Schema = defineAction({
 
     ctx.emit('ldp.container.created', { containerUri, options, webId });
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/createAndAttach.ts
+++ b/src/middleware/packages/ldp/services/container/actions/createAndAttach.ts
@@ -1,5 +1,5 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { getParentContainerUri } from '../../../utils.ts';
 
 /**
@@ -7,7 +7,7 @@ import { getParentContainerUri } from '../../../utils.ts';
  * Recursively create the parent container(s) if they don't exist
  * In Pod provider config, the webId is required to find the Pod root
  */
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' },
@@ -79,6 +79,6 @@ const Schema = defineAction({
       }
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/delete.ts
+++ b/src/middleware/packages/ldp/services/container/actions/delete.ts
@@ -1,7 +1,7 @@
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -47,6 +47,6 @@ const Schema = defineAction({
 
     return returnValues;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/detach.ts
+++ b/src/middleware/packages/ldp/services/container/actions/detach.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' },
@@ -50,6 +50,6 @@ const Schema = defineAction({
       );
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/exist.ts
+++ b/src/middleware/packages/ldp/services/container/actions/exist.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' }
@@ -27,6 +27,6 @@ const Schema = defineAction({
       webId: 'system'
     });
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/get.ts
+++ b/src/middleware/packages/ldp/services/container/actions/get.ts
@@ -1,12 +1,12 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { buildFiltersQuery, isContainer, cleanUndefined, arrayOf } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string', optional: true },
@@ -131,6 +131,6 @@ const Schema = defineAction({
 
     return compactResults;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/getAll.ts
+++ b/src/middleware/packages/ldp/services/container/actions/getAll.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     dataset: { type: 'string', optional: true }
@@ -22,6 +22,6 @@ const Schema = defineAction({
 
     return result.map((node: any) => node.containerUri.value);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/getPath.ts
+++ b/src/middleware/packages/ldp/services/container/actions/getPath.ts
@@ -1,9 +1,9 @@
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'dash... Remove this comment to see the full error message
 import dashify from 'dashify';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { isURL } from '../../../utils.ts';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -41,6 +41,6 @@ const Schema = defineAction({
 
     return `/${prefix}/${dashify(className)}`;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/getUris.ts
+++ b/src/middleware/packages/ldp/services/container/actions/getUris.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string', optional: true }
@@ -23,6 +23,6 @@ const Schema = defineAction({
 
     return result.map((node: any) => node.resourceUri.value);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/includes.ts
+++ b/src/middleware/packages/ldp/services/container/actions/includes.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' },
@@ -33,6 +33,6 @@ const Schema = defineAction({
       webId
     });
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/isEmpty.ts
+++ b/src/middleware/packages/ldp/services/container/actions/isEmpty.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string' },
@@ -25,6 +25,6 @@ const Schema = defineAction({
     const num = Number(res[0].count.value);
     return num === 0;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/patch.ts
+++ b/src/middleware/packages/ldp/services/container/actions/patch.ts
@@ -1,4 +1,4 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { isMirror } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
@@ -21,7 +21,7 @@ const checkTripleValidity = (triple: any, containerUri: any) => {
   }
 };
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: {
@@ -128,6 +128,6 @@ const Schema = defineAction({
       );
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/container/actions/post.ts
+++ b/src/middleware/packages/ldp/services/container/actions/post.ts
@@ -1,12 +1,12 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { cleanUndefined } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: {
@@ -145,6 +145,6 @@ const Schema = defineAction({
 
     return resourceUri;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/link-header/actions/get.ts
+++ b/src/middleware/packages/ldp/services/link-header/actions/get.ts
@@ -1,7 +1,7 @@
 import LinkHeader from 'http-link-header';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     uri: { type: 'string' }
@@ -33,6 +33,6 @@ const Schema = defineAction({
 
     return linkHeader.toString();
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/link-header/actions/register.ts
+++ b/src/middleware/packages/ldp/services/link-header/actions/register.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     actionName: { type: 'string' }
@@ -9,6 +9,6 @@ const Schema = defineAction({
     const { actionName } = ctx.params;
     this.registeredActionNames.push(actionName);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/permissions/actions/addAuthorizer.ts
+++ b/src/middleware/packages/ldp/services/permissions/actions/addAuthorizer.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     actionName: { type: 'string' },
@@ -14,6 +14,6 @@ const Schema = defineAction({
     // Re-order all authorizers by priority
     this.authorizers.sort((a: any, b: any) => b.priority - a.priority);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/permissions/actions/check.ts
+++ b/src/middleware/packages/ldp/services/permissions/actions/check.ts
@@ -1,4 +1,4 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
@@ -7,7 +7,7 @@ const { MoleculerError } = Errors;
 /**
  * Calls "has" action and throws error if no authorization was granted
  */
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     uri: { type: 'string' },
@@ -20,6 +20,6 @@ const Schema = defineAction({
       throw new MoleculerError('Forbidden', 403, 'ACCESS_DENIED');
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/permissions/actions/has.ts
+++ b/src/middleware/packages/ldp/services/permissions/actions/has.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     uri: { type: 'string' },
@@ -28,6 +28,6 @@ const Schema = defineAction({
     // If no guards returned a positive
     return false;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/registry/actions/getByType.ts
+++ b/src/middleware/packages/ldp/services/registry/actions/getByType.ts
@@ -1,10 +1,10 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 /**
  * Find the container options for a resource type
  * This only returns containers registered with the LDP registry, not the ones registered with the TypeIndex.
  */
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type '{ type: "array"; }' is not assignable to typ... Remove this comment to see the full error message
@@ -22,6 +22,6 @@ const Schema = defineAction({
       )
     );
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/registry/actions/getByUri.ts
+++ b/src/middleware/packages/ldp/services/registry/actions/getByUri.ts
@@ -1,9 +1,9 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 /**
  * Find the container options for a container URI
  */
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     containerUri: { type: 'string', optional: true },
@@ -32,6 +32,6 @@ const Schema = defineAction({
     }
     return this.settings.defaultOptions;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/registry/actions/getUri.ts
+++ b/src/middleware/packages/ldp/services/registry/actions/getUri.ts
@@ -1,11 +1,11 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 /**
  * Get the container URI based on its path
  * In Pod provider config, the webId is required to find the Pod root
  */
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     path: { type: 'string' },
@@ -23,6 +23,6 @@ const Schema = defineAction({
       return urlJoin(this.settings.baseUrl, path);
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/registry/actions/list.ts
+++ b/src/middleware/packages/ldp/services/registry/actions/list.ts
@@ -1,10 +1,10 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   handler() {
     return this.registeredContainers;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/registry/actions/register.ts
+++ b/src/middleware/packages/ldp/services/registry/actions/register.ts
@@ -1,12 +1,12 @@
 import urlJoin from 'url-join';
 import pathModule from 'path';
 import { pathToRegexp } from 'path-to-regexp';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { arrayOf } from '../../../utils.ts';
 
 const pathJoin = pathModule.join;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     path: { type: 'string', optional: true },
@@ -97,6 +97,6 @@ const Schema = defineAction({
 
     return options;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/registry/index.ts
+++ b/src/middleware/packages/ldp/services/registry/index.ts
@@ -1,5 +1,5 @@
 import urlJoin from 'url-join';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import getByTypeAction from './actions/getByType.ts';
 import getByUriAction from './actions/getByUri.ts';
 import getUriAction from './actions/getUri.ts';
@@ -38,7 +38,7 @@ const LdpRegistrySchema = {
     }
   },
   events: {
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId, accountData } = ctx.params;
@@ -59,7 +59,7 @@ const LdpRegistrySchema = {
           }
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/ldp/services/remote/actions/delete.ts
+++ b/src/middleware/packages/ldp/services/remote/actions/delete.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -69,6 +69,6 @@ const Schema = defineAction({
 
     return returnValues;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/remote/actions/get.ts
+++ b/src/middleware/packages/ldp/services/remote/actions/get.ts
@@ -1,8 +1,8 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { cleanUndefined } from '../../../utils.ts';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -84,6 +84,6 @@ const Schema = defineAction({
         throw new Error(`Unknown strategy: ${strategy}`);
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/remote/actions/getGraph.ts
+++ b/src/middleware/packages/ldp/services/remote/actions/getGraph.ts
@@ -1,7 +1,7 @@
 import { triple, namedNode, variable } from '@rdfjs/data-model';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' }
@@ -27,6 +27,6 @@ const Schema = defineAction({
     }
     return false;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/remote/actions/getNetwork.ts
+++ b/src/middleware/packages/ldp/services/remote/actions/getNetwork.ts
@@ -1,12 +1,12 @@
 import fetch from 'node-fetch';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -65,6 +65,6 @@ const Schema = defineAction({
       }
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/remote/actions/getStored.ts
+++ b/src/middleware/packages/ldp/services/remote/actions/getStored.ts
@@ -1,12 +1,12 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { buildBlankNodesQuery } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -72,6 +72,6 @@ const Schema = defineAction({
       throw new MoleculerError(`Resource Not found ${resourceUri} in dataset ${ctx.meta.dataset}`, 404, 'NOT_FOUND');
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/remote/actions/isRemote.ts
+++ b/src/middleware/packages/ldp/services/remote/actions/isRemote.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -32,6 +32,6 @@ const Schema = defineAction({
       }
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/remote/actions/store.ts
+++ b/src/middleware/packages/ldp/services/remote/actions/store.ts
@@ -1,10 +1,10 @@
 import { MIME_TYPES } from '@semapps/mime-types';
 // @ts-expect-error
 import { Errors as E } from 'moleculer-web';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { hasType } from '../../../utils.ts';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string', optional: true },
@@ -106,6 +106,6 @@ const Schema = defineAction({
 
     return resource;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/remote/index.ts
+++ b/src/middleware/packages/ldp/services/remote/index.ts
@@ -1,6 +1,6 @@
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'mole... Remove this comment to see the full error message
 import Schedule from 'moleculer-schedule';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import deleteAction from './actions/delete.ts';
 import getAction from './actions/get.ts';
 import getGraphAction from './actions/getGraph.ts';
@@ -30,12 +30,12 @@ const LdpRemoteSchema = {
     isRemote: isRemoteAction,
     store: storeAction,
 
-    runCron: defineAction({
+    runCron: {
       // Used by tests
       handler() {
         this.updateSingleMirroredResources();
       }
-    })
+    }
   },
   methods: {
     async proxyAvailable() {

--- a/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/awaitCreateComplete.ts
@@ -1,9 +1,9 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { waitForResource } from '../../../utils.ts';
 
 /** @type {import('moleculer').ServiceActionsSchema} */
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -39,6 +39,6 @@ const Schema = defineAction({
       )
     );
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/create.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/create.ts
@@ -1,11 +1,11 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -98,6 +98,6 @@ const Schema = defineAction({
 
     return returnValues;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/delete.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/delete.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -76,6 +76,6 @@ const Schema = defineAction({
 
     return returnValues;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/exist.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/exist.ts
@@ -1,7 +1,7 @@
 import { triple, namedNode, variable } from '@rdfjs/data-model';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -35,6 +35,6 @@ const Schema = defineAction({
 
     return exist;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/generateId.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/generateId.ts
@@ -3,9 +3,9 @@ import createSlug from 'speakingurl';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'uuid... Remove this comment to see the full error message
 import { v4 as uuidv4 } from 'uuid';
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -65,6 +65,6 @@ const Schema = defineAction({
 
     return urlJoin(containerUri, slug || uuid);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/get.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/get.ts
@@ -1,12 +1,12 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { buildBlankNodesQuery } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -82,6 +82,6 @@ const Schema = defineAction({
       throw new MoleculerError(`Resource not found ${resourceUri}`, 404, 'NOT_FOUND');
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/getContainers.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/getContainers.ts
@@ -1,8 +1,8 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { getContainerFromUri } from '../../../utils.ts';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -37,6 +37,6 @@ const Schema = defineAction({
 
     return result.map((node: any) => node.containerUri.value);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/getTypes.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/getTypes.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -26,6 +26,6 @@ const Schema = defineAction({
 
     return result.map((node: any) => node.type.value);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/patch.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/patch.ts
@@ -1,4 +1,4 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
@@ -20,7 +20,7 @@ function checkTriplesSubjectIsResource(triples: any, resourceUri: any) {
   }
 }
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resourceUri: {
@@ -105,6 +105,6 @@ const Schema = defineAction({
 
     return returnValues;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/put.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/put.ts
@@ -1,12 +1,12 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { cleanUndefined } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type '{ type: "object"; }' is not assignable to ty... Remove this comment to see the full error message
@@ -162,6 +162,6 @@ const Schema = defineAction({
       webId
     };
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ldp/services/resource/actions/upload.ts
+++ b/src/middleware/packages/ldp/services/resource/actions/upload.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 import fs from 'fs';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { getSlugFromUri, getContainerFromUri } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -50,6 +50,6 @@ const Schema = defineAction({
       fileName
     };
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/migration/service.ts
+++ b/src/middleware/packages/migration/service.ts
@@ -1,6 +1,6 @@
 import { getAclUriFromResourceUri } from '@semapps/webacl';
 import { getContainerFromUri } from '@semapps/ldp';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const MigrationSchema = {
   name: 'migration' as const,
@@ -13,7 +13,7 @@ const MigrationSchema = {
     }
   },
   actions: {
-    replacePredicate: defineAction({
+    replacePredicate: {
       async handler(ctx) {
         const { oldPredicate, newPredicate, dataset } = ctx.params;
 
@@ -34,9 +34,9 @@ const MigrationSchema = {
           webId: 'system'
         });
       }
-    }),
+    },
 
-    moveResourcesToContainer: defineAction({
+    moveResourcesToContainer: {
       async handler(ctx) {
         const { oldContainerUri, newContainerUri, dataset } = ctx.params;
 
@@ -52,9 +52,9 @@ const MigrationSchema = {
           );
         }
       }
-    }),
+    },
 
-    moveResource: defineAction({
+    moveResource: {
       async handler(ctx) {
         const { oldResourceUri, newResourceUri, dataset } = ctx.params;
 
@@ -107,9 +107,9 @@ const MigrationSchema = {
 
         await this.actions.moveAclRights({ newResourceUri, oldResourceUri, dataset }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    moveAclGroup: defineAction({
+    moveAclGroup: {
       async handler(ctx) {
         const { oldGroupUri, newGroupUri, dataset } = ctx.params;
 
@@ -142,9 +142,9 @@ const MigrationSchema = {
           { parentCtx: ctx }
         );
       }
-    }),
+    },
 
-    moveAclRights: defineAction({
+    moveAclRights: {
       async handler(ctx) {
         const { oldResourceUri, newResourceUri, dataset } = ctx.params;
 
@@ -166,9 +166,9 @@ const MigrationSchema = {
           });
         }
       }
-    }),
+    },
 
-    clearUserRights: defineAction({
+    clearUserRights: {
       async handler(ctx) {
         const { userUri, dataset } = ctx.params;
 
@@ -194,7 +194,7 @@ const MigrationSchema = {
           webId: 'system'
         });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/nodeinfo/service.ts
+++ b/src/middleware/packages/nodeinfo/service.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import urlJoin from 'url-join';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const NodeinfoService = {
   name: 'nodeinfo' as const,
@@ -58,22 +58,22 @@ const NodeinfoService = {
     });
   },
   actions: {
-    addLink: defineAction({
+    addLink: {
       handler(ctx) {
         const { rel, href } = ctx.params;
         this.links.push({ rel, href });
       }
-    }),
+    },
 
-    getLinks: defineAction({
+    getLinks: {
       handler() {
         return {
           links: this.links
         };
       }
-    }),
+    },
 
-    getSchema: defineAction({
+    getSchema: {
       async handler(ctx) {
         const users = await this.actions.getUsersCount({}, { parentCtx: ctx });
         return {
@@ -86,9 +86,9 @@ const NodeinfoService = {
           metadata: this.settings.metadata
         };
       }
-    }),
+    },
 
-    getUsersCount: defineAction({
+    getUsersCount: {
       // Overwrite this method to return your users count
       async handler() {
         return {
@@ -97,7 +97,7 @@ const NodeinfoService = {
           activeMonth: 0
         };
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/notifications/services/digest/service.ts
+++ b/src/middleware/packages/notifications/services/digest/service.ts
@@ -2,7 +2,7 @@
 import MailService from 'moleculer-mail';
 import cronParser from 'cron-parser';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import DigestSubscriptionService from './subscription.ts';
 
 const DigestNotificationsService = {
@@ -40,7 +40,7 @@ const DigestNotificationsService = {
     }
   },
   actions: {
-    build: defineAction({
+    build: {
       async handler(ctx) {
         const { frequency, timestamp } = ctx.params;
         const success = [];
@@ -134,7 +134,7 @@ const DigestNotificationsService = {
 
         return { failures, success };
       }
-    })
+    }
   },
   methods: {
     // Optional method called for each notification

--- a/src/middleware/packages/notifications/services/digest/subscription.ts
+++ b/src/middleware/packages/notifications/services/digest/subscription.ts
@@ -1,6 +1,6 @@
 import DbService from 'moleculer-db';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const DigestSubscriptionSchema = {
   name: 'digest.subscription' as const,
@@ -11,13 +11,13 @@ const DigestSubscriptionSchema = {
   },
   dependencies: ['triplestore'],
   actions: {
-    findByWebId: defineAction({
+    findByWebId: {
       async handler(ctx) {
         const { webId } = ctx.params;
         const subscriptions = await this._find(ctx, { query: { webId } });
         return subscriptions.length > 0 ? subscriptions[0] : null;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/notifications/services/expo-push/device.ts
+++ b/src/middleware/packages/notifications/services/expo-push/device.ts
@@ -1,6 +1,6 @@
 import DbService from 'moleculer-db';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const ExpoPushDeviceService = {
   name: 'expo-push.device' as const,
@@ -14,7 +14,7 @@ const ExpoPushDeviceService = {
     }
   },
   actions: {
-    subscribe: defineAction({
+    subscribe: {
       async handler(ctx) {
         const { name, yearClass, userUri, pushToken } = ctx.params;
 
@@ -61,9 +61,9 @@ const ExpoPushDeviceService = {
 
         return device;
       }
-    }),
+    },
 
-    findUsersDevices: defineAction({
+    findUsersDevices: {
       async handler(ctx) {
         const devices = [];
 
@@ -85,7 +85,7 @@ const ExpoPushDeviceService = {
 
         return devices;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/notifications/services/expo-push/notification.ts
+++ b/src/middleware/packages/notifications/services/expo-push/notification.ts
@@ -1,7 +1,7 @@
 import DbService from 'moleculer-db';
 import { Expo } from 'expo-server-sdk';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const ExpoPushNotificationService = {
   name: 'expo-push.notification' as const,
@@ -17,15 +17,15 @@ const ExpoPushNotificationService = {
     setInterval(this.actions.checkReceipts, 5 * 60 * 1000);
   },
   actions: {
-    send: defineAction({
+    send: {
       async handler(ctx) {
         await this.actions.queue(ctx.params, { parentCtx: ctx });
 
         this.actions.processQueue({}, { parentCtx: ctx });
       }
-    }),
+    },
 
-    queue: defineAction({
+    queue: {
       async handler(ctx) {
         const { to, message, data } = ctx.params;
 
@@ -49,9 +49,9 @@ const ExpoPushNotificationService = {
           );
         }
       }
-    }),
+    },
 
-    processQueue: defineAction({
+    processQueue: {
       async handler(ctx) {
         const notifications = await this.findByStatus('queued', ctx);
 
@@ -84,9 +84,9 @@ const ExpoPushNotificationService = {
           }
         }
       }
-    }),
+    },
 
-    checkReceipts: defineAction({
+    checkReceipts: {
       async handler(ctx) {
         const notifications = await this.findByStatus('processed', ctx);
 
@@ -135,7 +135,7 @@ const ExpoPushNotificationService = {
           }
         }
       }
-    })
+    }
   },
   methods: {
     async findByStatus(status, ctx) {

--- a/src/middleware/packages/notifications/services/single-mail/service.ts
+++ b/src/middleware/packages/notifications/services/single-mail/service.ts
@@ -3,7 +3,7 @@ import path from 'path';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'mole... Remove this comment to see the full error message
 import MailService from 'moleculer-mail';
 import { getSlugFromUri } from '@semapps/ldp';
-import { ServiceSchema, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { fileURLToPath } from 'url';
 
 // @ts-expect-error TS(1470): The 'import.meta' meta-property is not allowed in ... Remove this comment to see the full error message
@@ -26,7 +26,7 @@ const SingleMailNotificationsService = {
     data: {}
   },
   events: {
-    'activitypub.inbox.received': defineServiceEvent({
+    'activitypub.inbox.received': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'activity' does not exist on type 'Option... Remove this comment to see the full error message
         const { activity, recipients } = ctx.params;
@@ -76,7 +76,7 @@ const SingleMailNotificationsService = {
           }
         }
       }
-    })
+    }
   },
   methods: {
     // Optional method called for each notification

--- a/src/middleware/packages/ontologies/actions/findNamespace.ts
+++ b/src/middleware/packages/ontologies/actions/findNamespace.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -20,6 +20,6 @@ const Schema = defineAction({
 
     return null;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/actions/findPrefix.ts
+++ b/src/middleware/packages/ontologies/actions/findPrefix.ts
@@ -1,8 +1,8 @@
 import fetch from 'node-fetch';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { isURL } from '../utils.ts';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -25,6 +25,6 @@ const Schema = defineAction({
 
     return null;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/actions/get.ts
+++ b/src/middleware/packages/ontologies/actions/get.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     prefix: { type: 'string', optional: true },
@@ -30,6 +30,6 @@ const Schema = defineAction({
 
     return ontology;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/actions/getPrefixes.ts
+++ b/src/middleware/packages/ontologies/actions/getPrefixes.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   cache: true,
   async handler(ctx) {
@@ -11,6 +11,6 @@ const Schema = defineAction({
         .map((ontology: any) => [ontology.prefix, ontology.namespace])
     );
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/actions/getRdfPrefixes.ts
+++ b/src/middleware/packages/ontologies/actions/getRdfPrefixes.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   cache: true,
   async handler(ctx) {
@@ -10,6 +10,6 @@ const Schema = defineAction({
       .map((ontology: any) => `PREFIX ${ontology.prefix}: <${ontology.namespace}>`)
       .join('\n');
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/actions/list.ts
+++ b/src/middleware/packages/ontologies/actions/list.ts
@@ -1,11 +1,11 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   cache: true,
   handler() {
     return Object.values(this.ontologies);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/actions/prefixToUri.ts
+++ b/src/middleware/packages/ontologies/actions/prefixToUri.ts
@@ -1,9 +1,9 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { isURL } from '../utils.ts';
 
 const regexPrefix = /^([^:]+):([^:]+)$/gm;
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -27,6 +27,6 @@ const Schema = defineAction({
 
     return value.replace(`${ontology.prefix}:`, ontology.namespace);
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/actions/register.ts
+++ b/src/middleware/packages/ontologies/actions/register.ts
@@ -1,7 +1,7 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { isURL, arrayOf } from '../utils.ts';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type 'string' is not assignable to type 'Parameter... Remove this comment to see the full error message
@@ -62,6 +62,6 @@ const Schema = defineAction({
 
     ctx.emit('ontologies.registered', { prefix, namespace, owl, jsonldContext, preserveContextUri });
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/ontologies/sub-services/registry.ts
+++ b/src/middleware/packages/ontologies/sub-services/registry.ts
@@ -1,6 +1,6 @@
 import DbService from 'moleculer-db';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const OntologiesRegistrySchema = {
   name: 'ontologies.registry' as const,
@@ -10,30 +10,30 @@ const OntologiesRegistrySchema = {
     idField: '@id'
   },
   actions: {
-    getByPrefix: defineAction({
+    getByPrefix: {
       async handler(ctx) {
         const { prefix } = ctx.params;
         const [ontology] = await this._find(ctx, { query: { prefix } });
         return ontology && { prefix: ontology.prefix, namespace: ontology.namespace };
       }
-    }),
+    },
 
-    getByNamespace: defineAction({
+    getByNamespace: {
       async handler(ctx) {
         const { namespace } = ctx.params;
         const [ontology] = await this._find(ctx, { query: { namespace } });
         return ontology && { prefix: ontology.prefix, namespace: ontology.namespace };
       }
-    }),
+    },
 
-    list: defineAction({
+    list: {
       async handler(ctx) {
         const ontologies = await this._list(ctx, {});
         return ontologies.rows.map(({ prefix, namespace }: any) => ({ prefix, namespace }));
       }
-    }),
+    },
 
-    updateOrCreate: defineAction({
+    updateOrCreate: {
       async handler(ctx) {
         const { prefix, namespace } = ctx.params;
 
@@ -51,7 +51,7 @@ const OntologiesRegistrySchema = {
           });
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/solid/services/endpoint.ts
+++ b/src/middleware/packages/solid/services/endpoint.ts
@@ -1,5 +1,5 @@
 import { SpecialEndpointMixin } from '@semapps/ldp';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const SolidEndpointSchema = {
   name: 'solid-endpoint' as const,
@@ -19,14 +19,14 @@ const SolidEndpointSchema = {
     await this.broker.call('ldp.link-header.register', { actionName: 'solid-endpoint.getLink' });
   },
   actions: {
-    getLink: defineAction({
+    getLink: {
       handler() {
         return {
           uri: this.endpointUrl,
           rel: 'http://www.w3.org/ns/solid/terms#storageDescription'
         };
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.ts
+++ b/src/middleware/packages/solid/services/notifications/channels/notification-channel.mixin.ts
@@ -8,7 +8,7 @@ import { namedNode } from '@rdfjs/data-model';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'uuid... Remove this comment to see the full error message
 import { v4 as uuidV4 } from 'uuid';
 import moment from 'moment';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 /**
  * Solid Notification Channel mixin.
@@ -75,7 +75,7 @@ const Schema = {
     this.loadChannelsFromDb({ removeOldChannels: true });
   },
   actions: {
-    endpointPost: defineAction({
+    endpointPost: {
       // Action called by the SpecialEndpointMixin when POSTing to the endpoint
       async handler(ctx) {
         // Expect format https://communitysolidserver.github.io/CommunitySolidServer/latest/usage/notifications/#webhooks
@@ -154,76 +154,76 @@ const Schema = {
           { parentCtx: ctx }
         );
       }
-    }),
+    },
 
-    getCache: defineAction({
+    getCache: {
       handler() {
         return this.channels;
       }
-    }),
+    },
 
-    resetCache: defineAction({
+    resetCache: {
       handler() {
         this.channels = [];
       }
-    })
+    }
   },
   events: {
-    'ldp.resource.created': defineServiceEvent({
+    'ldp.resource.created': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, newData } = ctx.params;
         // @ts-expect-error TS(2339): Property 'onResourceEvent' does not exist on type ... Remove this comment to see the full error message
         this.onResourceEvent(resourceUri, ACTIVITY_TYPES.CREATE, newData['dc:modified']);
       }
-    }),
+    },
 
-    'ldp.resource.updated': defineServiceEvent({
+    'ldp.resource.updated': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, newData } = ctx.params;
         // @ts-expect-error TS(2339): Property 'onResourceEvent' does not exist on type ... Remove this comment to see the full error message
         this.onResourceEvent(resourceUri, ACTIVITY_TYPES.UPDATE, newData['dc:modified']);
       }
-    }),
+    },
 
-    'ldp.resource.patched': defineServiceEvent({
+    'ldp.resource.patched': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'onResourceEvent' does not exist on type ... Remove this comment to see the full error message
         this.onResourceEvent(resourceUri, ACTIVITY_TYPES.UPDATE, await this.getModified(resourceUri));
       }
-    }),
+    },
 
-    'ldp.resource.deleted': defineServiceEvent({
+    'ldp.resource.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'onResourceEvent' does not exist on type ... Remove this comment to see the full error message
         this.onResourceEvent(resourceUri, ACTIVITY_TYPES.DELETE, new Date().toISOString());
       }
-    }),
+    },
 
-    'ldp.container.attached': defineServiceEvent({
+    'ldp.container.attached': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'containerUri' does not exist on type 'Op... Remove this comment to see the full error message
         const { containerUri, resourceUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'onContainerOrCollectionEvent' does not e... Remove this comment to see the full error message
         this.onContainerOrCollectionEvent(containerUri, resourceUri, ACTIVITY_TYPES.ADD);
       }
-    }),
+    },
 
-    'ldp.container.detached': defineServiceEvent({
+    'ldp.container.detached': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'containerUri' does not exist on type 'Op... Remove this comment to see the full error message
         const { containerUri, resourceUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'onContainerOrCollectionEvent' does not e... Remove this comment to see the full error message
         this.onContainerOrCollectionEvent(containerUri, resourceUri, ACTIVITY_TYPES.REMOVE);
       }
-    }),
+    },
 
-    'activitypub.collection.added': defineServiceEvent({
+    'activitypub.collection.added': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'collectionUri' does not exist on type 'O... Remove this comment to see the full error message
         const { collectionUri, itemUri, item } = ctx.params;
@@ -233,16 +233,16 @@ const Schema = {
         // @ts-expect-error TS(2339): Property 'onContainerOrCollectionEvent' does not e... Remove this comment to see the full error message
         this.onContainerOrCollectionEvent(collectionUri, itemUri || item, ACTIVITY_TYPES.ADD);
       }
-    }),
+    },
 
-    'activitypub.collection.removed': defineServiceEvent({
+    'activitypub.collection.removed': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'collectionUri' does not exist on type 'O... Remove this comment to see the full error message
         const { collectionUri, itemUri } = ctx.params;
         // @ts-expect-error TS(2339): Property 'onContainerOrCollectionEvent' does not e... Remove this comment to see the full error message
         this.onContainerOrCollectionEvent(collectionUri, itemUri, ACTIVITY_TYPES.REMOVE);
       }
-    })
+    }
   },
   methods: {
     async getModified(resourceUri) {

--- a/src/middleware/packages/solid/services/notifications/channels/webhook-channel.ts
+++ b/src/middleware/packages/solid/services/notifications/channels/webhook-channel.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import NotificationChannelMixin from './notification-channel.mixin.ts';
 
 const queueOptions =
@@ -35,15 +35,15 @@ const WebhookChannel2023Service = {
     if (!this.createJob) throw new Error('The QueueMixin must be configured with this service');
   },
   actions: {
-    getAppChannels: defineAction({
+    getAppChannels: {
       async handler(ctx) {
         const { appUri, webId } = ctx.params;
         const { origin: appOrigin } = new URL(appUri);
         return this.channels.filter((c: any) => c.webId === webId && c.sendTo.startsWith(appOrigin));
       }
-    }),
+    },
 
-    deleteAppChannels: defineAction({
+    deleteAppChannels: {
       async handler(ctx) {
         const { appUri, webId } = ctx.params;
         const appChannels = await this.actions.getAppChannels({ appUri, webId }, { parentCtx: ctx });
@@ -51,7 +51,7 @@ const WebhookChannel2023Service = {
           await this.actions.delete({ resourceUri: appChannel.id, webId: appChannel.webId });
         }
       }
-    })
+    }
   },
   methods: {
     onEvent(channel, activity) {

--- a/src/middleware/packages/solid/services/notifications/listener.ts
+++ b/src/middleware/packages/solid/services/notifications/listener.ts
@@ -8,7 +8,7 @@ import DbService from 'moleculer-db';
 import { parseHeader, negotiateContentType, parseJson } from '@semapps/middlewares';
 import { notify } from '@semapps/ontologies';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { Errors, ServiceSchema, defineAction } from 'moleculer';
+import { Errors, ServiceSchema } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
@@ -46,7 +46,7 @@ const SolidNotificationsListenerSchema = {
     });
   },
   actions: {
-    register: defineAction({
+    register: {
       async handler(ctx) {
         const { resourceUri, actionName } = ctx.params;
 
@@ -143,9 +143,9 @@ const SolidNotificationsListenerSchema = {
 
         return listener;
       }
-    }),
+    },
 
-    transfer: defineAction({
+    transfer: {
       async handler(ctx) {
         const { uuid, ...data } = ctx.params;
         const webhookUrl = urlJoin(this.settings.baseUrl, '.webhooks', uuid);
@@ -165,13 +165,13 @@ const SolidNotificationsListenerSchema = {
           throw new MoleculerError(`No webhook found with URL ${webhookUrl}`, 404, 'NOT_FOUND');
         }
       }
-    }),
+    },
 
-    getCache: defineAction({
+    getCache: {
       handler() {
         return this.listeners;
       }
-    })
+    }
   },
   methods: {
     async getSolidEndpoint(resourceUri) {

--- a/src/middleware/packages/solid/services/storage.ts
+++ b/src/middleware/packages/solid/services/storage.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
 import { triple, namedNode } from '@rdfjs/data-model';
 import { pim } from '@semapps/ontologies';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 /** @type {import('moleculer').ServiceSchema} */
 const SolidStorageSchema = {
@@ -26,7 +26,7 @@ const SolidStorageSchema = {
     });
   },
   actions: {
-    create: defineAction({
+    create: {
       async handler(ctx) {
         const { username } = ctx.params;
         if (!username) throw new Error('Cannot create Solid storage without a username');
@@ -45,18 +45,18 @@ const SolidStorageSchema = {
 
         return storageRootUri;
       }
-    }),
+    },
 
-    getUrl: defineAction({
+    getUrl: {
       async handler(ctx) {
         const { webId } = ctx.params;
         // This is faster, but later we should use the 'pim:storage' property of the webId
         return urlJoin(webId, this.settings.pathName);
       }
-    })
+    }
   },
   events: {
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId } = ctx.params;
@@ -95,7 +95,7 @@ const SolidStorageSchema = {
           webId: 'system'
         });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/solid/services/type-index/type-indexes.ts
+++ b/src/middleware/packages/solid/services/type-index/type-indexes.ts
@@ -2,7 +2,7 @@ import { ControlledContainerMixin, DereferenceMixin, delay, arrayOf } from '@sem
 import { solid, skos, apods } from '@semapps/ontologies';
 import { MIME_TYPES } from '@semapps/mime-types';
 import { namedNode, triple } from '@rdfjs/data-model';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import TypeRegistrationsService from './type-registrations.ts';
 
 const TypeIndexesSchema = {
@@ -31,7 +31,7 @@ const TypeIndexesSchema = {
     await this.broker.call('ontologies.register', apods);
   },
   actions: {
-    createPublicIndex: defineAction({
+    createPublicIndex: {
       async handler(ctx) {
         const { webId } = ctx.params;
 
@@ -65,9 +65,9 @@ const TypeIndexesSchema = {
           webId
         });
       }
-    }),
+    },
 
-    createPrivateIndex: defineAction({
+    createPrivateIndex: {
       async handler(ctx) {
         const { webId } = ctx.params;
 
@@ -103,9 +103,9 @@ const TypeIndexesSchema = {
           webId
         });
       }
-    }),
+    },
 
-    getPublicIndex: defineAction({
+    getPublicIndex: {
       async handler(ctx) {
         const { webId } = ctx.params;
 
@@ -117,9 +117,9 @@ const TypeIndexesSchema = {
 
         return user['solid:publicTypeIndex'];
       }
-    }),
+    },
 
-    getPrivateIndex: defineAction({
+    getPrivateIndex: {
       async handler(ctx) {
         const { webId } = ctx.params;
 
@@ -130,9 +130,9 @@ const TypeIndexesSchema = {
 
         return preferencesFileUri?.['solid:privateTypeIndex'];
       }
-    }),
+    },
 
-    waitForIndexCreation: defineAction({
+    waitForIndexCreation: {
       async handler(ctx) {
         const { type, webId } = ctx.params;
         let indexUri;
@@ -160,9 +160,9 @@ const TypeIndexesSchema = {
 
         return indexUri;
       }
-    }),
+    },
 
-    awaitCreateComplete: defineAction({
+    awaitCreateComplete: {
       /**
        * Wait until all type registrations have been created for the newly-created user
        */
@@ -186,7 +186,7 @@ const TypeIndexesSchema = {
             );
         } while (numTypeRegistrations < numContainersWithTypeIndex);
       }
-    })
+    }
   },
   methods: {
     async preferencesFileAvailable() {
@@ -195,7 +195,7 @@ const TypeIndexesSchema = {
     }
   },
   events: {
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId } = ctx.params;
@@ -215,7 +215,7 @@ const TypeIndexesSchema = {
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.createPrivateIndex({ webId }, { parentCtx: ctx });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/solid/services/type-index/type-registrations.ts
+++ b/src/middleware/packages/solid/services/type-index/type-registrations.ts
@@ -2,7 +2,7 @@ import urlJoin from 'url-join';
 import { namedNode, triple } from '@rdfjs/data-model';
 import { ControlledContainerMixin, arrayOf } from '@semapps/ldp';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const TypeRegistrationsSchema = {
   name: 'type-registrations' as const,
@@ -15,7 +15,7 @@ const TypeRegistrationsSchema = {
     activateTombstones: false
   },
   actions: {
-    register: defineAction({
+    register: {
       visibility: 'public',
       params: {
         // @ts-expect-error TS(2322): Type '{ type: "array"; }' is not assignable to typ... Remove this comment to see the full error message
@@ -113,14 +113,14 @@ const TypeRegistrationsSchema = {
           return registrationUri;
         }
       }
-    }),
+    },
 
     /**
      * Bind an application to a certain type of resources
      * If no other app is bound with this type yet, it will be marked as the default app
      * Otherwise, the app will be added to the list of available apps, that the user can switch to
      */
-    bindApp: defineAction({
+    bindApp: {
       visibility: 'public',
       params: {
         containerUri: { type: 'string' },
@@ -145,12 +145,12 @@ const TypeRegistrationsSchema = {
           webId
         });
       }
-    }),
+    },
 
     /**
      * Unbind an application from a certain type of resource (Mirror of the above action.)
      */
-    unbindApp: defineAction({
+    unbindApp: {
       visibility: 'public',
       params: {
         containerUri: { type: 'string' },
@@ -180,9 +180,9 @@ const TypeRegistrationsSchema = {
           webId
         });
       }
-    }),
+    },
 
-    getByType: defineAction({
+    getByType: {
       visibility: 'public',
       params: {
         type: { type: 'string' },
@@ -204,9 +204,9 @@ const TypeRegistrationsSchema = {
         // There can be several TypeRegistration per type
         return arrayOf(filteredContainer['ldp:contains']);
       }
-    }),
+    },
 
-    getByContainerUri: defineAction({
+    getByContainerUri: {
       visibility: 'public',
       params: {
         containerUri: { type: 'string' },
@@ -226,9 +226,9 @@ const TypeRegistrationsSchema = {
         // There should be only one TypeRegistration per container
         return arrayOf(filteredContainer['ldp:contains'])[0];
       }
-    }),
+    },
 
-    findContainersUris: defineAction({
+    findContainersUris: {
       visibility: 'public',
       params: {
         type: { type: 'string' },
@@ -241,13 +241,13 @@ const TypeRegistrationsSchema = {
 
         return registrations.map((r: any) => r['solid:instanceContainer']);
       }
-    }),
+    },
 
     /**
      * Reset the public and private registries of the given user
      * Based on the information found on the LDP registry
      */
-    resetFromRegistry: defineAction({
+    resetFromRegistry: {
       visibility: 'public',
       params: {
         webId: { type: 'string' }
@@ -291,10 +291,10 @@ const TypeRegistrationsSchema = {
           }
         }
       }
-    })
+    }
   },
   events: {
-    'ldp.container.created': defineServiceEvent({
+    'ldp.container.created': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'containerUri' does not exist on type 'Op... Remove this comment to see the full error message
         const { containerUri, options, webId } = ctx.params;
@@ -314,7 +314,7 @@ const TypeRegistrationsSchema = {
           );
         }
       }
-    })
+    }
   },
   hooks: {
     after: {

--- a/src/middleware/packages/sparql-endpoint/service.ts
+++ b/src/middleware/packages/sparql-endpoint/service.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error
 import path from 'path';
 import urlJoin from 'url-join';
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import getRoute from './getRoute.ts';
 
 const SparqlEndpointService = {
@@ -24,7 +24,7 @@ const SparqlEndpointService = {
     }
   },
   actions: {
-    query: defineAction({
+    query: {
       async handler(ctx) {
         const query = ctx.params.query || ctx.params.body;
         // @ts-expect-error
@@ -57,10 +57,10 @@ const SparqlEndpointService = {
 
         return response;
       }
-    })
+    }
   },
   events: {
-    'auth.registered': defineServiceEvent({
+    'auth.registered': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId } = ctx.params;
@@ -73,7 +73,7 @@ const SparqlEndpointService = {
           });
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/sync/services/mirror.ts
+++ b/src/middleware/packages/sync/services/mirror.ts
@@ -2,7 +2,7 @@ import urlJoin from 'url-join';
 import fetch from 'node-fetch';
 import { createFragmentURL, arrayOf } from '@semapps/ldp';
 import { ACTIVITY_TYPES } from '@semapps/activitypub';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import SynchronizerService from './synchronizer.ts';
 
 import { Errors } from 'moleculer';
@@ -50,7 +50,7 @@ const MirrorSchema = {
     }
   },
   actions: {
-    mirror: defineAction({
+    mirror: {
       visibility: 'public',
       params: {
         serverUrl: { type: 'string', optional: false }
@@ -177,7 +177,7 @@ const MirrorSchema = {
 
         return remoteRelayActorUri;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/triplestore/actions/countTriplesOfSubject.ts
+++ b/src/middleware/packages/triplestore/actions/countTriplesOfSubject.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     uri: {
@@ -44,6 +44,6 @@ const Schema = defineAction({
 
     return results.length;
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/triplestore/actions/deleteOrphanBlankNodes.ts
+++ b/src/middleware/packages/triplestore/actions/deleteOrphanBlankNodes.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     dataset: {
@@ -42,6 +42,6 @@ const Schema = defineAction({
       );
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/triplestore/actions/dropAll.ts
+++ b/src/middleware/packages/triplestore/actions/dropAll.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     webId: {
@@ -30,6 +30,6 @@ const Schema = defineAction({
       }
     });
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/triplestore/actions/insert.ts
+++ b/src/middleware/packages/triplestore/actions/insert.ts
@@ -1,8 +1,8 @@
 import urlJoin from 'url-join';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     resource: {
@@ -63,6 +63,6 @@ const Schema = defineAction({
       });
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/triplestore/actions/query.ts
+++ b/src/middleware/packages/triplestore/actions/query.ts
@@ -1,8 +1,8 @@
 import urlJoin from 'url-join';
 import { MIME_TYPES, negotiateType } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     query: {
@@ -83,6 +83,6 @@ const Schema = defineAction({
         throw new Error('SPARQL Verb not supported');
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/triplestore/actions/tripleExist.ts
+++ b/src/middleware/packages/triplestore/actions/tripleExist.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type '{ type: "object"; }' is not assignable to ty... Remove this comment to see the full error message
@@ -50,6 +50,6 @@ const Schema = defineAction({
       dataset
     });
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/triplestore/actions/update.ts
+++ b/src/middleware/packages/triplestore/actions/update.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-const Schema = defineAction({
+const Schema = {
   visibility: 'public',
   params: {
     query: {
@@ -45,6 +45,6 @@ const Schema = defineAction({
       });
     }
   }
-});
+} satisfies ActionSchema;
 
 export default Schema;

--- a/src/middleware/packages/triplestore/subservices/dataset.ts
+++ b/src/middleware/packages/triplestore/subservices/dataset.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import urlJoin from 'url-join';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'stri... Remove this comment to see the full error message
 import format from 'string-template';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -24,7 +24,7 @@ const DatasetService = {
     };
   },
   actions: {
-    backup: defineAction({
+    backup: {
       async handler(ctx) {
         const { dataset } = ctx.params;
 
@@ -38,9 +38,9 @@ const DatasetService = {
         const { taskId } = await response.json();
         await this.actions.waitForTaskCompletion({ taskId }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    create: defineAction({
+    create: {
       async handler(ctx) {
         const { dataset, secure } = ctx.params;
         if (!dataset) throw new Error('Unable to create dataset. The parameter dataset is missing');
@@ -70,9 +70,9 @@ const DatasetService = {
           }
         }
       }
-    }),
+    },
 
-    exist: defineAction({
+    exist: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         const response = await fetch(urlJoin(this.settings.url, '$/datasets/', dataset), {
@@ -80,9 +80,9 @@ const DatasetService = {
         });
         return response.status === 200;
       }
-    }),
+    },
 
-    list: defineAction({
+    list: {
       async handler() {
         const response = await fetch(urlJoin(this.settings.url, '$/datasets'), {
           headers: this.headers
@@ -94,9 +94,9 @@ const DatasetService = {
         }
         return [];
       }
-    }),
+    },
 
-    isSecure: defineAction({
+    isSecure: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         // Check if http://semapps.org/webacl graph exists
@@ -106,9 +106,9 @@ const DatasetService = {
           webId: 'system'
         });
       }
-    }),
+    },
 
-    waitForCreation: defineAction({
+    waitForCreation: {
       async handler(ctx) {
         const { dataset } = ctx.params;
         let datasetExist;
@@ -117,9 +117,9 @@ const DatasetService = {
           datasetExist = await this.actions.exist({ dataset }, { parentCtx: ctx });
         } while (!datasetExist);
       }
-    }),
+    },
 
-    waitForTaskCompletion: defineAction({
+    waitForTaskCompletion: {
       async handler(ctx) {
         const { taskId } = ctx.params;
         let task;
@@ -137,9 +137,9 @@ const DatasetService = {
           }
         } while (!task || !task.finished);
       }
-    }),
+    },
 
-    delete: defineAction({
+    delete: {
       params: {
         dataset: { type: 'string' },
         iKnowWhatImDoing: { type: 'boolean' }
@@ -180,7 +180,7 @@ const DatasetService = {
           ]);
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/void/service.ts
+++ b/src/middleware/packages/void/service.ts
@@ -5,7 +5,7 @@ import { JsonLdSerializer } from 'jsonld-streaming-serializer';
 import { DataFactory, Writer } from 'n3';
 import { createFragmentURL, regexProtocolAndHostAndPort, arrayOf } from '@semapps/ldp';
 import { parseHeader } from '@semapps/middlewares';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const { quad, namedNode, literal, blankNode } = DataFactory;
 import { Errors } from 'moleculer';
@@ -182,7 +182,7 @@ const VoidSchema = {
     });
   },
   actions: {
-    getRemote: defineAction({
+    getRemote: {
       visibility: 'public',
       params: {
         serverUrl: { type: 'string', optional: false }
@@ -205,9 +205,9 @@ const VoidSchema = {
           this.logger.warn(`Silently ignored error when fetching void endpoint: ${e.message}`);
         }
       }
-    }),
+    },
 
-    get: defineAction({
+    get: {
       visibility: 'public',
       params: {
         accept: { type: 'string', optional: true }
@@ -362,9 +362,9 @@ const VoidSchema = {
 
         return await this.formatOutput(ctx, graph, url, accept === MIME_TYPES.JSON);
       }
-    }),
+    },
 
-    api_get: defineAction({
+    api_get: {
       handler: async function api(ctx) {
         // @ts-expect-error TS(2339): Property 'headers' does not exist on type '{}'.
         let { accept } = ctx.meta.headers;
@@ -376,7 +376,7 @@ const VoidSchema = {
           accept: accept
         });
       }
-    })
+    }
   },
   methods: {
     async getContainers(ctx) {

--- a/src/middleware/packages/webacl/bots/authorizer.ts
+++ b/src/middleware/packages/webacl/bots/authorizer.ts
@@ -1,4 +1,4 @@
-import { ServiceSchema, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const AuthorizerSchema = {
   name: 'authorizer' as const,
@@ -31,7 +31,7 @@ const AuthorizerSchema = {
     }
   },
   events: {
-    'ldp.resource.created': defineServiceEvent({
+    'ldp.resource.created': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, newData } = ctx.params;
@@ -63,9 +63,9 @@ const AuthorizerSchema = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.updated': defineServiceEvent({
+    'ldp.resource.updated': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, newData, oldData } = ctx.params;
@@ -123,7 +123,7 @@ const AuthorizerSchema = {
           }
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/webacl/bots/groups-manager.ts
+++ b/src/middleware/packages/webacl/bots/groups-manager.ts
@@ -1,6 +1,6 @@
 import { arrayOf } from '@semapps/ldp';
 import { MIME_TYPES } from '@semapps/mime-types';
-import { defineAction, defineServiceEvent } from 'moleculer';
+import 'moleculer';
 
 import { hasType } from '../utils.ts';
 
@@ -20,7 +20,7 @@ const GroupsManagerSchema = {
     }
   },
   actions: {
-    refreshAll: defineAction({
+    refreshAll: {
       async handler(ctx) {
         const usersContainer = await ctx.call('ldp.container.get', {
           containerUri: this.settings.usersContainer,
@@ -50,7 +50,7 @@ const GroupsManagerSchema = {
           }
         }
       }
-    })
+    }
   },
   methods: {
     matchRule(rule, record) {
@@ -69,7 +69,7 @@ const GroupsManagerSchema = {
     }
   },
   events: {
-    'ldp.resource.created': defineServiceEvent({
+    'ldp.resource.created': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, newData } = ctx.params;
@@ -90,9 +90,9 @@ const GroupsManagerSchema = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.updated': defineServiceEvent({
+    'ldp.resource.updated': {
       async handler(ctx) {
         const { resourceUri, newData } = ctx.params;
         // @ts-expect-error TS(2339): Property 'isUser' does not exist on type 'ServiceE... Remove this comment to see the full error message
@@ -120,9 +120,9 @@ const GroupsManagerSchema = {
           }
         }
       }
-    }),
+    },
 
-    'ldp.resource.deleted': defineServiceEvent({
+    'ldp.resource.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'resourceUri' does not exist on type 'Opt... Remove this comment to see the full error message
         const { resourceUri, oldData } = ctx.params;
@@ -140,7 +140,7 @@ const GroupsManagerSchema = {
           }
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/webacl/services/cache/index.ts
+++ b/src/middleware/packages/webacl/services/cache/index.ts
@@ -1,9 +1,9 @@
-import { ServiceSchema, defineAction, defineServiceEvent } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const WebaclCacheSchema = {
   name: 'webacl.cache' as const,
   actions: {
-    invalidateResourceRights: defineAction({
+    invalidateResourceRights: {
       // Invalidate the WebACL cache of the given resource
       // If specificUriOnly is false, it will invalidate all resources starting with the given URI
       async handler(ctx) {
@@ -13,9 +13,9 @@ const WebaclCacheSchema = {
           await this.broker.cacher.clean(`webacl.resource.hasRights:${uri}${specificUriOnly ? '|**' : '**'}`);
         }
       }
-    }),
+    },
 
-    invalidateAllUserRights: defineAction({
+    invalidateAllUserRights: {
       // Invalidate all WebACL cache for the given user
       async handler(ctx) {
         if (this.broker.cacher) {
@@ -24,9 +24,9 @@ const WebaclCacheSchema = {
           await this.broker.cacher.clean(`webacl.resource.hasRights:**${uri}**`);
         }
       }
-    }),
+    },
 
-    invalidateAllUserRightsOnPod: defineAction({
+    invalidateAllUserRightsOnPod: {
       async handler(ctx) {
         if (this.broker.cacher) {
           const { webId, podOwner } = ctx.params;
@@ -36,9 +36,9 @@ const WebaclCacheSchema = {
           await this.broker.cacher.clean(`webacl.resource.hasRights:${podOwner}/**|**|${webId}`);
         }
       }
-    }),
+    },
 
-    generateForUser: defineAction({
+    generateForUser: {
       async handler(ctx) {
         const { webId } = ctx.params;
         this.logger.info(`Generating cache for user ${webId}`);
@@ -55,9 +55,9 @@ const WebaclCacheSchema = {
           }
         }
       }
-    }),
+    },
 
-    generateForAll: defineAction({
+    generateForAll: {
       async handler(ctx) {
         const { usersContainer } = ctx.params;
         const users = await ctx.call('ldp.container.getUris', { containerUri: usersContainer });
@@ -65,10 +65,10 @@ const WebaclCacheSchema = {
           await this.actions.generateForUser({ webId }, { parentCtx: ctx });
         }
       }
-    })
+    }
   },
   events: {
-    'webacl.resource.updated': defineServiceEvent({
+    'webacl.resource.updated': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'uri' does not exist on type 'Optionalize... Remove this comment to see the full error message
         const { uri, isContainer, defaultRightsUpdated } = ctx.params;
@@ -78,27 +78,27 @@ const WebaclCacheSchema = {
           { parentCtx: ctx }
         );
       }
-    }),
+    },
 
-    'webacl.resource.deleted': defineServiceEvent({
+    'webacl.resource.deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'uri' does not exist on type 'Optionalize... Remove this comment to see the full error message
         const { uri, isContainer } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateResourceRights({ uri, specificUriOnly: !isContainer }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'webacl.resource.user-deleted': defineServiceEvent({
+    'webacl.resource.user-deleted': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type 'Optionali... Remove this comment to see the full error message
         const { webId } = ctx.params;
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateAllUserRights({ uri: webId }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'webacl.group.member-added': defineServiceEvent({
+    'webacl.group.member-added': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'groupUri' does not exist on type 'Option... Remove this comment to see the full error message
         const { groupUri, memberUri } = ctx.params;
@@ -107,9 +107,9 @@ const WebaclCacheSchema = {
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateAllUserRights({ uri: memberUri }, { parentCtx: ctx });
       }
-    }),
+    },
 
-    'webacl.group.member-removed': defineServiceEvent({
+    'webacl.group.member-removed': {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'groupUri' does not exist on type 'Option... Remove this comment to see the full error message
         const { groupUri, memberUri } = ctx.params;
@@ -118,7 +118,7 @@ const WebaclCacheSchema = {
         // @ts-expect-error TS(2339): Property 'actions' does not exist on type 'Service... Remove this comment to see the full error message
         await this.actions.invalidateAllUserRights({ uri: memberUri }, { parentCtx: ctx });
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/webacl/services/group/actions/addMember.ts
+++ b/src/middleware/packages/webacl/services/group/actions/addMember.ts
@@ -1,6 +1,6 @@
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
@@ -18,7 +18,7 @@ export const api = async function api(this: any, ctx: any) {
   ctx.meta.$statusCode = 204;
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupSlug: { type: 'string', optional: true, min: 1, trim: true },
@@ -66,4 +66,4 @@ export const action = defineAction({
 
     ctx.emit('webacl.group.member-added', { groupUri, memberUri }, { meta: { webId: null, dataset: null } });
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/create.ts
+++ b/src/middleware/packages/webacl/services/group/actions/create.ts
@@ -2,7 +2,7 @@
 import createSlug from 'speakingurl';
 import urlJoin from 'url-join';
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
@@ -25,7 +25,7 @@ export const api = async function api(this: any, ctx: any) {
   ctx.meta.$statusCode = 201;
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupUri: { type: 'string', optional: true },
@@ -88,4 +88,4 @@ export const action = defineAction({
 
     return { groupUri };
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/delete.ts
+++ b/src/middleware/packages/webacl/services/group/actions/delete.ts
@@ -1,6 +1,6 @@
 import urlJoin from 'url-join';
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { removeAgentGroupOrAgentFromAuthorizations } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
@@ -16,7 +16,7 @@ export const api = async function api(this: any, ctx: any) {
   ctx.meta.$statusCode = 204;
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupSlug: { type: 'string', optional: true, min: 1, trim: true },
@@ -61,4 +61,4 @@ export const action = defineAction({
 
     await removeAgentGroupOrAgentFromAuthorizations(groupUri, true, this.settings.graphName, ctx);
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/exist.ts
+++ b/src/middleware/packages/webacl/services/group/actions/exist.ts
@@ -1,12 +1,12 @@
 import urlJoin from 'url-join';
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupSlug: { type: 'string', optional: true, min: 1, trim: true },
@@ -33,4 +33,4 @@ export const action = defineAction({
       webId
     });
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/getGroups.ts
+++ b/src/middleware/packages/webacl/services/group/actions/getGroups.ts
@@ -1,11 +1,11 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 export const api = async function api(this: any, ctx: any) {
   if (this.settings.podProvider) ctx.meta.dataset = ctx.params.username;
   return await ctx.call('webacl.group.getGroups', {});
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     webId: { type: 'string', optional: true }
@@ -56,4 +56,4 @@ export const action = defineAction({
 
     return groups.map((m: any) => m.g.value);
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/getMembers.ts
+++ b/src/middleware/packages/webacl/services/group/actions/getMembers.ts
@@ -1,6 +1,6 @@
 import urlJoin from 'url-join';
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
@@ -13,7 +13,7 @@ export const api = async function api(this: any, ctx: any) {
   });
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupSlug: { type: 'string', optional: true, min: 1, trim: true },
@@ -58,4 +58,4 @@ export const action = defineAction({
 
     return members.map((m: any) => m.m.value);
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/getUri.ts
+++ b/src/middleware/packages/webacl/services/group/actions/getUri.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupSlug: { type: 'string', optional: false, trim: true }
@@ -10,4 +10,4 @@ export const action = defineAction({
     const { groupSlug } = ctx.params;
     return urlJoin(this.settings.baseUrl, '_groups', groupSlug);
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/isMember.ts
+++ b/src/middleware/packages/webacl/services/group/actions/isMember.ts
@@ -1,12 +1,12 @@
 import urlJoin from 'url-join';
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupSlug: { type: 'string', optional: true, min: 1, trim: true },
@@ -52,4 +52,4 @@ export const action = defineAction({
       webId: 'system'
     });
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/group/actions/removeMember.ts
+++ b/src/middleware/packages/webacl/services/group/actions/removeMember.ts
@@ -1,6 +1,6 @@
 import urlJoin from 'url-join';
 import { sanitizeSparqlQuery } from '@semapps/triplestore';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
@@ -19,7 +19,7 @@ export const api = async function api(this: any, ctx: any) {
   ctx.meta.$statusCode = 204;
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     groupSlug: { type: 'string', optional: true, min: 1, trim: true },
@@ -66,4 +66,4 @@ export const action = defineAction({
 
     ctx.emit('webacl.group.member-removed', { groupUri, memberUri }, { meta: { webId: null, dataset: null } });
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/addRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/addRights.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
 import urlJoin from 'url-join';
 
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import {
   getAclUriFromResourceUri,
   convertBodyToTriples,
@@ -37,7 +37,7 @@ export const api = async function api(this: any, ctx: any) {
   ctx.meta.$statusCode = 204;
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -176,4 +176,4 @@ export const action = defineAction({
     ctx.emit('webacl.resource.updated', returnValues, { meta: { webId: null, dataset: null } });
     return returnValues;
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/awaitReadRight.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/awaitReadRight.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -35,4 +35,4 @@ export const action = defineAction({
       interval = setInterval(checkRights, 1000);
     });
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/deleteAllRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/deleteAllRights.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string', optional: false }
@@ -29,4 +29,4 @@ export const action = defineAction({
       { meta: { webId: null, dataset: null } }
     );
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/deleteAllUserRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/deleteAllUserRights.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     webId: { type: 'string', optional: false }
@@ -25,4 +25,4 @@ export const action = defineAction({
       { meta: { webId: null, dataset: null } }
     );
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/getLink.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/getLink.ts
@@ -1,7 +1,7 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { getAclUriFromResourceUri } from '../../../utils.ts';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     uri: { type: 'string', optional: false }
@@ -13,4 +13,4 @@ export const action = defineAction({
       rel: 'acl'
     };
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/getRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/getRights.ts
@@ -3,7 +3,7 @@ import { DataFactory, Writer } from 'n3';
 import urlJoin from 'url-join';
 import { MIME_TYPES } from '@semapps/mime-types';
 
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import {
   getAuthorizationNode,
   checkAgentPresent,
@@ -209,7 +209,7 @@ export const api = async function api(this: any, ctx: any) {
   });
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -233,4 +233,4 @@ export const action = defineAction({
 
     return await getPermissions(ctx, resourceUri, this.settings.baseUrl, webId, this.settings.graphName, isContainer);
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/getUsersWithReadRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/getUsersWithReadRights.ts
@@ -1,8 +1,8 @@
 import { MIME_TYPES } from '@semapps/mime-types';
 import { arrayOf } from '@semapps/ldp';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' }
@@ -32,4 +32,4 @@ export const action = defineAction({
     // Deduplicate (users might be in multiple groups).
     return [...new Set(usersWithReadRights)];
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/hasRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/hasRights.ts
@@ -1,6 +1,6 @@
 import urlJoin from 'url-join';
 
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import {
   getAuthorizationNode,
   checkAgentPresent,
@@ -96,7 +96,7 @@ export const api = async function api(this: any, ctx: any) {
   });
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -132,4 +132,4 @@ export const action = defineAction({
     await this.checkResourceOrContainerExists(ctx, resourceUri);
     return await hasPermissions(ctx, resourceUri, rights, this.settings.baseUrl, webId, this.settings.graphName);
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/isPublic.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/isPublic.ts
@@ -1,6 +1,6 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' }
@@ -14,4 +14,4 @@ export const action = defineAction({
     });
     return read;
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/refreshContainersRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/refreshContainersRights.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   async handler(ctx) {
     const { webId } = ctx.params;
@@ -59,4 +59,4 @@ export const action = defineAction({
       }
     }
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/removeRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/removeRights.ts
@@ -1,11 +1,11 @@
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import { getAclUriFromResourceUri, processRights, FULL_AGENTCLASS_URI, FULL_FOAF_AGENT } from '../../../utils.ts';
 
 import { Errors } from 'moleculer';
 
 const { MoleculerError } = Errors;
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     // @ts-expect-error TS(2322): Type '{ type: "string"; optional: false; }' is not... Remove this comment to see the full error message
@@ -75,4 +75,4 @@ export const action = defineAction({
       { meta: { webId: null, dataset: null } }
     );
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webacl/services/resource/actions/setRights.ts
+++ b/src/middleware/packages/webacl/services/resource/actions/setRights.ts
@@ -1,7 +1,7 @@
 import { MIME_TYPES } from '@semapps/mime-types';
 import urlJoin from 'url-join';
 
-import { defineAction } from 'moleculer';
+import { ActionSchema } from 'moleculer';
 import {
   getAclUriFromResourceUri,
   convertBodyToTriples,
@@ -36,7 +36,7 @@ export const api = async function api(this: any, ctx: any) {
   ctx.meta.$statusCode = 204;
 };
 
-export const action = defineAction({
+export const action = {
   visibility: 'public',
   params: {
     resourceUri: { type: 'string' },
@@ -160,4 +160,4 @@ export const action = defineAction({
     ctx.emit('webacl.resource.updated', returnValues, { meta: { webId: null, dataset: null } });
     return returnValues;
   }
-});
+} satisfies ActionSchema;

--- a/src/middleware/packages/webfinger/service.ts
+++ b/src/middleware/packages/webfinger/service.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 const WebfingerService = {
   name: 'webfinger' as const,
@@ -26,7 +26,7 @@ const WebfingerService = {
     });
   },
   actions: {
-    get: defineAction({
+    get: {
       async handler(ctx) {
         const { resource } = ctx.params;
 
@@ -54,9 +54,9 @@ const WebfingerService = {
         // @ts-expect-error TS(2339): Property '$statusCode' does not exist on type '{}'... Remove this comment to see the full error message
         ctx.meta.$statusCode = 404;
       }
-    }),
+    },
 
-    getRemoteUri: defineAction({
+    getRemoteUri: {
       // TODO add cache if response.ok
       async handler(ctx) {
         const { account } = ctx.params;
@@ -75,7 +75,7 @@ const WebfingerService = {
           }
         }
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/packages/webhooks/service.ts
+++ b/src/middleware/packages/webhooks/service.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import DbService from 'moleculer-db';
 import { TripleStoreAdapter } from '@semapps/triplestore';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 import { Errors } from 'moleculer';
 
@@ -31,7 +31,7 @@ const WebhooksService = {
     }
   },
   actions: {
-    process: defineAction({
+    process: {
       async handler(ctx) {
         const { hash, ...data } = ctx.params;
         let webhook;
@@ -49,9 +49,9 @@ const WebhooksService = {
           return await this.actions[webhook.action]({ data, user: webhook.user }, { parentCtx: ctx });
         }
       }
-    }),
+    },
 
-    generate: defineAction({
+    generate: {
       async handler(ctx) {
         // @ts-expect-error TS(2339): Property 'webId' does not exist on type '{}'.
         const userUri = ctx.meta.webId || ctx.params.userUri;
@@ -72,9 +72,9 @@ const WebhooksService = {
 
         return webhook['@id'];
       }
-    }),
+    },
 
-    getApiRoutes: defineAction({
+    getApiRoutes: {
       handler(basePath) {
         return [
           // Unsecured routes
@@ -103,7 +103,7 @@ const WebhooksService = {
           }
         ];
       }
-    })
+    }
   },
   queues: {
     webhooks: {

--- a/src/middleware/packages/webid/service.ts
+++ b/src/middleware/packages/webid/service.ts
@@ -2,7 +2,7 @@ import urlJoin from 'url-join';
 import { MIME_TYPES } from '@semapps/mime-types';
 import { foaf, schema } from '@semapps/ontologies';
 import { ControlledContainerMixin, DereferenceMixin, getDatasetFromUri } from '@semapps/ldp';
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 
 /** @type {import('moleculer').ServiceSchema} */
 const WebIdService = {
@@ -32,7 +32,7 @@ const WebIdService = {
     await this.broker.call('ontologies.register', schema);
   },
   actions: {
-    get: defineAction({
+    get: {
       handler(ctx) {
         // Always get WebID as system and on the correct dataset, since they are public
         return ctx.call(
@@ -49,9 +49,9 @@ const WebIdService = {
           }
         );
       }
-    }),
+    },
 
-    createWebId: defineAction({
+    createWebId: {
       /**
        * This should only be called after the user has been authenticated
        */
@@ -114,7 +114,7 @@ const WebIdService = {
 
         return webId;
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 

--- a/src/middleware/tests/ldp/initialize.ts
+++ b/src/middleware/tests/ldp/initialize.ts
@@ -1,4 +1,4 @@
-import { ServiceBroker, ServiceSchema, defineAction } from 'moleculer';
+import { ServiceBroker, ServiceSchema } from 'moleculer';
 import fs from 'fs';
 import path, { join as pathJoin } from 'path';
 import { CoreService } from '@semapps/core';
@@ -109,7 +109,7 @@ const initialize = async () => {
       permissions
     },
     actions: {
-      getHeaderLinks: defineAction({
+      getHeaderLinks: {
         handler() {
           return [
             {
@@ -118,7 +118,7 @@ const initialize = async () => {
             }
           ];
         }
-      })
+      }
     }
   });
 

--- a/src/middleware/tests/types/moleculer.test-d.ts
+++ b/src/middleware/tests/types/moleculer.test-d.ts
@@ -1,7 +1,7 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema, ActionSchema } from 'moleculer';
 import { expectTypeOf } from 'expect-type';
 
-const actionWithComplexParam = defineAction({
+const actionWithComplexParam = {
   params: {
     optionalParam: { type: 'string', optional: true },
     defaultParam: { type: 'string', default: 'default value' },
@@ -25,7 +25,7 @@ const actionWithComplexParam = defineAction({
 
     return null;
   }
-});
+} satisfies ActionSchema;
 
 const testService1 = {
   name: 'test-service1' as const,
@@ -62,11 +62,11 @@ const testVersionedService2 = {
         return number;
       }
     },
-    actionWithoutParamsReturnsStringArr: defineAction({
+    actionWithoutParamsReturnsStringArr: {
       handler() {
         return [''];
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 
@@ -74,7 +74,7 @@ const testVersionedService3 = {
   name: 'test-service3-versioned' as const,
   version: 'v3' as const, // Version as string
   actions: {
-    actionWithDocumentedNumParamReturnsString: defineAction({
+    actionWithDocumentedNumParamReturnsString: {
       params: {
         /**
          * **You can have documentation here and even parameter renaming is supported. **
@@ -87,11 +87,11 @@ const testVersionedService3 = {
 
         return 'return value of actionWithNumParamReturnsString';
       }
-    })
+    }
   }
 } satisfies ServiceSchema;
 
-const externalAction = defineAction({
+const externalAction = {
   params: {
     length: { type: 'number' }
   },
@@ -102,7 +102,7 @@ const externalAction = defineAction({
 
     return `list was called successfully with length param ${length * 2}`;
   }
-});
+} satisfies ActionSchema;
 
 const testService4ExternalAction = {
   name: 'test-service4-external-action' as const,
@@ -115,7 +115,7 @@ const testService4ExternalAction = {
 const testCallService = {
   name: 'test-call-service',
   actions: {
-    testAction: defineAction({
+    testAction: {
       params: {},
       async handler(ctx) {
         expectTypeOf(ctx.call('not.registered.returns.any')).toEqualTypeOf<Promise<any>>(); // okay because unknown
@@ -157,7 +157,7 @@ const testCallService = {
         // @ts-expect-error TS(2554): Expected 2-3 arguments, but got 1.
         await ctx.call('v2.test-service2-versioned.actionWithStringParamReturnsNum');
       }
-    })
+    }
   },
   methods: {
     async m1(v1) {


### PR DESCRIPTION
Since this was causing issues when using yarn classic and for now the moleculer type definitions are not quite working, I'll revert that change for now.