### PR TITLE
run yalc:publish upon git operations in background

### DIFF
--- a/scripts/run-yalc-publish.sh
+++ b/scripts/run-yalc-publish.sh
@@ -10,13 +10,17 @@ if [ "$SKIP_YALC_PUBLISH" = true ] || [ "$SKIP_YALC_PUBLISH" = 1 ] ; then
 fi
 
 
-echo ===  Running yalc:publish ===
 
+# Determine repository root so we can cd into the frontend package.
 ROOT_DIR=$(git rev-parse --show-toplevel)
-cd "$ROOT_DIR"/src/frontend
 
-# Run yalc:publish. If not available, just print an info message.
-yarn yalc:publish &> /dev/null || \
-   echo "⚠️ yarn or yalc is not installed. Skipping yalc:publish" 
+# Run yalc:publish in a detached background process and discard all output.
+nohup bash -lc "cd \"${ROOT_DIR}/src/frontend\" && yarn yalc:publish >/dev/null 2>&1" >/dev/null 2>&1 &
+
+# Capture background PID and disown it so it won't be tied to this script's shell.
+PID=$!
+disown "$PID" >/dev/null 2>&1 || true
+
+echo "=== Running yalc:publish in the background (pid ${PID}) ==="
 
 exit 0


### PR DESCRIPTION
I detached the yalc:publish command from the git hook (using nohup) so that switching branches is faster.