### PR TITLE
Register apods:recommendedBy in the apods core ontology

### DIFF
--- a/src/middleware/packages/ontologies/ontologies/solid/apods.json
+++ b/src/middleware/packages/ontologies/ontologies/solid/apods.json
@@ -74,6 +74,9 @@
     },
     "apods:availableApps": {
       "@type": "@id"
+    },
+    "apods:recommendedBy": {
+      "@type": "@id"
     }
   }
 }


### PR DESCRIPTION
Backs the new Endorse activity type (used by la-carte-des-savoirs, but generic enough for any app to reuse): links a recommendable resource to the Endorse activities that vouch for it.