### PR TITLE
Implement LDP paging and sorting

### DIFF
--- a/src/middleware/packages/ldp/services/api/actions/get.ts
+++ b/src/middleware/packages/ldp/services/api/actions/get.ts
@@ -7,7 +7,7 @@ const { MoleculerError } = Errors;
 
 export default async function get(this: any, ctx: any) {
   try {
-    const { username, slugParts } = ctx.params;
+    const { username, slugParts, page } = ctx.params;
 
     const uri = this.getUriFromSlugParts(slugParts, username);
     ctx.meta.dataset = getDatasetFromUri(uri);
@@ -23,16 +23,27 @@ export default async function get(this: any, ctx: any) {
 
       const { controlledActions } = await ctx.call('ldp.registry.getByUri', { containerUri: uri });
 
+      let doNotIncludeResources = false;
+      let maxPerPage;
+
       // See https://www.w3.org/TR/ldp/#prefer-parameters
-      const doNotIncludeResources =
-        ctx.meta.headers?.prefer === 'return=representation; include="http://www.w3.org/ns/ldp#PreferMinimalContainer"';
+      if (ctx.meta.headers?.prefer) {
+        doNotIncludeResources = ctx.meta.headers.prefer.includes(
+          'include="http://www.w3.org/ns/ldp#PreferMinimalContainer"'
+        );
+
+        const regexResults = /max-member-count="(\d+)"/.exec(ctx.meta.headers.prefer);
+        maxPerPage = regexResults?.[1] && parseInt(regexResults[1]);
+      }
 
       res = await ctx.call(
         controlledActions?.list || 'ldp.container.get',
         cleanUndefined({
           containerUri: uri,
           jsonContext: parseJson(ctx.meta.headers?.jsonldcontext),
-          doNotIncludeResources
+          doNotIncludeResources,
+          maxPerPage,
+          page: page && parseInt(page, 10)
         })
       );
 

--- a/src/middleware/packages/ldp/services/api/actions/get.ts
+++ b/src/middleware/packages/ldp/services/api/actions/get.ts
@@ -24,7 +24,9 @@ export default async function get(this: any, ctx: any) {
       const { controlledActions } = await ctx.call('ldp.registry.getByUri', { containerUri: uri });
 
       let doNotIncludeResources = false;
-      let maxPerPage;
+      let maxPerPage: number | undefined;
+      let sortPredicate: string | undefined;
+      let sortOrder: string | undefined;
 
       // See https://www.w3.org/TR/ldp/#prefer-parameters
       if (ctx.meta.headers?.prefer) {
@@ -32,8 +34,14 @@ export default async function get(this: any, ctx: any) {
           'include="http://www.w3.org/ns/ldp#PreferMinimalContainer"'
         );
 
-        const regexResults = /max-member-count="(\d+)"/.exec(ctx.meta.headers.prefer);
-        maxPerPage = regexResults?.[1] && parseInt(regexResults[1]);
+        let regexResults = /max-member-count="(\d+)"/.exec(ctx.meta.headers.prefer);
+        maxPerPage = regexResults?.[1] ? parseInt(regexResults[1]) : undefined;
+
+        regexResults = /sort-predicate="([^"]+)"/.exec(ctx.meta.headers.prefer);
+        sortPredicate = regexResults?.[1];
+
+        regexResults = /sort-order="([ASC|asc|DESC|desc]+)"/.exec(ctx.meta.headers.prefer);
+        sortOrder = regexResults?.[1] ? regexResults?.[1].toUpperCase() : 'ASC';
       }
 
       res = await ctx.call(
@@ -43,7 +51,9 @@ export default async function get(this: any, ctx: any) {
           jsonContext: parseJson(ctx.meta.headers?.jsonldcontext),
           doNotIncludeResources,
           maxPerPage,
-          page: page && parseInt(page, 10)
+          page: page && parseInt(page, 10),
+          sortPredicate,
+          sortOrder
         })
       );
 

--- a/src/middleware/packages/ldp/services/api/actions/get.ts
+++ b/src/middleware/packages/ldp/services/api/actions/get.ts
@@ -7,7 +7,8 @@ const { MoleculerError } = Errors;
 
 export default async function get(this: any, ctx: any) {
   try {
-    const { username, slugParts, page } = ctx.params;
+    let { username, slugParts, page } = ctx.params;
+    page = page ? parseInt(page, 10) : 1;
 
     const uri = this.getUriFromSlugParts(slugParts, username);
     ctx.meta.dataset = getDatasetFromUri(uri);
@@ -15,6 +16,7 @@ export default async function get(this: any, ctx: any) {
     const types = await ctx.call('ldp.resource.getTypes', { resourceUri: uri });
 
     let res;
+    let links = [];
 
     if (types.includes('http://www.w3.org/ns/ldp#Container')) {
       /*
@@ -37,6 +39,17 @@ export default async function get(this: any, ctx: any) {
         let regexResults = /max-member-count="(\d+)"/.exec(ctx.meta.headers.prefer);
         maxPerPage = regexResults?.[1] ? parseInt(regexResults[1]) : undefined;
 
+        if (maxPerPage) {
+          links.push({ uri: 'http://www.w3.org/ns/ldp#Page', rel: 'type' });
+          links.push({ uri: `${uri}?page=${1}`, rel: 'first' });
+
+          const resourcesUris = await ctx.call('ldp.container.getUris', { containerUri: uri });
+          const numPages = Math.ceil(resourcesUris.length / maxPerPage);
+          if (numPages > page) links.push({ uri: `${uri}?page=${page + 1}`, rel: 'next' });
+          if (page > 1) links.push({ uri: `${uri}?page=${page - 1}`, rel: 'prev' });
+          if (numPages > 1) links.push({ uri: `${uri}?page=${numPages}`, rel: 'last' });
+        }
+
         regexResults = /sort-predicate="([^"]+)"/.exec(ctx.meta.headers.prefer);
         sortPredicate = regexResults?.[1];
 
@@ -51,13 +64,13 @@ export default async function get(this: any, ctx: any) {
           jsonContext: parseJson(ctx.meta.headers?.jsonldcontext),
           doNotIncludeResources,
           maxPerPage,
-          page: page && parseInt(page, 10),
+          page: page === 1 ? undefined : page,
           sortPredicate,
           sortOrder
         })
       );
 
-      if (doNotIncludeResources) {
+      if (doNotIncludeResources || maxPerPage || sortPredicate) {
         if (!ctx.meta.$responseHeaders) ctx.meta.$responseHeaders = {};
         ctx.meta.$responseHeaders['Preference-Applied'] = 'return=representation';
       }
@@ -121,7 +134,7 @@ export default async function get(this: any, ctx: any) {
     }
 
     if (!ctx.meta.$responseHeaders) ctx.meta.$responseHeaders = {};
-    ctx.meta.$responseHeaders.Link = await ctx.call('ldp.link-header.get', { uri });
+    ctx.meta.$responseHeaders.Link = await ctx.call('ldp.link-header.get', { uri, additionalLinks: links });
 
     // Hack to make our servers work with Mastodon servers, which expect a special profile
     if (ctx.meta.$responseType === 'application/ld+json')

--- a/src/middleware/packages/ldp/services/api/actions/get.ts
+++ b/src/middleware/packages/ldp/services/api/actions/get.ts
@@ -8,7 +8,6 @@ const { MoleculerError } = Errors;
 export default async function get(this: any, ctx: any) {
   try {
     let { username, slugParts, page } = ctx.params;
-    page = page ? parseInt(page, 10) : 1;
 
     const uri = this.getUriFromSlugParts(slugParts, username);
     ctx.meta.dataset = getDatasetFromUri(uri);
@@ -40,14 +39,25 @@ export default async function get(this: any, ctx: any) {
         maxPerPage = regexResults?.[1] ? parseInt(regexResults[1]) : undefined;
 
         if (maxPerPage) {
-          links.push({ uri: 'http://www.w3.org/ns/ldp#Page', rel: 'type' });
-          links.push({ uri: `${uri}?page=${1}`, rel: 'first' });
+          if (!page) {
+            // If a paging is requested, but the page number is not provided, redirect to first page
+            ctx.meta.$statusCode = 303;
+            ctx.meta.$location = `${uri}?page=1`;
+            ctx.meta.$responseHeaders = { 'Content-Length': 0 };
+            return;
+          } else {
+            page = parseInt(page, 10);
 
-          const resourcesUris = await ctx.call('ldp.container.getUris', { containerUri: uri });
-          const numPages = Math.ceil(resourcesUris.length / maxPerPage);
-          if (numPages > page) links.push({ uri: `${uri}?page=${page + 1}`, rel: 'next' });
-          if (page > 1) links.push({ uri: `${uri}?page=${page - 1}`, rel: 'prev' });
-          if (numPages > 1) links.push({ uri: `${uri}?page=${numPages}`, rel: 'last' });
+            links.push({ uri: 'http://www.w3.org/ns/ldp#Page', rel: 'type' });
+            links.push({ uri: `${uri}?page=1`, rel: 'first' });
+
+            const resourcesUris = await ctx.call('ldp.container.getUris', { containerUri: uri });
+            const numPages = Math.ceil(resourcesUris.length / maxPerPage);
+
+            if (numPages > page) links.push({ uri: `${uri}?page=${page + 1}`, rel: 'next' });
+            if (page > 1) links.push({ uri: `${uri}?page=${page - 1}`, rel: 'prev' });
+            if (numPages > 1) links.push({ uri: `${uri}?page=${numPages}`, rel: 'last' });
+          }
         }
 
         regexResults = /sort-predicate="([^"]+)"/.exec(ctx.meta.headers.prefer);
@@ -64,7 +74,7 @@ export default async function get(this: any, ctx: any) {
           jsonContext: parseJson(ctx.meta.headers?.jsonldcontext),
           doNotIncludeResources,
           maxPerPage,
-          page: page === 1 ? undefined : page,
+          page: maxPerPage ? page : undefined,
           sortPredicate,
           sortOrder
         })
@@ -72,7 +82,7 @@ export default async function get(this: any, ctx: any) {
 
       if (doNotIncludeResources || maxPerPage || sortPredicate) {
         if (!ctx.meta.$responseHeaders) ctx.meta.$responseHeaders = {};
-        ctx.meta.$responseHeaders['Preference-Applied'] = 'return=representation';
+        ctx.meta.$responseHeaders['Preference-Applied'] = ctx.meta.headers.prefer;
       }
     } else {
       /*

--- a/src/middleware/packages/ldp/services/container/actions/clear.ts
+++ b/src/middleware/packages/ldp/services/container/actions/clear.ts
@@ -14,7 +14,6 @@ const Schema = {
     this.logger.info(`Deleting ${resourcesUris.length} resources...`);
 
     for (let resourceUri of resourcesUris) {
-      // @ts-expect-error TS(2533): Object is possibly 'null' or 'undefined'.
       this.logger.info(`Deleting ${resourceUri}...`);
       await ctx.call('ldp.resource.delete', { resourceUri, webId });
     }

--- a/src/middleware/packages/ldp/services/container/actions/get.ts
+++ b/src/middleware/packages/ldp/services/container/actions/get.ts
@@ -82,6 +82,10 @@ const Schema = {
         `
         : '';
 
+      // Transform the prefixed predicate to a full URI if necessary
+      const expandedSortPredicate =
+        sortPredicate && (await ctx.call('jsonld.parser.expandPredicate', { predicate: sortPredicate }));
+
       const resourcesResults: any = await ctx.call('triplestore.query', {
         query: `
           ${await ctx.call('ontologies.getRdfPrefixes')}
@@ -91,7 +95,7 @@ const Schema = {
               <${containerUri}> <http://www.w3.org/ns/ldp#contains> ?s1 .
             }
             ${filtersQuery}
-            ${sortPredicate ? `GRAPH ?s1 { ?s1 <${sortPredicate}> ?sortValue }` : ''}
+            ${sortPredicate ? `GRAPH ?s1 { ?s1 <${expandedSortPredicate}> ?sortValue }` : ''}
           }
           ${sortPredicate ? `ORDER BY ${sortOrder}(?sortValue)` : ''}
           ${limitQuery}

--- a/src/middleware/packages/ldp/services/container/actions/get.ts
+++ b/src/middleware/packages/ldp/services/container/actions/get.ts
@@ -13,13 +13,38 @@ const Schema = {
     accept: { type: 'string', optional: true },
     filters: { type: 'object', optional: true },
     doNotIncludeResources: { type: 'boolean', default: false },
+    maxPerPage: { type: 'number', optional: true },
+    page: { type: 'number', default: 1 },
+    sortOrder: { type: 'enum', values: ['ASC', 'DESC'], default: 'ASC' },
+    sortPredicate: { type: 'string', optional: true },
     jsonContext: { type: 'multi', rules: [{ type: 'array' }, { type: 'object' }, { type: 'string' }], optional: true }
   },
   cache: {
-    keys: ['containerUri', 'filters', 'doNotIncludeResources', 'jsonContext', 'webId', '#webId']
+    keys: [
+      'containerUri',
+      'filters',
+      'doNotIncludeResources',
+      'maxPerPage',
+      'page',
+      'sortOrder',
+      'sortPredicate',
+      'jsonContext',
+      'webId',
+      '#webId'
+    ]
   },
   async handler(ctx) {
-    const { containerUri, accept, filters, doNotIncludeResources, jsonContext } = ctx.params;
+    const {
+      containerUri,
+      accept,
+      filters,
+      doNotIncludeResources,
+      maxPerPage,
+      page,
+      sortOrder,
+      sortPredicate,
+      jsonContext
+    } = ctx.params;
     const webId = ctx.params.webId || ctx.meta.webId || 'anon';
 
     await ctx.call('permissions.check', { uri: containerUri, type: 'container', mode: 'acl:Read', webId });
@@ -50,6 +75,13 @@ const Schema = {
     if (!doNotIncludeResources) {
       const filtersQuery = buildFiltersQuery(filters);
 
+      const limitQuery = maxPerPage
+        ? `
+          LIMIT ${maxPerPage}
+          OFFSET ${(page - 1) * maxPerPage}
+        `
+        : '';
+
       const resourcesResults: any = await ctx.call('triplestore.query', {
         query: `
           ${await ctx.call('ontologies.getRdfPrefixes')}
@@ -59,7 +91,10 @@ const Schema = {
               <${containerUri}> <http://www.w3.org/ns/ldp#contains> ?s1 .
             }
             ${filtersQuery}
+            ${sortPredicate ? `GRAPH ?s1 { ?s1 <${sortPredicate}> ?sortValue }` : ''}
           }
+          ${sortPredicate ? `ORDER BY ${sortOrder}(?sortValue)` : ''}
+          ${limitQuery}
         `,
         accept,
         webId

--- a/src/middleware/packages/ldp/services/link-header/actions/get.ts
+++ b/src/middleware/packages/ldp/services/link-header/actions/get.ts
@@ -1,29 +1,29 @@
 import LinkHeader from 'http-link-header';
 import { ActionSchema } from 'moleculer';
+import { Registration } from '../../../types.ts';
 
-const Schema = {
+const GetAction = {
   visibility: 'public',
   params: {
-    uri: { type: 'string' }
+    uri: { type: 'string' },
+    additionalLinks: { type: 'array' }
   },
   async handler(ctx) {
-    const { uri } = ctx.params;
+    const { uri, additionalLinks } = ctx.params;
     const linkHeader = new LinkHeader();
 
     for (const actionName of this.registeredActionNames) {
-      const params = await ctx.call(actionName, { uri });
-
+      const params: any = await ctx.call(actionName, { uri });
       if (params) {
         if (!params.uri) throw new Error(`An uri should be returned from the ${actionName} action`);
-
         linkHeader.set(params);
       }
     }
 
     // Get container-specific headers (if any)
-    const { controlledActions } = await ctx.call('ldp.registry.getByUri', { resourceUri: uri });
+    const { controlledActions }: Registration = await ctx.call('ldp.registry.getByUri', { resourceUri: uri });
     if (controlledActions?.getHeaderLinks) {
-      const links = await ctx.call(controlledActions.getHeaderLinks, { uri });
+      const links: any[] = await ctx.call(controlledActions.getHeaderLinks, { uri });
       if (links && links.length > 0) {
         for (const link of links) {
           linkHeader.set(link);
@@ -31,8 +31,14 @@ const Schema = {
       }
     }
 
+    if (additionalLinks) {
+      for (const additionalLink of additionalLinks) {
+        linkHeader.set(additionalLink);
+      }
+    }
+
     return linkHeader.toString();
   }
 } satisfies ActionSchema;
 
-export default Schema;
+export default GetAction;

--- a/src/middleware/packages/ldp/services/link-header/actions/get.ts
+++ b/src/middleware/packages/ldp/services/link-header/actions/get.ts
@@ -6,7 +6,7 @@ const GetAction = {
   visibility: 'public',
   params: {
     uri: { type: 'string' },
-    additionalLinks: { type: 'array' }
+    additionalLinks: { type: 'array', optional: true }
   },
   async handler(ctx) {
     const { uri, additionalLinks } = ctx.params;

--- a/src/middleware/packages/ldp/services/link-header/index.ts
+++ b/src/middleware/packages/ldp/services/link-header/index.ts
@@ -1,4 +1,4 @@
-import { ServiceSchema, defineAction } from 'moleculer';
+import { ServiceSchema } from 'moleculer';
 import getAction from './actions/get.ts';
 import registerAction from './actions/register.ts';
 
@@ -6,7 +6,6 @@ const LdpLinkHeaderSchema = {
   name: 'ldp.link-header' as const,
   actions: {
     get: getAction,
-    // @ts-expect-error TS(2322): Type 'ActionSchema<{ actionName: { type: "string";... Remove this comment to see the full error message
     register: registerAction
   },
   async started() {

--- a/src/middleware/tests/ldp/api.test.ts
+++ b/src/middleware/tests/ldp/api.test.ts
@@ -138,7 +138,9 @@ describe('LDP handling through API', () => {
     });
 
     expect(json['ldp:contains']).toBeUndefined();
-    expect(headers.get('Preference-Applied')).toBe('return=representation');
+    expect(headers.get('Preference-Applied')).toBe(
+      'return=representation; include="http://www.w3.org/ns/ldp#PreferMinimalContainer"'
+    );
   });
 
   test('Replace resource', async () => {

--- a/src/middleware/tests/ldp/headers.test.ts
+++ b/src/middleware/tests/ldp/headers.test.ts
@@ -63,14 +63,12 @@ describe('Headers handling of LDP server', () => {
       }
     });
 
-    const resourceUri = postHeaders.get('Location');
-    // @ts-expect-error TS(2345): Argument of type 'string | null' is not assignable... Remove this comment to see the full error message
+    const resourceUri = postHeaders.get('Location')!;
     const resourcePath = new URL(resourceUri).pathname;
 
     const { headers } = await fetchServer(resourceUri, { method: 'HEAD' });
 
-    // @ts-expect-error TS(2345): Argument of type 'string | null' is not assignable... Remove this comment to see the full error message
-    const parsedLinks = parseLinkHeader(headers.get('link'));
+    const parsedLinks = parseLinkHeader(headers.get('link')!);
 
     expect(parsedLinks.refs).toMatchObject([
       {
@@ -91,14 +89,12 @@ describe('Headers handling of LDP server', () => {
       }
     });
 
-    const resourceUri = postHeaders.get('Location');
-    // @ts-expect-error TS(2345): Argument of type 'string | null' is not assignable... Remove this comment to see the full error message
+    const resourceUri = postHeaders.get('Location')!;
     const resourcePath = new URL(resourceUri).pathname;
 
     const { headers } = await fetchServer(resourceUri, { method: 'HEAD' });
 
-    // @ts-expect-error TS(2345): Argument of type 'string | null' is not assignable... Remove this comment to see the full error message
-    const parsedLinks = parseLinkHeader(headers.get('link'));
+    const parsedLinks = parseLinkHeader(headers.get('link')!);
 
     expect(parsedLinks.refs).toMatchObject([
       { uri: urlJoin(CONFIG.HOME_URL!, '_acl', resourcePath), rel: 'acl' },

--- a/src/middleware/tests/ldp/paging.test.ts
+++ b/src/middleware/tests/ldp/paging.test.ts
@@ -1,3 +1,4 @@
+import fetch from 'node-fetch';
 import { ServiceBroker } from 'moleculer';
 import initialize from './initialize.ts';
 import { createAccount } from '../utils.ts';
@@ -44,42 +45,77 @@ describe('LDP paging tests', () => {
     expect(container['ldp:contains']).toHaveLength(5);
   });
 
-  test('Get container with paging', async () => {
-    const page1 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2 });
-    expect(page1['ldp:contains']).toHaveLength(2);
+  describe('Get through Moleculer actions', () => {
+    test('Get container with paging', async () => {
+      const page1 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2 });
+      expect(page1['ldp:contains']).toHaveLength(2);
 
-    const page2 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2, page: 2 });
-    expect(page2['ldp:contains']).toHaveLength(2);
+      const page2 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2, page: 2 });
+      expect(page2['ldp:contains']).toHaveLength(2);
 
-    // The last page only has a single resource
-    const page3 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2, page: 3 });
-    expect(page3['ldp:contains']).toHaveLength(1);
+      // The last page only has a single resource
+      const page3 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2, page: 3 });
+      expect(page3['ldp:contains']).toHaveLength(1);
 
-    // All resources are in the 3 pages
-    expect([
-      ...page1['ldp:contains'].map((r: any) => r.id),
-      ...page2['ldp:contains'].map((r: any) => r.id),
-      ...page3['ldp:contains'].map((r: any) => r.id)
-    ]).toEqual(expect.arrayContaining(resourcesUris));
+      // All resources are in the 3 pages
+      expect([
+        ...page1['ldp:contains'].map((r: any) => r.id),
+        ...page2['ldp:contains'].map((r: any) => r.id),
+        ...page3['ldp:contains'].map((r: any) => r.id)
+      ]).toEqual(expect.arrayContaining(resourcesUris));
+    });
+
+    test('Get container with paging and sorting', async () => {
+      let container = await alice.call('ldp.container.get', {
+        containerUri,
+        maxPerPage: 2,
+        sortPredicate: 'http://virtual-assembly.org/ontologies/pair#startDate',
+        sortOrder: 'ASC'
+      });
+      expect(container['ldp:contains'][0]['pair:label']).toBe('Project #1');
+      expect(container['ldp:contains'][1]['pair:label']).toBe('Project #2');
+
+      container = await alice.call('ldp.container.get', {
+        containerUri,
+        maxPerPage: 2,
+        sortPredicate: 'http://virtual-assembly.org/ontologies/pair#startDate',
+        sortOrder: 'DESC'
+      });
+      expect(container['ldp:contains'][0]['pair:label']).toBe('Project #5');
+      expect(container['ldp:contains'][1]['pair:label']).toBe('Project #4');
+    });
   });
 
-  test('Get container with paging and sorting', async () => {
-    let container = await alice.call('ldp.container.get', {
-      containerUri,
-      maxPerPage: 2,
-      sortPredicate: 'http://virtual-assembly.org/ontologies/pair#startDate',
-      sortOrder: 'ASC'
-    });
-    expect(container['ldp:contains'][0]['pair:label']).toBe('Project #1');
-    expect(container['ldp:contains'][1]['pair:label']).toBe('Project #2');
+  describe('Get through API', () => {
+    test('Get container with paging', async () => {
+      const { json: page1 } = await alice.fetch(containerUri, {
+        headers: new fetch.Headers({
+          Prefer: 'return=representation; max-member-count="2"'
+        })
+      });
+      expect(page1['ldp:contains']).toHaveLength(2);
 
-    container = await alice.call('ldp.container.get', {
-      containerUri,
-      maxPerPage: 2,
-      sortPredicate: 'http://virtual-assembly.org/ontologies/pair#startDate',
-      sortOrder: 'DESC'
+      const { json: page2 } = await alice.fetch(`${containerUri}?page=2`, {
+        headers: new fetch.Headers({
+          Prefer: 'return=representation; max-member-count="2"'
+        })
+      });
+      expect(page2['ldp:contains']).toHaveLength(2);
+
+      // The last page only has a single resource
+      const { json: page3 } = await alice.fetch(`${containerUri}?page=3`, {
+        headers: new fetch.Headers({
+          Prefer: 'return=representation; max-member-count="2"'
+        })
+      });
+      expect(page3['ldp:contains']).toHaveLength(1);
+
+      // All resources are in the 3 pages
+      expect([
+        ...page1['ldp:contains'].map((r: any) => r.id),
+        ...page2['ldp:contains'].map((r: any) => r.id),
+        ...page3['ldp:contains'].map((r: any) => r.id)
+      ]).toEqual(expect.arrayContaining(resourcesUris));
     });
-    expect(container['ldp:contains'][0]['pair:label']).toBe('Project #5');
-    expect(container['ldp:contains'][1]['pair:label']).toBe('Project #4');
   });
 });

--- a/src/middleware/tests/ldp/paging.test.ts
+++ b/src/middleware/tests/ldp/paging.test.ts
@@ -89,12 +89,25 @@ describe('LDP paging tests', () => {
 
   describe('Get through API', () => {
     test('Get container with paging', async () => {
+      // First fetch without automatic redirect, to ensure the redirection is correct
+      const { status, statusText, headers } = await alice.fetch(containerUri, {
+        headers: new fetch.Headers({
+          Prefer: 'return=representation; max-member-count="2"'
+        }),
+        redirect: 'manual'
+      });
+
+      expect(status).toBe(303);
+      expect(statusText).toBe('See Other');
+      expect(headers.get('location')).toBe(`${containerUri}?page=1`);
+
       const { json: page1, headers: headers1 } = await alice.fetch(containerUri, {
         headers: new fetch.Headers({
           Prefer: 'return=representation; max-member-count="2"'
         })
       });
       expect(page1['ldp:contains']).toHaveLength(2);
+      expect(headers1.get('Preference-Applied')).toBe('return=representation; max-member-count="2"');
 
       let parsedLinks = parseLinkHeader(headers1.get('link')!);
       expect(parsedLinks.refs).toEqual(
@@ -190,7 +203,7 @@ describe('LDP paging tests', () => {
     });
 
     test('Get container with paging and sorting', async () => {
-      const { json: container1 } = await alice.fetch(containerUri, {
+      const { json: container1, headers } = await alice.fetch(containerUri, {
         headers: new fetch.Headers({
           Prefer:
             'return=representation; max-member-count="2"; sort-predicate="http://virtual-assembly.org/ontologies/pair#startDate"'
@@ -199,6 +212,9 @@ describe('LDP paging tests', () => {
       expect(container1['ldp:contains']).toHaveLength(2);
       expect(container1['ldp:contains'][0]['pair:label']).toBe('Project #1');
       expect(container1['ldp:contains'][1]['pair:label']).toBe('Project #2');
+      expect(headers.get('Preference-Applied')).toBe(
+        'return=representation; max-member-count="2"; sort-predicate="http://virtual-assembly.org/ontologies/pair#startDate"'
+      );
 
       const { json: container2 } = await alice.fetch(containerUri, {
         headers: new fetch.Headers({

--- a/src/middleware/tests/ldp/paging.test.ts
+++ b/src/middleware/tests/ldp/paging.test.ts
@@ -1,0 +1,85 @@
+import { ServiceBroker } from 'moleculer';
+import initialize from './initialize.ts';
+import { createAccount } from '../utils.ts';
+
+jest.setTimeout(20000);
+let broker: ServiceBroker;
+let alice: any;
+
+beforeAll(async () => {
+  broker = await initialize(true);
+  await broker.start();
+  alice = await createAccount(broker, 'alice');
+});
+
+afterAll(async () => {
+  if (broker) await broker.stop();
+});
+
+describe('LDP paging tests', () => {
+  let containerUri: string;
+  let resourcesUris: string[] = [];
+
+  test('Post 5 resources in a container', async () => {
+    containerUri = await alice.getContainerUri('pair:Project');
+
+    for (let i = 1; i <= 5; i++) {
+      const startDate = new Date(2025, 11, i, 12, 0, 0);
+
+      resourcesUris[i] = await alice.call('ldp.container.post', {
+        containerUri,
+        resource: {
+          '@context': {
+            '@vocab': 'http://virtual-assembly.org/ontologies/pair#'
+          },
+          '@type': 'Project',
+          label: `Project #${i}`,
+          startDate: startDate.toISOString()
+        },
+        slug: `project-${i}`
+      });
+    }
+
+    const container = await alice.call('ldp.container.get', { containerUri });
+    expect(container['ldp:contains']).toHaveLength(5);
+  });
+
+  test('Get container with paging', async () => {
+    const page1 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2 });
+    expect(page1['ldp:contains']).toHaveLength(2);
+
+    const page2 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2, page: 2 });
+    expect(page2['ldp:contains']).toHaveLength(2);
+
+    // The last page only has a single resource
+    const page3 = await alice.call('ldp.container.get', { containerUri, maxPerPage: 2, page: 3 });
+    expect(page3['ldp:contains']).toHaveLength(1);
+
+    // All resources are in the 3 pages
+    expect([
+      ...page1['ldp:contains'].map((r: any) => r.id),
+      ...page2['ldp:contains'].map((r: any) => r.id),
+      ...page3['ldp:contains'].map((r: any) => r.id)
+    ]).toEqual(expect.arrayContaining(resourcesUris));
+  });
+
+  test('Get container with paging and sorting', async () => {
+    let container = await alice.call('ldp.container.get', {
+      containerUri,
+      maxPerPage: 2,
+      sortPredicate: 'http://virtual-assembly.org/ontologies/pair#startDate',
+      sortOrder: 'ASC'
+    });
+    expect(container['ldp:contains'][0]['pair:label']).toBe('Project #1');
+    expect(container['ldp:contains'][1]['pair:label']).toBe('Project #2');
+
+    container = await alice.call('ldp.container.get', {
+      containerUri,
+      maxPerPage: 2,
+      sortPredicate: 'http://virtual-assembly.org/ontologies/pair#startDate',
+      sortOrder: 'DESC'
+    });
+    expect(container['ldp:contains'][0]['pair:label']).toBe('Project #5');
+    expect(container['ldp:contains'][1]['pair:label']).toBe('Project #4');
+  });
+});

--- a/src/middleware/tests/ldp/paging.test.ts
+++ b/src/middleware/tests/ldp/paging.test.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { ServiceBroker } from 'moleculer';
+import { parse as parseLinkHeader } from 'http-link-header';
 import initialize from './initialize.ts';
 import { createAccount } from '../utils.ts';
 
@@ -88,27 +89,97 @@ describe('LDP paging tests', () => {
 
   describe('Get through API', () => {
     test('Get container with paging', async () => {
-      const { json: page1 } = await alice.fetch(containerUri, {
+      const { json: page1, headers: headers1 } = await alice.fetch(containerUri, {
         headers: new fetch.Headers({
           Prefer: 'return=representation; max-member-count="2"'
         })
       });
       expect(page1['ldp:contains']).toHaveLength(2);
 
-      const { json: page2 } = await alice.fetch(`${containerUri}?page=2`, {
+      let parsedLinks = parseLinkHeader(headers1.get('link')!);
+      expect(parsedLinks.refs).toEqual(
+        expect.arrayContaining([
+          {
+            uri: 'http://www.w3.org/ns/ldp#Page',
+            rel: 'type'
+          },
+          {
+            uri: `${containerUri}?page=1`,
+            rel: 'first'
+          },
+          {
+            uri: `${containerUri}?page=2`,
+            rel: 'next'
+          },
+          {
+            uri: `${containerUri}?page=3`,
+            rel: 'last'
+          }
+        ])
+      );
+
+      const { json: page2, headers: headers2 } = await alice.fetch(`${containerUri}?page=2`, {
         headers: new fetch.Headers({
           Prefer: 'return=representation; max-member-count="2"'
         })
       });
       expect(page2['ldp:contains']).toHaveLength(2);
 
+      parsedLinks = parseLinkHeader(headers2.get('link')!);
+      expect(parsedLinks.refs).toEqual(
+        expect.arrayContaining([
+          {
+            uri: 'http://www.w3.org/ns/ldp#Page',
+            rel: 'type'
+          },
+          {
+            uri: `${containerUri}?page=1`,
+            rel: 'first'
+          },
+          {
+            uri: `${containerUri}?page=1`,
+            rel: 'prev'
+          },
+          {
+            uri: `${containerUri}?page=3`,
+            rel: 'next'
+          },
+          {
+            uri: `${containerUri}?page=3`,
+            rel: 'last'
+          }
+        ])
+      );
+
       // The last page only has a single resource
-      const { json: page3 } = await alice.fetch(`${containerUri}?page=3`, {
+      const { json: page3, headers: headers3 } = await alice.fetch(`${containerUri}?page=3`, {
         headers: new fetch.Headers({
           Prefer: 'return=representation; max-member-count="2"'
         })
       });
       expect(page3['ldp:contains']).toHaveLength(1);
+
+      parsedLinks = parseLinkHeader(headers3.get('link')!);
+      expect(parsedLinks.refs).toEqual(
+        expect.arrayContaining([
+          {
+            uri: 'http://www.w3.org/ns/ldp#Page',
+            rel: 'type'
+          },
+          {
+            uri: `${containerUri}?page=1`,
+            rel: 'first'
+          },
+          {
+            uri: `${containerUri}?page=2`,
+            rel: 'prev'
+          },
+          {
+            uri: `${containerUri}?page=3`,
+            rel: 'last'
+          }
+        ])
+      );
 
       // All resources are in the 3 pages
       expect([

--- a/src/middleware/tests/ldp/paging.test.ts
+++ b/src/middleware/tests/ldp/paging.test.ts
@@ -117,5 +117,47 @@ describe('LDP paging tests', () => {
         ...page3['ldp:contains'].map((r: any) => r.id)
       ]).toEqual(expect.arrayContaining(resourcesUris));
     });
+
+    test('Get container with paging and sorting', async () => {
+      const { json: container1 } = await alice.fetch(containerUri, {
+        headers: new fetch.Headers({
+          Prefer:
+            'return=representation; max-member-count="2"; sort-predicate="http://virtual-assembly.org/ontologies/pair#startDate"'
+        })
+      });
+      expect(container1['ldp:contains']).toHaveLength(2);
+      expect(container1['ldp:contains'][0]['pair:label']).toBe('Project #1');
+      expect(container1['ldp:contains'][1]['pair:label']).toBe('Project #2');
+
+      const { json: container2 } = await alice.fetch(containerUri, {
+        headers: new fetch.Headers({
+          Prefer:
+            'return=representation; max-member-count="2"; sort-predicate="http://virtual-assembly.org/ontologies/pair#startDate"; sort-order="ASC"'
+        })
+      });
+      expect(container2['ldp:contains']).toHaveLength(2);
+      expect(container2['ldp:contains'][0]['pair:label']).toBe('Project #1');
+      expect(container2['ldp:contains'][1]['pair:label']).toBe('Project #2');
+
+      const { json: container3 } = await alice.fetch(containerUri, {
+        headers: new fetch.Headers({
+          Prefer:
+            'return=representation; max-member-count="2"; sort-predicate="http://virtual-assembly.org/ontologies/pair#startDate"; sort-order="DESC"'
+        })
+      });
+      expect(container3['ldp:contains']).toHaveLength(2);
+      expect(container3['ldp:contains'][0]['pair:label']).toBe('Project #5');
+      expect(container3['ldp:contains'][1]['pair:label']).toBe('Project #4');
+
+      // We can use a prefix if the ontology is known by the server
+      const { json: container4 } = await alice.fetch(containerUri, {
+        headers: new fetch.Headers({
+          Prefer: 'return=representation; max-member-count="2"; sort-predicate="pair:startDate"; sort-order="DESC"'
+        })
+      });
+      expect(container4['ldp:contains']).toHaveLength(2);
+      expect(container4['ldp:contains'][0]['pair:label']).toBe('Project #5');
+      expect(container4['ldp:contains'][1]['pair:label']).toBe('Project #4');
+    });
   });
 });

--- a/src/middleware/tests/utils.ts
+++ b/src/middleware/tests/utils.ts
@@ -71,6 +71,7 @@ export const fetchServer = async (url: string, options: FetchOptions = {}) => {
   }
 
   return fetch(url, {
+    ...options,
     method: options.method || 'GET',
     body: options.body as fetch.BodyInit,
     headers: options.headers

--- a/src/middleware/tests/utils.ts
+++ b/src/middleware/tests/utils.ts
@@ -3,11 +3,12 @@ import fetch from 'node-fetch';
 import Redis from 'ioredis';
 import { ActionParamSchema, CallingOptions, ServiceBroker, ServiceSchema } from 'moleculer';
 import { Account } from '@semapps/auth';
-import * as CONFIG from './config.ts';
 import { delay } from '@semapps/ldp';
+import * as CONFIG from './config.ts';
 
 type FetchOptions = Omit<fetch.RequestInit, 'body'> & {
   body?: ArrayBuffer | ArrayBufferView | ReadableStream | string | URLSearchParams | FormData | object;
+  headers?: fetch.Headers;
 };
 
 export const listDatasets = async (): Promise<string[]> => {
@@ -51,16 +52,13 @@ export const fetchServer = async (url: string, options: FetchOptions = {}) => {
     case 'POST':
     case 'PATCH':
     case 'PUT':
-      // @ts-expect-error TS(2339): Property 'headers' does not exist on type '{}'.
       if (!options.headers.has('Accept')) options.headers.set('Accept', 'application/ld+json');
-      // @ts-expect-error TS(2339): Property 'headers' does not exist on type '{}'.
       if (!options.headers.has('Content-Type')) options.headers.set('Content-Type', 'application/ld+json');
       break;
     case 'DELETE':
       break;
     case 'GET':
     default:
-      // @ts-expect-error TS(2339): Property 'headers' does not exist on type '{}'.
       if (!options.headers.has('Accept')) options.headers.set('Accept', 'application/ld+json');
       break;
   }

--- a/website/docs/middleware/ldp/container.md
+++ b/website/docs/middleware/ldp/container.md
@@ -33,34 +33,16 @@ Delete all the resources attached to a container
 
 ### `create`
 
-- Create a new LDP container
-- This does **not** create the relative API routes.
+Create a new LDP container
 
 ##### Parameters
 
-| Property       | Type     | Default             | Description                                   |
-| -------------- | -------- | ------------------- | --------------------------------------------- |
-| `containerUri` | `String` | **required**        | URI of the container to create                |
-| `title`        | `String` |                     | Title of the container                        |
-| `description`  | `String` |                     | Description of the container                  |
-| `permissions`  | `String` |                     | WAC permissions to apply to the new container |
-| `webId`        | `String` | Logged user's webId | User doing the action                         |
-
-### `createAndAttach`
-
-- Create a container and attach it to its parent container(s)
-- Recursively create the parent container(s) if they don't exist
-- In Pod provider config, the webId is required to find the Pod root
-
-##### Parameters
-
-| Property       | Type     | Default             | Description                                   |
-| -------------- | -------- | ------------------- | --------------------------------------------- |
-| `containerUri` | `String` | **required**        | URI of the container to create                |
-| `title`        | `String` |                     | Title of the container                        |
-| `description`  | `String` |                     | Description of the container                  |
-| `permissions`  | `String` |                     | WAC permissions to apply to the new container |
-| `webId`        | `String` | Logged user's webId | User doing the action                         |
+| Property       | Type           | Default      | Description                    |
+| -------------- | -------------- | ------------ | ------------------------------ |
+| `containerUri` | `String`       | **required** | URI of the container to create |
+| `title`        | `String`       |              | Title of the container         |
+| `description`  | `String`       |              | Description of the container   |
+| `registration` | `Registration` |              | The container options          |
 
 ### `detach`
 
@@ -94,20 +76,21 @@ Get the LDP container with all its resources (which are dereferenced)
 
 ##### Parameters
 
-| Property                | Type                | Default             | Description                                        |
-| ----------------------- | ------------------- | ------------------- | -------------------------------------------------- |
-| `containerUri`          | `String`            | **required**        | URI of container                                   |
-| `accept`                | `String`            | **required**        | Type to return                                     |
-| `filters`               | `Object`            |                     | Key/value with predicates and value                |
-| `doNotIncludeResources` | `Boolean`           | false               | If true, does not return the contained resources   |
-| `jsonContext`           | `Object`or `String` |                     | JSON-LD context to use when compacting the results |
-| `webId`                 | `String`            | Logged user's webId | User doing the action                              |
+| Property                | Type                | Default             | Description                                                           |
+| ----------------------- | ------------------- | ------------------- | --------------------------------------------------------------------- |
+| `containerUri`          | `String`            | **required**        | URI of container                                                      |
+| `filters`               | `Object`            |                     | Key/value with predicates and value                                   |
+| `doNotIncludeResources` | `Boolean`           | false               | If true, does not return the contained resources                      |
+| `maxPerPage`            | `Number`            |                     | Number of resources to return                                         |
+| `page`                  | `Number`            | 1                   | If paging is activated, the page to display                           |
+| `sortPredicate`         | `String`            |                     | Sort the resources according to this predicate (full URI or prefixed) |
+| `sortOrder`             | `String`            | "ASC"               | Sort the resources in ascending (ASC) or descending (DESC) order      |
+| `jsonContext`           | `Object`or `String` |                     | JSON-LD context to use when compacting the results                    |
+| `webId`                 | `String`            | Logged user's webId | User doing the action                                                 |
 
-You can also pass parameters defined in the [container options](index.md#container-options).
+#### Return
 
-##### Return
-
-Triples, Turtle or JSON-LD depending on `accept` type.
+The LDP container in JSON-LD format
 
 ### `getAll`
 
@@ -123,25 +106,9 @@ Get the list of all existing containers
 
 Array of URIs
 
-### `getPath`
-
-Get the container path based on the provided resourceType.
-For example, if you pass `pair:ProjectType`, it will return `/pair/project-type`.
-Ontologies must be previously [registered](../ontologies#register) or the action will throw an error.
-
-##### Parameters
-
-| Property       | Type     | Default      | Description                   |
-| -------------- | -------- | ------------ | ----------------------------- |
-| `resourceType` | `String` | **required** | URI or prefixed resource type |
-
-##### Return
-
-The path of the container
-
 ### `getUris`
 
-Get the list of all resources within a container
+Get the URIs of all resources within a container
 
 ##### Parameters
 


### PR DESCRIPTION
Closes #176 

- Add 4 parameters to `ldp.container.get` action: `maxPerPage`, `page`, `sortOrder`, `sortPredicate`
  - If the `sortPredicate` use a prefix of a known ontology, the action will transform it to a full URI
- Take into account LDP paging headers in the `ldp.api.get` action
- Add paging tests
- Update documentation

## Implementation details

We have been following closely the [LDP Paging spec](https://www.w3.org/TR/ldp-paging/). Paging is only activated for LDP containers, and for the `max-member-count` preference. If `max-member-count` is included in the `Prefer` header, we provide a redirect to the first page of results. Additionally we provide link headers to the next / prev / first and last pages.

The LDP Paging spec note [the need for sorting](https://www.w3.org/TR/ldp-paging/#ldpc-informative) when using pagination, but unfortunately it is up to the LDP server to decide how to sort resources (and to show this choice to the client, using a `http://www.w3.org/ns/ldp#pageSequence` link header). This does not fit our needs, since in Solid storages, the server will not know about most resources being stored, and thus it has no idea about what sort criteria to use. We think it is much better if the client can declare its sorting preference (and the server can ignore it).

So we allow clients to indicate a `sort-predicate` and `sort-order` ("ASC" or "DESC") in the `Prefer` header, which may end up looking like this when using all preferences:

```
Prefer: return=representation; max-member-count="10"; sort-predicate="http://virtual-assembly.org/ontologies/pair#startDate"; sort-order="DESC"
```