### PR TITLE
triplestore template .ttl imports to .ts string imports

### DIFF
--- a/src/middleware/packages/triplestore/service.ts
+++ b/src/middleware/packages/triplestore/service.ts
@@ -83,7 +83,7 @@ const TripleStoreService = {
           if (response.status === 500 && text.includes('permissions violation')) {
             throw403(text);
           } else {
-            throw500(`Unable to reach SPARQL endpoint ${url}. Error message: ${response.statusText}. Query: ${body}`);
+            throw500(`Problem with SPARQL-request to ${url}. Error message: ${response.statusText}. Query: ${body}`);
           }
         }
       }

--- a/src/middleware/packages/triplestore/subservices/dataset.ts
+++ b/src/middleware/packages/triplestore/subservices/dataset.ts
@@ -6,6 +6,8 @@ import urlJoin from 'url-join';
 import format from 'string-template';
 import { ServiceSchema } from 'moleculer';
 import { fileURLToPath } from 'url';
+import datasetTemplate from '../templates/dataset.ttl.ts';
+import secureDatasetTemplate from '../templates/secure-dataset.ttl.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const delay = (t: any) => new Promise(resolve => setTimeout(resolve, t));
@@ -52,8 +54,8 @@ const DatasetService = {
           if (dataset.endsWith('Acl') || dataset.endsWith('Mirror'))
             throw new Error(`Error when creating dataset ${dataset}. Its name cannot end with Acl or Mirror`);
 
-          const templateFilePath = path.join(__dirname, '../templates', secure ? 'secure-dataset.ttl' : 'dataset.ttl');
-          const template = await fs.promises.readFile(templateFilePath, 'utf8');
+          const template = secure ? secureDatasetTemplate : datasetTemplate;
+
           const assembler = format(template, { dataset: dataset });
           response = await fetch(urlJoin(this.settings.url, '$/datasets'), {
             method: 'POST',

--- a/src/middleware/packages/triplestore/templates/dataset.ttl.ts
+++ b/src/middleware/packages/triplestore/templates/dataset.ttl.ts
@@ -1,4 +1,4 @@
-@prefix :      <http://base/#> .
+export default `@prefix :      <http://base/#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix tdb2:  <http://jena.apache.org/2016/tdb#> .
 @prefix ja:    <http://jena.hpl.hp.com/2005/11/Assembler#> .
@@ -62,3 +62,4 @@ ja:RDFDatasetOne  rdfs:subClassOf  ja:RDFDataset .
 ja:RDFDatasetSink  rdfs:subClassOf  ja:RDFDataset .
 
 tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
+`;

--- a/src/middleware/packages/triplestore/templates/secure-dataset.ttl.ts
+++ b/src/middleware/packages/triplestore/templates/secure-dataset.ttl.ts
@@ -1,4 +1,4 @@
-# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+export default `# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
 PREFIX :        <#>
 PREFIX fuseki:  <http://jena.apache.org/fuseki#>
@@ -97,3 +97,4 @@ sa:securedDataset rdf:type ja:RDFDataset ;
     fuseki:dataset          sa:securedDataset  ;
   
     .
+`;


### PR DESCRIPTION
This way we don't have to manually copy the .ttl files to the dist directory.